### PR TITLE
Atmos piping

### DIFF
--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -28447,6 +28447,12 @@
 "bPR" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "bPT" = (
@@ -38224,11 +38230,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cBY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science)
 "cBZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -38410,12 +38416,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cCN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
+/area/engineering/atmos/upper)
 "cCO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -38445,21 +38450,8 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cCS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -38788,6 +38780,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
+"cEm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cEn" = (
@@ -48902,11 +48914,9 @@
 /area/hallway/primary/starboard)
 "qaf" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science)
@@ -81598,7 +81608,7 @@ csI
 cxP
 cyR
 cFS
-cBY
+cCN
 cCP
 cEg
 cAk
@@ -82372,7 +82382,7 @@ mmv
 cBB
 cxT
 cEj
-cCS
+cEm
 cFq
 cHO
 cxT
@@ -83398,7 +83408,7 @@ cxT
 czn
 cAr
 cBF
-cCN
+cCS
 cBF
 cFu
 cGB
@@ -95446,7 +95456,7 @@ bJy
 bKQ
 bMG
 aPA
-bPT
+bxG
 bOz
 bOz
 caq
@@ -95703,7 +95713,7 @@ bAR
 bKR
 bMG
 bOz
-bPT
+bxG
 bOz
 cmy
 caq
@@ -96217,7 +96227,7 @@ npH
 bKT
 bIl
 bOz
-bPT
+bxG
 bOz
 bOz
 caq
@@ -96474,7 +96484,7 @@ npH
 bKU
 bIl
 bOz
-bPT
+bxG
 bOz
 aUn
 caq
@@ -96731,7 +96741,7 @@ npH
 bKV
 bIl
 bOz
-bPT
+bxG
 bOz
 bOz
 caq
@@ -96988,7 +96998,7 @@ npH
 bKW
 bMG
 bSX
-bPT
+bxG
 bOz
 bOz
 caq
@@ -97245,7 +97255,7 @@ npH
 bLo
 bMG
 bOv
-bPT
+bxG
 bOz
 aYA
 caq
@@ -97502,7 +97512,7 @@ bJP
 bIl
 bMG
 bOz
-bPT
+bxG
 bOz
 bci
 caq
@@ -97759,7 +97769,7 @@ bOz
 bOz
 blS
 bOz
-bPT
+bxG
 bOz
 bOz
 fpK
@@ -98016,7 +98026,7 @@ jJv
 uvU
 cgv
 ldq
-uvU
+cBY
 ldq
 cgv
 ldq

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -37410,6 +37410,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cyW" = (
@@ -37703,6 +37704,7 @@
 	dir = 1;
 	name = "Mix to Filter"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cAk" = (
@@ -37737,10 +37739,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cAp" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -37802,12 +37804,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cAz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cAA" = (
@@ -38096,7 +38101,6 @@
 /area/medical/medbay/central)
 "cBx" = (
 /obj/machinery/meter,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
 	},
@@ -38135,10 +38139,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cBD" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -38172,10 +38176,8 @@
 /turf/open/floor/iron,
 /area/space)
 "cBK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cBL" = (
@@ -38193,6 +38195,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cBR" = (
@@ -38409,7 +38412,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cCN" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cCO" = (
@@ -38441,32 +38446,21 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cCS" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cCT" = (
-/obj/structure/cable,
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cCU" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -38503,8 +38497,8 @@
 /area/engineering/atmos/upper)
 "cDd" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -38736,21 +38730,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cEe" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 10
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cEf" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cEg" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "Mix to Distro"
@@ -38764,30 +38755,42 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cEj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cEk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
+"cEl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"cEl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "atmospherics mix pump"
-	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "cEm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cEn" = (
@@ -38826,7 +38829,6 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cEy" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 4
 	},
@@ -38846,13 +38848,10 @@
 /turf/open/floor/plating/grass,
 /area/security/prison)
 "cEH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/atmos/upper";
-	dir = 4;
-	name = "Atmospherics Upper APC";
-	pixel_x = 25
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cEI" = (
@@ -39038,23 +39037,23 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cFr" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cFs" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Port Out"
+	name = "atmospherics mix pump"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cFt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -39062,6 +39061,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cFv" = (
@@ -39178,11 +39178,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cFS" = (
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cFT" = (
@@ -39270,13 +39266,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cGj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cGk" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 4
@@ -39289,16 +39278,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cGm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "CO2 Outlet Pump"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cGn" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 4
@@ -39306,10 +39285,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cGo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cGp" = (
@@ -39327,11 +39306,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "cGs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
 	name = "Unfiltered to Mix"
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cGt" = (
@@ -39361,16 +39340,23 @@
 	pixel_y = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Port Out"
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGB" = (
@@ -39442,6 +39428,11 @@
 /area/engineering/main)
 "cHb" = (
 /obj/machinery/portable_atmospherics/canister,
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cHc" = (
@@ -39552,7 +39543,10 @@
 	dir = 8;
 	name = "Security red corner"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "N2 Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cHo" = (
@@ -39604,7 +39598,10 @@
 	dir = 8;
 	name = "Command blue corner"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "O2 Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cHs" = (
@@ -39654,7 +39651,10 @@
 	alpha = 255;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Air Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cHw" = (
@@ -39717,7 +39717,10 @@
 	color = "#000000";
 	name = "dark corner"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "CO2 Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cHA" = (
@@ -39778,7 +39781,10 @@
 	dir = 8;
 	name = "Prison Orange"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Plasma Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cHE" = (
@@ -39943,17 +39949,17 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cHQ" = (
-/obj/machinery/computer/atmos_control/incinerator{
-	dir = 1
-	},
 /obj/machinery/computer/security/telescreen/turbine{
 	dir = 1;
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/computer/atmos_control/incinerator{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cHR" = (
@@ -39965,7 +39971,6 @@
 	pixel_x = 6;
 	pixel_y = -24
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
@@ -40201,7 +40206,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cIN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "cIO" = (
@@ -40311,7 +40316,10 @@
 	alpha = 255;
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "N2O Outlet Pump"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cJl" = (
@@ -40438,6 +40446,12 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/west,
+/obj/machinery/camera{
+	c_tag = "Atmospherics Turbine";
+	dir = 4;
+	name = "Turbine Camera";
+	network = list("ss13","engineering","atmos")
+	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "cJA" = (
@@ -41046,12 +41060,6 @@
 	luminosity = 2
 	},
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Atmospherics Turbine";
-	dir = 4;
-	name = "Turbine Camera";
-	network = list("ss13","engineering","atmos")
-	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "cMa" = (
@@ -44242,26 +44250,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/engineering/main)
-"cWz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "N2 Outlet Pump"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"cWA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "O2 Outlet Pump"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cWB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -45700,16 +45688,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"fZe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "N2O Outlet Pump"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fZf" = (
 /obj/item/target/syndicate,
 /turf/open/floor/iron,
@@ -45835,13 +45813,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gsR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Air Outlet Pump"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gth" = (
@@ -50984,13 +50959,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wMF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Plasma Outlet Pump"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wOw" = (
@@ -75224,7 +75196,7 @@ csA
 cCC
 cDS
 ctX
-cWz
+gsR
 cHn
 cIy
 cJs
@@ -76252,7 +76224,7 @@ csA
 cAe
 cDU
 cFg
-cWA
+gsR
 cHr
 cIy
 cJs
@@ -76766,7 +76738,7 @@ csA
 cAe
 cDV
 ctX
-cGj
+gsR
 mnv
 cIz
 cJt
@@ -78051,7 +78023,7 @@ cyG
 crj
 cAe
 cHw
-cGj
+gsR
 cHy
 cIA
 cJq
@@ -78308,7 +78280,7 @@ cyJ
 cCI
 cDX
 cFi
-cGm
+wMF
 cHz
 cID
 cJs
@@ -80364,7 +80336,7 @@ crj
 crj
 cCE
 cFi
-fZe
+wMF
 cJk
 cID
 cJw
@@ -81132,7 +81104,7 @@ cxN
 cyP
 cAi
 cBx
-cCN
+cAk
 cEe
 cFm
 cGt
@@ -81644,8 +81616,8 @@ csJ
 csI
 cxP
 cyR
-cAk
-cAk
+cFS
+cCN
 cCP
 cEg
 cAk
@@ -82417,9 +82389,9 @@ cxR
 cAn
 mmv
 cBB
-cCS
+cxT
 cEj
-cFq
+cEm
 cFq
 cHO
 cxT
@@ -83187,9 +83159,9 @@ csI
 cxT
 czm
 cXO
-cBF
+cEn
 cCW
-cEm
+cEn
 cFt
 cGA
 cHR
@@ -83445,8 +83417,8 @@ cxT
 czn
 cAr
 cBF
-cCW
-cEn
+cCS
+cBF
 cFu
 cGB
 cHS

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -34987,12 +34987,7 @@
 /obj/structure/cable,
 /obj/item/book/manual/wiki/atmospherics,
 /obj/item/storage/belt/utility/atmostech,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engineering/atmos";
-	dir = 1;
-	name = "Atmospherics APC";
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cqr" = (
@@ -36684,6 +36679,7 @@
 	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light/directional/north,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "cwu" = (
@@ -38500,6 +38496,11 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 8
 	},
+/obj/machinery/requests_console/directional/east{
+	department = "Atmospherics";
+	departmentType = 4;
+	name = "Atmos RC"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cDh" = (
@@ -39332,17 +39333,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cGy" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal/incinerator";
-	dir = 8;
-	name = "Incinerator APC";
-	pixel_x = -25;
-	pixel_y = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cGz" = (
@@ -39428,11 +39423,6 @@
 /area/engineering/main)
 "cHb" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/machinery/requests_console/directional/east{
-	department = "Atmospherics";
-	departmentType = 4;
-	name = "Atmos RC"
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cHc" = (

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -28680,7 +28680,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bRc" = (
@@ -30160,7 +30160,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bXs" = (
@@ -38224,9 +38224,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cBY" = (
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
+/area/engineering/atmos/upper)
 "cBZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -38408,11 +38410,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cCN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/maintenance/disposal/incinerator)
 "cCO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
@@ -38442,8 +38445,21 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cCS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Turbine Access";
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -38772,26 +38788,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
-"cEm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Turbine Access";
-	req_access_txt = "24"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cEn" = (
@@ -39480,12 +39476,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cHj" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	frequency = 1459;
-	name = "Incinerator Chamber Air control";
-	pixel_x = 24
-	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cHm" = (
@@ -40432,15 +40423,15 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Turbine";
 	dir = 4;
 	name = "Turbine Camera";
 	network = list("ss13","engineering","atmos")
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
@@ -40712,10 +40703,10 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
+/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "cKH" = (
@@ -81607,7 +81598,7 @@ csI
 cxP
 cyR
 cFS
-cCN
+cBY
 cCP
 cEg
 cAk
@@ -82381,7 +82372,7 @@ mmv
 cBB
 cxT
 cEj
-cEm
+cCS
 cFq
 cHO
 cxT
@@ -83407,7 +83398,7 @@ cxT
 czn
 cAr
 cBF
-cCS
+cCN
 cBF
 cFu
 cGB
@@ -83663,7 +83654,7 @@ cXT
 cug
 cyZ
 cEn
-cBY
+cEn
 cDh
 cEO
 cFT

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -28680,7 +28680,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bRc" = (
@@ -30160,7 +30160,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "bXs" = (
@@ -40430,7 +40430,7 @@
 	name = "Turbine Camera";
 	network = list("ss13","engineering","atmos")
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -40704,8 +40704,8 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)


### PR DESCRIPTION
Moves pipes in atmos down so unwrenching it doesnt instantly flood the room with the gas
Replaces green pipes with bridge pipes so they dont connect to manifolds
DELETES THE STUPID TURBINE CAMERA THATS LITERALLY ON THE TURBINE WHAT THE FUCK.
Adds a heater to distro
Helian's favorite, replaces atmos APCs with autonaming directional ones
Adds a new AI status display to atmos :)
Fixes turbine pipes (and toxins too since it has the same problem)
Fixes turbine cables
Deletes turbine having 2 Air alarms (They're meant to have ONE, its not a TOXIN MIXING CHAMBER)