### PR TITLE
re-does science for the third time

### DIFF
--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -84,15 +84,10 @@
 /turf/open/openspace,
 /area/security/prison/visit)
 "at" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/science)
 "au" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
@@ -120,6 +115,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"ay" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "az" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -167,7 +168,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aE" = (
-/obj/machinery/atmospherics/components/unary/passive_vent,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "aG" = (
@@ -194,11 +198,12 @@
 /area/engineering/atmos/upper)
 "aO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science/breakroom)
+"aR" = (
+/obj/item/toy/plush/slimeplushie,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "aS" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -226,7 +231,17 @@
 /turf/open/openspace,
 /area/space)
 "aY" = (
-/mob/living/simple_animal/slime,
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #1";
+	req_access_txt = "55"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aZ" = (
@@ -317,28 +332,24 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "bo" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 8;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "bq" = (
 /obj/structure/cable,
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"bs" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "bt" = (
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -441,15 +452,8 @@
 /turf/open/openspace,
 /area/medical/virology)
 "bU" = (
-/obj/machinery/button/door/directional/south{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage Blast Door";
-	pixel_x = -24;
-	pixel_y = 0;
-	req_access_txt = "30"
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/rd)
 "bW" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -469,7 +473,17 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "bZ" = (
-/obj/item/toy/plush/slimeplushie,
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #5";
+	req_access_txt = "55"
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ca" = (
@@ -517,6 +531,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"cj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ck" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -590,14 +614,14 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "cC" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology - Freezer";
-	dir = 4;
-	name = "Xenobiology Camera";
-	network = list("ss13","rd","xeno")
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "cD" = (
 /obj/structure/railing{
 	dir = 5
@@ -682,20 +706,19 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "cR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
-"cS" = (
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"cS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -743,14 +766,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
 /area/space)
-"dc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
-	name = "Xenobio Pen 1 Blast Door"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "dd" = (
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
@@ -825,24 +840,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"du" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #1";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
-	name = "Xenobio Pen 1 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "dv" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -953,20 +950,6 @@
 "dS" = (
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"dT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio1";
-	name = "Xenobio Pen 1 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "dU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -1064,14 +1047,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
-"ej" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "Xenobio Pen 2 Blast Door"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "el" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/white,
@@ -1102,6 +1077,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/space)
+"et" = (
+/obj/machinery/door/airlock/research/glass{
+	name = "Xenobiology Kill Room";
+	req_access_txt = "47"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "eu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
@@ -1124,24 +1109,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
-"ey" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #2";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "Xenobio Pen 2 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "ez" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1208,9 +1175,12 @@
 /turf/open/floor/plating,
 /area/medical/psychology)
 "eR" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/white,
+/area/science)
 "eS" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -1245,20 +1215,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
-"eY" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio2";
-	name = "Xenobio Pen 2 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "eZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -1351,11 +1307,9 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "fq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/science/xenobiology)
+/area/science/xenobiology)
 "fv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -1381,6 +1335,12 @@
 "fy" = (
 /turf/closed/wall,
 /area/commons/dorms)
+"fA" = (
+/obj/structure/railing/corner,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "fB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1433,6 +1393,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"fJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "fK" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -1474,16 +1444,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"fR" = (
-/obj/machinery/door/airlock/research/glass{
-	name = "Xenobiology Kill Room";
-	req_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "fS" = (
 /obj/structure/railing{
 	dir = 4
@@ -1638,9 +1598,9 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "go" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/iron/white,
+/area/science)
 "gp" = (
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -1686,12 +1646,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "gu" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 30
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "gx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -1725,24 +1683,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"gC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "Xenobio Pen 3 Blast Door"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "gE" = (
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "gF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/science)
 "gG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -1780,11 +1727,8 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "gQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/turf/open/openspace,
+/area/command/heads_quarters/rd)
 "gR" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -1793,11 +1737,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "gT" = (
-/obj/structure/railing/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/command/heads_quarters/rd)
 "gV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -1900,24 +1841,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"hj" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #3";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "Xenobio Pen 3 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "hk" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -2042,25 +1965,30 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
+"hC" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "hD" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
-"hI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
-"hJ" = (
+"hH" = (
+/obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"hI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "hK" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -2073,6 +2001,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"hM" = (
+/obj/machinery/door/poddoor{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "hO" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -2140,23 +2084,16 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "ia" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard)
 "ic" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio3";
-	name = "Xenobio Pen 3 Blast Door"
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "id" = (
 /obj/structure/noticeboard/directional/south,
@@ -2187,14 +2124,14 @@
 	},
 /turf/open/floor/carpet/green,
 /area/space)
-"ij" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio4";
-	name = "Xenobio Pen 4 Blast Door"
+"il" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/railing/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/science)
 "in" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2203,6 +2140,16 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"io" = (
+/obj/machinery/button/door/directional/south{
+	id = "toxinsstorage";
+	name = "Toxins Secure Storage Blast Door";
+	pixel_x = -24;
+	pixel_y = 0;
+	req_access_txt = "30"
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "ip" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -2219,9 +2166,13 @@
 /turf/open/floor/plating,
 /area/cargo/office)
 "is" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen/fountain,
+/obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/command/heads_quarters/rd)
 "it" = (
 /obj/structure/bed,
 /turf/open/floor/iron/white,
@@ -2242,25 +2193,32 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "iy" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Xenobiology - Freezer";
+	dir = 4;
+	name = "Xenobiology Camera";
+	network = list("ss13","rd","xeno")
 	},
+/obj/structure/sign/warning/coldtemp{
+	pixel_x = -30
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "iz" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/xenobiology)
-"iA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/structure/table/glass,
+/obj/machinery/light/blacklight/directional/north,
+/obj/item/clothing/mask/facehugger/toy,
+/obj/machinery/status_display/ai/directional/north,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
+"iA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science)
 "iC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -2272,9 +2230,12 @@
 /turf/open/floor/plating/airless,
 /area/hallway/primary/upper)
 "iG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/obj/structure/table/glass,
+/obj/item/stamp/denied,
+/obj/item/modular_computer/laptop,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "iH" = (
 /obj/structure/chair/stool{
 	pixel_y = 15
@@ -2283,15 +2244,22 @@
 	icon_state = "wood-broken5"
 	},
 /area/service/abandoned_gambling_den)
+"iI" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -30
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "iK" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison/workout)
 "iL" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/research_and_development,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "iM" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -2374,15 +2342,14 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "jd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/modular_computer/console/preset/research,
+/obj/machinery/camera{
+	c_tag = "Research Director";
+	name = "RD Camera";
+	network = list("ss13","rd")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "je" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
@@ -2413,6 +2380,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"jk" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "jm" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
@@ -2427,24 +2398,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"jq" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #4";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio4";
-	name = "Xenobio Pen 4 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "jr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -2517,13 +2470,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
-"jA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "jB" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
@@ -2532,13 +2478,6 @@
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/space)
-"jF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -2614,20 +2553,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
-"jR" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio4";
-	name = "Xenobio Pen 4 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "jS" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -2672,6 +2597,16 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"ka" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "kb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2682,12 +2617,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ke" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio5";
-	name = "Xenobio Pen 5 Blast Door"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "kg" = (
 /turf/closed/wall,
@@ -2699,12 +2633,23 @@
 /obj/item/toy/figure/qm,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"ki" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "kj" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"kk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "km" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/secure_data/laptop{
@@ -3032,12 +2977,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"lg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "lh" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -3095,22 +3034,22 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lr" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #5";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #5";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio5";
-	name = "Xenobio Pen 5 Blast Door"
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
+"ls" = (
+/obj/machinery/camera{
+	c_tag = "Xenobiology - Freezer";
+	dir = 4;
+	name = "Xenobiology Camera";
+	network = list("ss13","rd","xeno")
 	},
-/turf/open/floor/engine,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "lt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -3150,6 +3089,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/space)
+"lz" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "lA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3190,6 +3133,12 @@
 /obj/item/stack/pipe_cleaner_coil/random,
 /turf/open/floor/iron,
 /area/security/prison)
+"lG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "lH" = (
 /turf/open/space/basic,
 /area/medical/virology)
@@ -3200,8 +3149,9 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "lL" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
 "lO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3497,13 +3447,6 @@
 "mG" = (
 /turf/open/floor/glass,
 /area/service/hydroponics/upper)
-"mI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
 "mJ" = (
 /turf/closed/wall,
 /area/engineering/atmospherics_engine)
@@ -3579,14 +3522,9 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "mY" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron{
-	amount = 50
-	},
-/obj/item/stack/sheet/plasteel/twenty,
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/modular_computer/console/preset/id,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "mZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -3664,7 +3602,9 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "nm" = (
@@ -3877,18 +3817,11 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "od" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio5";
-	name = "Xenobio Pen 5 Blast Door"
-	},
-/turf/open/floor/engine,
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/storage/box/lights/mixed,
+/obj/item/screwdriver,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "oe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -3951,6 +3884,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"ot" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "ov" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -3985,9 +3924,6 @@
 /obj/structure/ladder,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"oG" = (
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "oH" = (
 /obj/structure/railing{
 	dir = 4
@@ -4066,15 +4002,14 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "oU" = (
-/obj/machinery/button/door/directional/west{
-	id = "xenobio1";
+/obj/machinery/button/door/directional/east{
+	id = "xenobio7";
 	layer = 3.3;
-	name = "Xenobio Pen 1 Blast Doors";
+	name = "Xenobio Pen 7 Blast Doors";
 	pixel_x = 0;
-	pixel_y = 24;
+	pixel_y = -24;
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "oV" = (
@@ -4128,6 +4063,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"pd" = (
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #9";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #9";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "pe" = (
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
@@ -4157,6 +4106,10 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"pl" = (
+/obj/structure/railing,
+/turf/open/floor/iron/white,
+/area/science)
 "pm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -4179,31 +4132,18 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "pp" = (
-/obj/machinery/door/poddoor{
-	id = "toxinsstorage";
-	name = "Toxins Secure Storage"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
+/obj/machinery/suit_storage_unit/rd,
+/obj/machinery/light/blacklight/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
+"pq" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = -32
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"pq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
 "pr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/machinery/airalarm/directional/east,
@@ -4215,9 +4155,11 @@
 	},
 /area/medical/medbay/zone2)
 "ps" = (
-/obj/structure/railing,
+/obj/structure/closet/secure_closet/research_director,
+/obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/command/heads_quarters/rd)
 "pt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -4252,6 +4194,23 @@
 /obj/effect/wisp,
 /turf/open/floor/plating,
 /area/space)
+"py" = (
+/obj/machinery/button/door/directional/east{
+	id = "xenobio6";
+	layer = 3.3;
+	name = "Xenobio Pen 6 Blast Doors";
+	pixel_x = 0;
+	pixel_y = -24;
+	req_access_txt = "55"
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "pA" = (
 /turf/open/floor/iron,
 /area/science/research/abandoned)
@@ -4303,6 +4262,12 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"pH" = (
+/obj/structure/sign/warning/xeno_mining{
+	pixel_x = 30
+	},
+/turf/open/openspace,
+/area/science/xenobiology)
 "pI" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
@@ -4377,9 +4342,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "pV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "pW" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -4431,11 +4398,13 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "qe" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -30
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance";
+	req_one_access_txt = "30"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/xenobiology)
+/area/maintenance/starboard)
 "qf" = (
 /turf/open/openspace,
 /area/engineering/storage_shared)
@@ -4602,15 +4571,14 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "qC" = (
-/obj/machinery/button/door/directional/west{
-	id = "xenobio2";
+/obj/machinery/button/door/directional/east{
+	id = "xenobio8";
 	layer = 3.3;
-	name = "Xenobio Pen 2 Blast Doors";
+	name = "Xenobio Pen 8 Blast Doors";
 	pixel_x = 0;
-	pixel_y = 24;
+	pixel_y = -24;
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qE" = (
@@ -4624,9 +4592,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
-"qH" = (
-/turf/open/floor/iron/dark,
-/area/science/storage)
 "qI" = (
 /obj/structure/chair{
 	dir = 4
@@ -4654,15 +4619,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"qO" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
 "qQ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/trophy,
@@ -4805,10 +4761,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"rt" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark,
-/area/science/storage)
 "rv" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -4851,14 +4803,33 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"rB" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #3";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "rC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #11";
+	req_access_txt = "55"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #11";
+	req_access_txt = "55"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "rD" = (
 /obj/structure/bed,
@@ -4867,26 +4838,22 @@
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
 "rE" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance";
+	req_one_access_txt = "47"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/maintenance/starboard)
 "rF" = (
-/obj/machinery/button/door/directional/west{
-	id = "xenobio3";
+/obj/machinery/button/door/directional/east{
+	id = "xenobio9";
 	layer = 3.3;
-	name = "Xenobio Pen 3 Blast Doors";
+	name = "Xenobio Pen 9 Blast Doors";
 	pixel_x = 0;
-	pixel_y = 24;
+	pixel_y = -24;
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "rG" = (
@@ -4931,21 +4898,17 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "rO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/xenobiology)
+/turf/open/openspace,
+/area/science/xenobiology)
 "rP" = (
-/obj/machinery/button/door/directional/west{
-	id = "xenobio4";
+/obj/machinery/button/door/directional/east{
+	id = "xenobio10";
 	layer = 3.3;
-	name = "Xenobio Pen 4 Blast Doors";
+	name = "Xenobio Pen 10 Blast Doors";
 	pixel_x = 0;
-	pixel_y = 24;
+	pixel_y = -24;
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "rR" = (
@@ -5032,19 +4995,24 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "sf" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "sh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
 "sk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "sl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -5054,6 +5022,10 @@
 /obj/item/toy/mecha/ripley,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"sq" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "sr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -5079,16 +5051,17 @@
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
 "sv" = (
-/obj/machinery/button/door/directional/west{
-	id = "xenobio5";
+/obj/machinery/button/door/directional/east{
+	id = "xenobio11";
 	layer = 3.3;
-	name = "Xenobio Pen 5 Blast Doors";
+	name = "Xenobio Pen 11 Blast Doors";
 	pixel_x = 0;
-	pixel_y = 24;
+	pixel_y = -24;
 	req_access_txt = "55"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "sw" = (
@@ -5096,9 +5069,7 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "sx" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/science/breakroom)
 "sA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5137,11 +5108,22 @@
 /turf/open/floor/iron/dark,
 /area/cargo/sorting)
 "sH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Office";
+	req_access_txt = "30"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "sI" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -5204,13 +5186,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"sZ" = (
-/obj/structure/rack,
-/obj/item/wirecutters,
-/obj/item/storage/box/lights/mixed,
-/obj/item/screwdriver,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+"sY" = (
+/turf/open/floor/circuit/telecomms,
+/area/maintenance/department/science/xenobiology)
 "ta" = (
 /obj/machinery/door/airlock{
 	id_tag = "medtoilet1";
@@ -5234,16 +5212,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
-"te" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "tg" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -5251,6 +5219,12 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"ti" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "tj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -5319,22 +5293,9 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "ts" = (
-/obj/machinery/button/door/directional/east{
-	id = "xenobio6";
-	layer = 3.3;
-	name = "Xenobio Pen 6 Blast Doors";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "55"
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/xenobiology)
+/area/command/heads_quarters/rd)
 "tt" = (
 /obj/structure/chair{
 	dir = 1
@@ -5386,12 +5347,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"tI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
 "tL" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
@@ -5485,6 +5440,20 @@
 "ud" = (
 /turf/open/floor/iron/grimy,
 /area/space)
+"ue" = (
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #7";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #7";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "ug" = (
 /obj/structure/railing{
 	dir = 10
@@ -5497,18 +5466,11 @@
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "ui" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology - Freezer";
-	dir = 4;
-	name = "Xenobiology Camera";
-	network = list("ss13","rd","xeno")
-	},
-/obj/structure/sign/warning/coldtemp{
-	pixel_x = -30
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/machinery/disposal/bin,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/xenobiology)
+/area/command/heads_quarters/rd)
 "uj" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/prison_contraband,
@@ -5534,6 +5496,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"up" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "uq" = (
 /obj/structure/urinal/directional/north,
 /obj/machinery/airalarm/directional/east,
@@ -5545,6 +5517,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"us" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance";
+	req_one_access_txt = "12;47"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ut" = (
 /obj/structure/chair{
 	dir = 8
@@ -5617,26 +5596,13 @@
 /turf/open/floor/carpet/purple,
 /area/commons/dorms)
 "uC" = (
-/obj/machinery/button/door/directional/east{
-	id = "xenobio7";
-	layer = 3.3;
-	name = "Xenobio Pen 7 Blast Doors";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "55"
-	},
+/obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
-/area/science/xenobiology)
+/area/science)
 "uD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/science)
 "uF" = (
 /obj/structure/railing{
 	dir = 8
@@ -5672,16 +5638,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "uO" = (
-/obj/machinery/button/door/directional/east{
-	id = "xenobio8";
-	layer = 3.3;
-	name = "Xenobio Pen 8 Blast Doors";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "55"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/science/xenobiology)
+/area/command/heads_quarters/rd)
 "uP" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -5690,6 +5649,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/microwave,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "uQ" = (
@@ -5736,13 +5696,9 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "uV" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "psychology";
-	name = "Privacy Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/psychology)
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "uW" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
@@ -5785,22 +5741,22 @@
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "vc" = (
-/obj/machinery/button/door/directional/east{
-	id = "xenobio9";
-	layer = 3.3;
-	name = "Xenobio Pen 9 Blast Doors";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "55"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
+"vd" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
+"ve" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"ve" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/department/science/xenobiology)
 "vf" = (
 /obj/structure/chair{
 	dir = 8
@@ -5842,6 +5798,26 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/carpet/orange,
 /area/commons/dorms)
+"vr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/storage)
+"vv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance";
+	req_one_access_txt = "47"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/maintenance/starboard)
 "vx" = (
 /obj/machinery/camera{
 	c_tag = "Virology Monkey Pen";
@@ -5851,15 +5827,15 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "vz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
@@ -5950,17 +5926,13 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
 "vO" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_y = 30
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/table,
+/obj/item/toy/plush/slimeplushie,
+/turf/open/floor/iron/white,
+/area/science)
 "vQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vR" = (
@@ -6010,9 +5982,6 @@
 "vX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Emergency Room"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashutmed"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
@@ -6113,12 +6082,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "wq" = (
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "wr" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
@@ -6159,16 +6127,10 @@
 /turf/open/floor/plating,
 /area/space)
 "wz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Xenobiology Maintenance";
-	req_access_txt = "55"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/toy/plush/beeplushie,
 /turf/open/floor/iron/white,
-/area/maintenance/department/science/xenobiology)
+/area/science)
 "wA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6285,6 +6247,16 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"wT" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "wW" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
@@ -6303,15 +6275,9 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "xb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "xc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -6377,6 +6343,18 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/toilet)
+"xm" = (
+/obj/machinery/button/door/directional/west{
+	id = "xenobio3";
+	layer = 3.3;
+	name = "Xenobio Pen 3 Blast Doors";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "xn" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -6521,13 +6499,12 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "xO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "psychology";
-	name = "Privacy Door"
-	},
-/turf/open/floor/plating,
-/area/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science)
 "xP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6665,8 +6642,10 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "yq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "yr" = (
@@ -6726,14 +6705,34 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"yB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "yC" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/cargo/warehouse)
-"yG" = (
+"yF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/iron/dark,
+/area/science/storage)
+"yG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "yH" = (
@@ -6767,18 +6766,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "yQ" = (
-/obj/structure/sign/warning/coldtemp{
-	pixel_x = -30
-	},
-/obj/machinery/light/directional/west,
-/obj/structure/cable/multilayer/multiz,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/science/xenobiology)
 "yR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -6797,6 +6786,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"yY" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "yZ" = (
 /turf/open/openspace,
 /area/hallway/secondary/service)
@@ -6810,12 +6803,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"zd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
 "zf" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -6899,16 +6886,15 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "zr" = (
-/obj/machinery/button/door/directional/east{
-	id = "xenobio10";
-	layer = 3.3;
-	name = "Xenobio Pen 10 Blast Doors";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "55"
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance";
+	req_one_access_txt = "47"
 	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard)
 "zs" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -6917,11 +6903,12 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "zt" = (
-/obj/structure/sign/warning/coldtemp{
-	pixel_x = -30
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "zu" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -7021,29 +7008,47 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "zM" = (
-/obj/machinery/button/door/directional/east{
-	id = "xenobio11";
-	layer = 3.3;
-	name = "Xenobio Pen 11 Blast Doors";
-	pixel_x = 0;
-	pixel_y = -24;
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	name = "RD's Secured Computers";
+	req_access_txt = "30"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "zP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "zQ" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
+"zR" = (
+/obj/structure/sign/warning/coldtemp{
+	pixel_x = -30
+	},
+/turf/open/floor/circuit/telecomms,
+/area/maintenance/department/science/xenobiology)
+"zS" = (
+/obj/machinery/button/door/directional/west{
+	id = "xenobio1";
+	layer = 3.3;
+	name = "Xenobio Pen 1 Blast Doors";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "zU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance"
@@ -7099,16 +7104,6 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/wood,
 /area/service/bar)
-"Ac" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "Ad" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -7117,16 +7112,9 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Ae" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_one_access_txt = "47"
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/science)
-"Af" = (
-/turf/open/floor/iron/white,
-/area/science/storage)
 "Ag" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7226,6 +7214,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar/atrium)
+"Ax" = (
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/white,
+/area/science)
 "Az" = (
 /obj/structure/bed,
 /obj/machinery/camera{
@@ -7256,13 +7248,19 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "AE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio6";
-	name = "Xenobio Pen 6 Blast Door"
+/obj/effect/landmark/start/research_director,
+/obj/structure/chair/office/light{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
+"AF" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "AH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -7289,6 +7287,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"AL" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "AM" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -7394,26 +7401,6 @@
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/medical/medbay/zone2)
-"AW" = (
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	dir = 2;
-	icon_state = "right";
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #6";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio6";
-	name = "Xenobio Pen 6 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "AY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -7423,6 +7410,10 @@
 "AZ" = (
 /turf/open/floor/engine,
 /area/medical/chemistry)
+"Ba" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Bb" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -7432,17 +7423,16 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "Bd" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/stamp/denied,
+/obj/item/stamp/rd,
+/obj/item/cartridge/signal/toxins,
+/obj/item/cartridge/signal/toxins,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio6";
-	name = "Xenobio Pen 6 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "Be" = (
 /obj/machinery/button/crematorium{
 	id = "crematorium";
@@ -7552,16 +7542,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"BE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_one_access_txt = "47"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/storage)
 "BF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7586,16 +7566,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"BL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/space)
 "BM" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
@@ -7742,6 +7712,10 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"Cl" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Cm" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/orangejuice,
@@ -7802,9 +7776,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut1"
-	},
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
 	dir = 1;
@@ -7821,11 +7792,11 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Cv" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
 	req_one_access_txt = "47"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "Cz" = (
@@ -7862,13 +7833,11 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "CG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio7";
-	name = "Xenobio Pen 7 Blast Door"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "CH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -7916,13 +7885,8 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "CQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "CR" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 30
@@ -7956,6 +7920,24 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"CU" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "CV" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Coldroom";
@@ -8124,21 +8106,7 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Dr" = (
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #7";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #7";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio7";
-	name = "Xenobio Pen 7 Blast Door"
-	},
+/mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "Dt" = (
@@ -8224,6 +8192,11 @@
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /turf/open/floor/wood,
 /area/service/bar)
+"DO" = (
+/obj/structure/filingcabinet/filingcabinet,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "DP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8279,16 +8252,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
-"DW" = (
-/obj/structure/sign/warning/explosives/alt{
-	pixel_y = 30
-	},
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/turf/open/floor/iron/dark,
-/area/science/storage)
 "DX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "DY" = (
@@ -8323,8 +8290,14 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "Ef" = (
-/turf/open/openspace,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "Eg" = (
 /turf/closed/wall,
 /area/holodeck/rec_center)
@@ -8463,9 +8436,14 @@
 /turf/open/floor/wood,
 /area/service/theater)
 "EC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/command/heads_quarters/rd)
 "ED" = (
 /obj/structure/railing{
 	dir = 9
@@ -8509,10 +8487,25 @@
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"EK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "EL" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Maintenance";
+	req_one_access_txt = "12;47"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "EM" = (
 /obj/structure/table,
 /obj/item/pen/fountain,
@@ -8653,7 +8646,17 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "Fi" = (
-/obj/structure/cable,
+/obj/structure/sign/warning/coldtemp{
+	pixel_x = -30
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/cable/multilayer/multiz,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "Fk" = (
@@ -8686,11 +8689,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Fo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "Fp" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -8712,9 +8715,6 @@
 	color = "#FF6700";
 	dir = 1;
 	name = "Prison Orange"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut4"
 	},
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt4";
@@ -8750,18 +8750,33 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Fz" = (
-/obj/structure/sign/warning/explosives/alt{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
-"FA" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science)
+"FA" = (
+/obj/machinery/door/airlock/command{
+	name = "Research Director's Office";
+	req_access_txt = "30"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "FB" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -8807,15 +8822,15 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "FL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_one_access_txt = "47"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "FM" = (
 /obj/structure/toilet{
 	dir = 1
@@ -8987,6 +9002,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"Gl" = (
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #8";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #8";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "Gm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -9024,10 +9053,8 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "Gs" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/closed/wall,
+/area/maintenance/department/science/xenobiology)
 "Gt" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -9219,6 +9246,13 @@
 /obj/item/toy/talking/ai,
 /turf/open/floor/iron,
 /area/security/prison)
+"Hd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "He" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -9531,10 +9565,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "HZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "Ia" = (
@@ -9542,30 +9573,36 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "Ib" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio7";
-	name = "Xenobio Pen 7 Blast Door"
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/science)
 "Ic" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
 /area/security/office)
+"Id" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 30
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "Ie" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "secofficelock";
-	name = "Security Office Lockdown Door"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "If" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -9719,13 +9756,16 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "IC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio8";
-	name = "Xenobio Pen 8 Blast Door"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "ID" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Testing Room";
@@ -9853,10 +9893,9 @@
 /turf/open/space/basic,
 /area/space)
 "Ja" = (
-/obj/structure/sign/warning/xeno_mining{
-	pixel_x = 30
-	},
-/turf/open/openspace,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "Jb" = (
 /obj/structure/window/reinforced,
@@ -9886,12 +9925,16 @@
 /turf/closed/wall,
 /area/cargo/warehouse)
 "Jg" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/white,
+/area/science)
 "Jh" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Security";
@@ -9919,15 +9962,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"Jl" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "hoslock";
-	name = "HoS Office Lockdown Door"
+"Jn" = (
+/obj/machinery/button/door/directional/west{
+	id = "xenobio2";
+	layer = 3.3;
+	name = "Xenobio Pen 2 Blast Doors";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "55"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/command/heads_quarters/hos)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "Jo" = (
 /turf/closed/wall,
 /area/medical/psychology)
@@ -9961,16 +10007,6 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
-"Ju" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/science/storage)
-"Jv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/space)
 "Jy" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
@@ -10144,15 +10180,6 @@
 /obj/item/card/id/advanced/prisoner/chef,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"Ke" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "hoslock";
-	name = "HoS Office Lockdown Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/command/heads_quarters/hos)
 "Kf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -10162,7 +10189,11 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard)
+"Kg" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Kh" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Lobby SE";
@@ -10177,23 +10208,15 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "Ki" = (
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #8";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #8";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio8";
-	name = "Xenobio Pen 8 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science)
 "Kj" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
@@ -10225,6 +10248,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"Km" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "Ko" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -10413,24 +10440,19 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "KU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science)
+"KV" = (
+/obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"KV" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio8";
-	name = "Xenobio Pen 8 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
 "KW" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -10453,6 +10475,22 @@
 /obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"La" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
+"Lb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "Lc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	color = "#B392CB"
@@ -10549,6 +10587,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"Lw" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Ly" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/blacklight/directional/south,
@@ -10624,13 +10666,12 @@
 /turf/open/floor/iron,
 /area/security/office)
 "LM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio9";
-	name = "Xenobio Pen 9 Blast Door"
+/obj/structure/sign/warning/explosives/alt{
+	pixel_y = 30
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/obj/machinery/portable_atmospherics/scrubber/huge,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "LN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10721,6 +10762,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"Me" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/iron{
+	amount = 50
+	},
+/obj/item/stack/sheet/plasteel/twenty,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Mf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -10783,23 +10833,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Ms" = (
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #9";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #9";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio9";
-	name = "Xenobio Pen 9 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Mt" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -10902,17 +10938,13 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ML" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_y = 30
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio9";
-	name = "Xenobio Pen 9 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "MN" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Grenade testing"
@@ -10920,9 +10952,13 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "MO" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "MP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -11005,9 +11041,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"Ne" = (
-/turf/open/openspace,
-/area/science/xenobiology)
 "Ng" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -11034,13 +11067,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Ni" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio10";
-	name = "Xenobio Pen 10 Blast Door"
+/obj/structure/sign/warning/explosives/alt{
+	pixel_y = 30
 	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Nj" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -11123,6 +11154,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"Nx" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Xenobiology Maintenance";
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/department/science/xenobiology)
 "Ny" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/item/storage/bag/construction,
@@ -11130,6 +11172,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"Nz" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "NB" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -11175,14 +11221,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "NF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/science/storage)
 "NH" = (
 /obj/structure/table,
@@ -11196,12 +11239,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "NL" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/storage)
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "NN" = (
 /obj/structure/table,
 /obj/item/coin/iron,
@@ -11272,6 +11311,19 @@
 "Oa" = (
 /turf/closed/mineral/random/labormineral,
 /area/space)
+"Ob" = (
+/obj/machinery/button/door/directional/west{
+	id = "xenobio5";
+	layer = 3.3;
+	name = "Xenobio Pen 5 Blast Doors";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "Od" = (
 /obj/machinery/door/airlock{
 	id_tag = "Black Dorm";
@@ -11301,10 +11353,9 @@
 	},
 /area/service/abandoned_gambling_den)
 "Oh" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/light/directional/east,
+/obj/structure/chair/office/light,
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/command/heads_quarters/rd)
 "Oi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -11331,21 +11382,31 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "Op" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "RD's Secured Computers";
+	req_access_txt = "30"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "Os" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison/work)
+"Ot" = (
+/obj/machinery/button/door/directional/west{
+	id = "xenobio4";
+	layer = 3.3;
+	name = "Xenobio Pen 4 Blast Doors";
+	pixel_x = 0;
+	pixel_y = 24;
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "Ou" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 5
@@ -11387,13 +11448,12 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "OA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/disposal/bin,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "OB" = (
 /turf/open/floor/iron/dark,
@@ -11402,6 +11462,13 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/service/bar/atrium)
+"OD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "OE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -11523,7 +11590,7 @@
 	req_one_access_txt = "47"
 	},
 /turf/open/floor/plating,
-/area/science/breakroom)
+/area/maintenance/starboard)
 "OZ" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
@@ -11550,9 +11617,6 @@
 "Pd" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut2"
 	},
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -11629,30 +11693,13 @@
 /turf/open/floor/carpet/orange,
 /area/commons/dorms)
 "Pm" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
+/obj/machinery/computer/security/telescreen/rd{
 	dir = 8;
-	name = "Science purple corner"
+	pixel_x = 30;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 4;
-	name = "Science purple corner"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "Pn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -11719,6 +11766,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"Pv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "Pw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -11843,9 +11900,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "PP" = (
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/table/glass,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "PQ" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -11865,23 +11922,11 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "PT" = (
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #10";
-	req_access_txt = "55"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #10";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio10";
-	name = "Xenobio Pen 10 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/science)
 "PV" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -12028,13 +12073,6 @@
 /obj/item/toy/dummy,
 /turf/open/floor/iron/white,
 /area/service/theater)
-"Qs" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 30
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "Qu" = (
 /obj/structure/window{
 	dir = 8
@@ -12055,6 +12093,14 @@
 /obj/machinery/vending/games,
 /turf/open/floor/iron,
 /area/security/prison)
+"Qz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "QA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -12162,10 +12208,11 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "QR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science)
 "QS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -12178,9 +12225,6 @@
 	color = "#FF6700";
 	dir = 1;
 	name = "Prison Orange"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut5"
 	},
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt5";
@@ -12297,6 +12341,20 @@
 "Rl" = (
 /turf/open/floor/carpet,
 /area/service/bar)
+"Rn" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #2";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "Ro" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -12381,6 +12439,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"RI" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "RJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile{
@@ -12395,17 +12459,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "RK" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio10";
-	name = "Xenobio Pen 10 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "RM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -12491,6 +12547,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"RX" = (
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #10";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #10";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "RZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -12572,13 +12642,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Si" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/science)
 "Sk" = (
 /obj/structure/railing{
 	dir = 4
@@ -12604,13 +12670,8 @@
 /turf/open/floor/iron,
 /area/security/office)
 "So" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio11";
-	name = "Xenobio Pen 11 Blast Door"
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Sp" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -12724,8 +12785,6 @@
 /turf/closed/wall/r_wall,
 /area/security/prison/safe)
 "SC" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "SD" = (
@@ -12772,14 +12831,10 @@
 /area/holodeck/rec_center)
 "SQ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/department/science/xenobiology)
 "SR" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -12819,6 +12874,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"SZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Ta" = (
 /obj/machinery/computer/cargo,
 /turf/open/floor/iron,
@@ -12854,6 +12919,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"Tj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Tk" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -12904,10 +12976,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Tu" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science)
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Tv" = (
 /obj/machinery/shower{
 	dir = 4
@@ -12925,23 +12999,14 @@
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
 "Ty" = (
-/obj/machinery/door/window/northleft{
-	dir = 2;
-	name = "Containment Pen #11";
-	req_access_txt = "55"
+/obj/machinery/computer/rdconsole{
+	dir = 1
 	},
-/obj/machinery/door/window/northleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Containment Pen #11";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio11";
-	name = "Xenobio Pen 11 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "Tz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/newscaster/directional/south,
@@ -13015,6 +13080,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
 "TP" = (
@@ -13025,9 +13091,18 @@
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "TQ" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/computer/mecha{
+	dir = 1
+	},
+/obj/machinery/requests_console/directional/south{
+	announcementConsole = 1;
+	department = "Research Director's Desk";
+	departmentType = 5;
+	name = "Research Director's RC Console"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/science/storage)
+/area/command/heads_quarters/rd)
 "TR" = (
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
@@ -13055,10 +13130,6 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "TU" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "hoslock";
-	name = "HoS Office Lockdown Door"
-	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13152,17 +13223,13 @@
 /turf/closed/wall/r_wall,
 /area/service/abandoned_gambling_den)
 "Ur" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/computer/robotics{
+	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio11";
-	name = "Xenobio Pen 11 Blast Door"
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/machinery/newscaster/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -13220,11 +13287,20 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "UE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	dir = 2;
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
 	},
-/turf/open/floor/iron/white,
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #6";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "UG" = (
 /obj/structure/chair/office,
@@ -13262,8 +13338,9 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "UO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "UP" = (
@@ -13279,15 +13356,15 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "UR" = (
+/obj/structure/displaycase/labcage,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/rd)
 "US" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -13325,6 +13402,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"UW" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "UX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
@@ -13436,9 +13518,27 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "Vj" = (
-/obj/structure/disposaloutlet,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/machinery/keycard_auth{
+	pixel_x = -5;
+	pixel_y = -25
+	},
+/obj/machinery/button/door/directional/south{
+	id = "rdoffice";
+	name = "RD Office Shutter Control";
+	pixel_x = 6;
+	pixel_y = -36;
+	req_access_txt = "30"
+	},
+/obj/machinery/button/door/directional/south{
+	id = "toxinsrd";
+	name = "Toxins Shield Button";
+	pixel_x = -6;
+	pixel_y = -36;
+	req_access_txt = "30"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "Vk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13449,9 +13549,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Vm" = (
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/table/glass,
+/obj/item/folder/blue,
+/obj/item/toy/figure/rd,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science)
+/area/command/heads_quarters/rd)
 "Vn" = (
 /obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/iron/dark,
@@ -13505,9 +13608,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "Vv" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/item/kirbyplants/dead,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "Vw" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -13581,6 +13684,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"VK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "VL" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -13626,10 +13733,6 @@
 "VR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "hoslock";
-	name = "HoS Office Lockdown Door"
-	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "VS" = (
@@ -13642,6 +13745,10 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"VV" = (
+/obj/machinery/atmospherics/components/unary/passive_vent,
+/turf/open/floor/circuit/telecomms,
+/area/maintenance/department/science/xenobiology)
 "VW" = (
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
@@ -13723,9 +13830,6 @@
 "Wn" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut3"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -13951,9 +14055,6 @@
 	dir = 1;
 	name = "Prison Orange"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "permashut6"
-	},
 /obj/machinery/door/airlock/public/glass{
 	id_tag = "permabolt6";
 	name = "Cell 6"
@@ -13972,6 +14073,31 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/warehouse)
+"Xe" = (
+/obj/machinery/door/airlock/research{
+	name = "Toxins Storage";
+	req_access_txt = "8"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 8;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 4;
+	name = "Science purple corner"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "Xf" = (
 /obj/structure/railing{
 	dir = 8
@@ -13991,9 +14117,8 @@
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
 "Xi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science)
 "Xj" = (
@@ -14107,12 +14232,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "XH" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/obj/structure/rack,
+/obj/item/circuitboard/aicore,
+/obj/item/aicard,
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "XI" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/white,
@@ -14203,6 +14327,13 @@
 /obj/structure/window,
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
+"XY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science)
 "Ya" = (
 /obj/machinery/atmospherics/pipe/multiz/cyan/visible/layer4{
 	dir = 1
@@ -14323,10 +14454,8 @@
 /turf/open/floor/plating,
 /area/cargo/sorting)
 "Ys" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/structure/disposaloutlet,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "Yt" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -14413,15 +14542,13 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "YF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/storage)
+/turf/open/floor/iron/white,
+/area/science)
 "YG" = (
 /turf/open/floor/iron/white,
 /area/commons/dorms)
@@ -14518,6 +14645,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"YY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "YZ" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -14571,12 +14702,12 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "Zk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/item/paicard,
+/obj/item/tape,
+/obj/item/taperecorder,
+/obj/structure/rack,
 /turf/open/floor/iron/white,
-/area/science/storage)
+/area/command/heads_quarters/rd)
 "Zl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -14752,6 +14883,20 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"ZT" = (
+/obj/machinery/door/window/northleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/northleft{
+	dir = 2;
+	name = "Containment Pen #4";
+	req_access_txt = "55"
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "ZV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -38986,7 +39131,7 @@ TK
 TK
 VR
 VR
-Ke
+VR
 VR
 TK
 TK
@@ -39503,7 +39648,7 @@ WQ
 WG
 WG
 JK
-Ke
+VR
 LL
 Gg
 Wf
@@ -40267,14 +40412,14 @@ Mu
 Mu
 Mu
 Mu
-Ke
+VR
 CB
 WG
 YD
 zQ
 WG
 Nr
-Jl
+TU
 qv
 Sm
 Wz
@@ -42332,10 +42477,10 @@ de
 de
 Xv
 Xv
-Ie
-Ie
-Ie
-Ie
+de
+de
+de
+de
 Xv
 Xv
 Xv
@@ -49363,7 +49508,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 ql
 ql
 ql
@@ -49619,8 +49764,8 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
+ql
+ql
 YB
 YB
 YB
@@ -49876,7 +50021,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -50133,7 +50278,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -50390,7 +50535,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -50647,7 +50792,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -50904,7 +51049,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -51161,7 +51306,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -51418,7 +51563,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -51675,7 +51820,7 @@ nD
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -51932,7 +52077,7 @@ nD
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -52189,7 +52334,7 @@ nD
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -52446,7 +52591,7 @@ nD
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -52703,7 +52848,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -52960,7 +53105,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 YB
 YB
 YB
@@ -53217,10 +53362,10 @@ Mu
 Mu
 Mu
 Mu
-Mu
-YB
-YB
-YB
+ql
+ql
+ql
+ql
 ql
 ql
 ql
@@ -55246,7 +55391,7 @@ yh
 WW
 Cq
 SW
-xO
+eQ
 cv
 hv
 cv
@@ -55503,7 +55648,7 @@ ZN
 Qp
 Qp
 BO
-xO
+eQ
 cv
 dD
 dD
@@ -55760,7 +55905,7 @@ RE
 Qp
 Qp
 Dx
-xO
+eQ
 cv
 dD
 dD
@@ -56017,7 +56162,7 @@ wA
 Qp
 Qp
 Dx
-xO
+eQ
 cv
 dD
 dD
@@ -56274,7 +56419,7 @@ rI
 vb
 Rg
 Dx
-uV
+eQ
 cv
 cv
 cv
@@ -56802,43 +56947,43 @@ EX
 EX
 EX
 EX
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
 ql
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+ql
+Ui
+Ui
+Ui
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Gs
 Mu
 Mu
 Mu
@@ -57059,43 +57204,43 @@ al
 al
 al
 al
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
 ql
-YB
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
 Ui
-iz
+CQ
+CQ
+CQ
+yI
+hC
+yI
+yI
+yI
+yI
 Ui
-Ui
-Ui
-Ui
-YB
-YB
-ct
+us
+Gs
+Gs
+Gs
 Mu
 Mu
 Mu
@@ -57316,43 +57461,43 @@ nh
 nL
 yg
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+CQ
+yI
 UB
-zt
-cC
+zR
+ls
 UB
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -57573,49 +57718,49 @@ nt
 nZ
 zF
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+CQ
+yI
 UB
+VV
+YY
 aE
-iG
-mI
-Ui
-YB
-YB
-ct
-ct
-ct
-ct
-ct
-ct
-ct
+yI
+CQ
+CQ
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -57830,49 +57975,49 @@ nE
 nE
 CZ
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+bo
+gu
+gu
+gu
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+CQ
+yI
 UB
+sY
 UB
-UB
-qO
-Ui
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
+AL
+yI
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -58087,49 +58232,49 @@ nE
 nE
 CZ
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+bo
+gQ
+gQ
+gu
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+Ui
+CQ
+CQ
+CQ
+yI
+yI
 Ui
 yI
+et
 yI
-yI
-fR
-Ui
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -58344,49 +58489,49 @@ nE
 nE
 CZ
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-ql
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+bo
+gQ
+gQ
+gu
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+Ui
+Ui
+us
+lG
+Km
 ve
 lL
 iy
 UO
-ui
-gQ
-Ui
-Ui
-Ui
-Ui
-Ui
-Ui
-Ui
-YB
-YB
-ct
+yI
+yI
+yI
+yI
+yI
+yI
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -58601,49 +58746,49 @@ nG
 nG
 Tz
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
-rO
-Ne
-Ne
-oG
-Fi
-Fi
-yQ
-ts
-AE
-wj
-wj
-wj
+EX
+EX
+EX
+EX
+EX
+EX
+bo
+gT
+gT
+gu
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
 Ui
-YB
-YB
-ct
+CQ
+CQ
+yB
+rO
+rO
+SC
+HZ
+HZ
+Fi
+py
+yQ
+wj
+wj
+wj
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -58858,49 +59003,49 @@ gE
 gE
 zF
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+bo
+gu
+sH
+gu
+gu
+gu
+gu
+bU
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+Ui
+CQ
+CQ
+yB
 rO
-Ne
-Ne
+rO
+ay
+kk
 vQ
 yq
 SC
 UE
-oG
-AW
 wj
-aY
+Dr
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -59115,49 +59260,49 @@ in
 xn
 DZ
 al
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+bU
+is
+gT
+gT
+zt
+NL
+Ty
+bU
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+Ui
+CQ
+CQ
+yB
 rO
-Ne
+pH
+OD
 Ja
 HZ
 yG
-Fi
+SC
 OA
-oG
-Bd
-Vj
+Ys
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -59372,49 +59517,49 @@ al
 al
 al
 al
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
+EX
+EX
+EX
+EX
+EX
+bU
+iz
+gT
+gT
+zM
+Oh
+TQ
+bU
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+Ui
+CQ
+CQ
+La
+fq
 fq
 nl
-nl
-zd
 yI
-Fi
-OA
-qe
+HZ
+yG
+iI
 yI
 yI
 yI
 yI
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -59635,6 +59780,14 @@ EX
 EX
 EX
 EX
+cC
+iG
+gT
+gT
+zt
+NL
+Ur
+bU
 EX
 EX
 EX
@@ -59642,36 +59795,28 @@ EX
 EX
 EX
 EX
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
 wj
-dc
+yQ
+zS
+yG
 oU
-OA
-uC
-CG
+yQ
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -59892,6 +60037,14 @@ EX
 EX
 EX
 EX
+bo
+iL
+gT
+gT
+zP
+Op
+UR
+bU
 EX
 EX
 EX
@@ -59899,36 +60052,28 @@ EX
 EX
 EX
 EX
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
 Ui
+CQ
+CQ
+yI
 wj
-aY
-wj
-du
-Fi
-OA
-oG
 Dr
 wj
 aY
+HZ
+yG
+SC
+ue
 wj
-Ui
-YB
-YB
-ct
+Dr
+wj
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -60149,43 +60294,43 @@ EX
 EX
 EX
 EX
-EX
-EX
-EX
-EX
-EX
-EX
-EX
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
-Ui
-wj
-wj
-cS
-dT
-DX
-jA
-Ys
-Ib
+bo
+jd
+gT
+gT
+AE
+Pm
 Vj
-wj
-wj
+bU
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
 Ui
-YB
-YB
-ct
+CQ
+CQ
+yI
+wj
+wj
+RI
+wT
+cS
+ic
+DX
+OA
+Ys
+wj
+wj
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -60406,6 +60551,14 @@ EX
 EX
 EX
 EX
+bo
+mY
+gT
+uO
+Bd
+PP
+Vm
+cC
 EX
 EX
 EX
@@ -60413,36 +60566,28 @@ EX
 EX
 EX
 EX
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
 Ui
+CQ
+CQ
 yI
 yI
 yI
 yI
-Qs
-OA
-oG
+yI
+Id
+yG
+SC
 yI
 yI
 yI
 yI
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -60663,6 +60808,14 @@ EX
 EX
 EX
 EX
+bo
+pp
+gT
+uV
+CG
+gT
+Vv
+cC
 EX
 EX
 EX
@@ -60670,36 +60823,28 @@ EX
 EX
 EX
 EX
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
 wj
-ej
+yQ
+Jn
+yG
 qC
-OA
-uO
-IC
+yQ
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -60912,51 +61057,51 @@ Yb
 yt
 Bb
 GB
-ql
+GB
+ty
+ty
+ty
+ty
+ty
+ty
 ia
-ia
-ia
-ia
-ia
-ia
-ia
-ia
-ia
-ql
+bU
+ps
+ts
+vc
+Ef
+gT
+XH
+cC
 EX
 EX
 EX
 EX
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
 wj
-ey
-Fi
-OA
-oG
-Ki
+Rn
+HZ
+yG
+SC
+Gl
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -61169,51 +61314,51 @@ Yb
 yt
 Bb
 GB
-nW
-nW
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-nW
-ia
+Yb
+Yb
+Bb
+Bb
+Bb
+Yb
+Bb
+Bb
+bU
+bU
+ui
+gT
+EC
+gT
+Zk
+cC
 EX
 EX
 EX
 EX
-ql
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-ql
-YB
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
-cS
-eY
-Fi
+RI
+wT
+HZ
+yG
+SC
 OA
-oG
-KV
-Vj
+Ys
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -61426,51 +61571,51 @@ Yb
 ce
 Yb
 Cv
-nW
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ia
-EX
-EX
-EX
-EX
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-YB
-YB
-Ui
-yI
-yI
-yI
-yI
-Fi
-OA
+Yb
+Bb
+Bb
+Bb
+Bb
+Yb
+Yb
+Yb
+Yb
 qe
-yI
-yI
-yI
-yI
+ts
+ts
+EC
+gT
+DO
+cC
+EX
+EX
+EX
+EX
+EX
+EX
+EX
+EX
 Ui
-YB
-YB
-ct
+CQ
+CQ
+yI
+yI
+yI
+yI
+yI
+HZ
+yG
+iI
+yI
+yI
+yI
+yI
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -61683,51 +61828,51 @@ Yb
 yt
 Bb
 GB
-nW
-nW
-YB
-YB
-YB
-nW
-nW
-nW
-YB
-YB
-ia
+Yb
+Yb
+Bb
+Bb
+Bb
+Yb
+Bb
+Bb
+Yb
+bU
+bU
+vy
+FA
+bo
+cC
+bU
 EX
 EX
 EX
 EX
-Kj
-Af
-Af
-Af
-Af
-Af
-Af
-Af
-Af
-Af
-Af
-Kj
-YB
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
 wj
-gC
+yQ
+xm
+yG
 rF
-OA
-vc
-LM
+yQ
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -61940,51 +62085,51 @@ Yb
 yt
 Bb
 GB
-ql
-ia
-ia
-ia
-ia
-ia
-ql
-nW
-YB
-YB
-ia
+GB
+ty
+ty
+ty
+ty
+ty
+GB
+Bb
+Yb
+Bb
+KC
+vO
+FL
+Wg
+Ae
+KC
 EX
 EX
 EX
 EX
-Kj
-Af
-zP
-aO
-gT
-Si
-Si
-QR
-QR
-QR
+EX
+EX
+EX
+EX
+Ui
 CQ
-BE
-UR
-YB
-Ui
+CQ
+yI
 wj
 wj
 wj
-hj
-Fi
-OA
-oG
-Ms
+rB
+HZ
+yG
+SC
+pd
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -62203,45 +62348,45 @@ EX
 EX
 EX
 EX
-ia
-nW
-YB
-YB
-ia
+ty
+Yb
+Yb
+Bb
+KC
+wq
+FL
+Wg
+uC
+KC
 EX
 EX
 EX
 EX
-Kj
-Af
-Af
-Zk
-ps
-Ef
-Ef
-Af
-Af
-Af
-lg
-Kj
-xb
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
+RI
+wT
 cS
 ic
 DX
-jA
+OA
 Ys
-ML
-Vj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -62460,45 +62605,45 @@ EX
 EX
 EX
 EX
-ia
-YB
-YB
-YB
-ia
+ty
+Bb
+Bb
+Bb
+KC
+wq
+Ib
+PT
+uD
+KC
 EX
 EX
 EX
 EX
-Kj
-Af
-Af
-Zk
-ps
-Ef
-Ef
-Af
-Af
-Af
-lg
-Kj
-xb
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
 yI
 yI
 yI
 yI
-Qs
-OA
-oG
+yI
+Id
+yG
+SC
 yI
 yI
 yI
 yI
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -62717,45 +62862,45 @@ EX
 EX
 EX
 EX
-ia
-YB
-YB
-YB
-ia
+ty
+Bb
+Bb
+Bb
+KC
+wq
+Ie
+QR
+Wg
+KC
 EX
 EX
 EX
 EX
-Kj
-Af
-Af
-Zk
-ps
-Ef
-Ef
-Af
-Af
-Af
-lg
-Kj
-xb
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
 wj
-ij
+yQ
+Ot
+yG
 rP
-OA
-zr
-Ni
+yQ
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -62974,45 +63119,45 @@ EX
 EX
 EX
 EX
-ia
-YB
-YB
-YB
-ia
+ty
+Yb
+Bb
+Bb
+KC
+wq
+FL
+Wg
+uC
+KC
 EX
 EX
 EX
 EX
-Kj
-Af
-is
-vy
-NL
-FA
-FA
-EC
-EC
-EC
-tI
-Kj
-xb
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
 wj
-jq
-Fi
-OA
-oG
-PT
+ZT
+HZ
+yG
+SC
+RX
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -63231,45 +63376,45 @@ EX
 EX
 EX
 EX
-ia
-nW
-YB
-nW
-ia
+GB
+Yb
+Yb
+Yb
+KC
+wz
+FL
+Wg
+Wg
+KC
 EX
 EX
 EX
 EX
-Kj
-Af
-Af
-NF
-Af
-Af
-Af
-Af
-Af
-Af
-Af
-Kj
-xb
-YB
+EX
+EX
+EX
+EX
 Ui
+CQ
+CQ
+yI
 wj
 wj
-cS
-jR
-Fi
+RI
+wT
+HZ
+yG
+SC
 OA
-oG
-RK
-Vj
+Ys
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -63488,45 +63633,45 @@ EX
 EX
 EX
 EX
-ql
-nW
-nW
-nW
-ql
-EX
-EX
-EX
-EX
-Kj
-Kj
-Kj
-Pm
-bo
-Kj
-pp
-pp
-pp
-Kj
-Kj
-Kj
+GB
+KC
+KC
+rE
+KC
+KC
+IC
 xb
-YB
+xb
+KC
+KC
+KC
+KC
+KC
+KC
+KC
+KC
+GB
+GB
 Ui
+CQ
 yI
 yI
 yI
 yI
-Fi
-OA
-qe
+yI
+HZ
+yG
+iI
 yI
 yI
 yI
 yI
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -63745,45 +63890,45 @@ EX
 EX
 EX
 EX
-KC
+EX
 KC
 Ae
+Ea
+Wg
 KC
+FL
+Wg
+Wg
+Ax
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
 KC
-KC
-EX
-EX
-EX
-Kj
-MO
-XH
-hJ
-mY
-go
-qH
-qH
-qH
-bU
-qH
-Kj
-xb
-YB
+Bb
+Bb
 Ui
+CQ
+yI
 wj
 wj
 wj
+yQ
+Ob
 ke
 sv
-jF
-zM
-So
+yQ
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -64002,45 +64147,45 @@ EX
 EX
 EX
 EX
+EX
 KC
-Tu
 Xi
 TN
-Wg
+uC
 KC
-EX
-EX
-EX
-Kj
-DW
+Jg
+RK
+Hd
+fA
+MO
 MO
 YF
-Ju
-Ju
-Ju
-Ju
+YF
+il
+Qz
+vv
 sk
-rt
+sk
 EL
-Kj
-xb
-YB
-Ui
+fJ
+yI
+wj
+aR
 wj
 bZ
-wj
+up
 lr
-te
+SC
 rC
-oG
-Ty
 wj
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -64259,45 +64404,45 @@ EX
 EX
 EX
 EX
+EX
 KC
-Vm
-Ea
+go
 yA
-Wg
-KC
-EX
-EX
-EX
-Kj
-Vv
-Vv
 uD
+KC
+Ki
+Wg
+XY
+pl
+AA
+AA
+AA
+AA
 pV
-pV
-pV
-pV
-KU
-rt
-EL
-Kj
-xb
-YB
-Ui
+ot
+KC
+Bb
+Bb
+Gs
+EK
+yI
 wj
 wj
-cS
+RI
+wT
+Lb
 od
-Ac
-sZ
-oG
-Ur
-Vj
+SC
+OA
+Ys
 wj
 wj
-Ui
-YB
-YB
-ct
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -64517,44 +64662,44 @@ EX
 EX
 EX
 KC
-Vf
+KC
 Vf
 yA
 Wg
 KC
-ql
-ql
-ql
-Kj
-vO
-Vv
-hJ
-qH
-qH
+Ki
+Wg
+XY
+pl
+AA
+AA
+AA
+AA
+pV
 eR
-iL
-TQ
-rt
+KC
+Bb
+Bb
 Gs
-Kj
-xb
-YB
-Ui
-Ui
-Ui
-Ui
-Ui
-wz
-Ui
-Ui
-Ui
-Ui
-Ui
-Ui
-Ui
-YB
-YB
-ct
+EK
+yI
+yI
+yI
+yI
+yI
+Nx
+yI
+yI
+yI
+yI
+yI
+yI
+yI
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -64778,40 +64923,40 @@ AA
 AA
 yA
 Wg
+xb
+Ki
+Wg
+XY
+Wg
+Wg
+Wg
+Wg
+Wg
+Wg
+ot
 KC
-YB
-YB
-YB
-Kj
-Vv
-Vv
-hJ
-qH
-qH
-eR
-iL
-TQ
-rt
-EL
-Kj
+Bb
+Bb
+Gs
+cj
 SQ
-Jv
-Jv
-Jv
-Jv
-Jv
-Jv
-BL
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
+SQ
+SQ
+SQ
+SQ
+Pv
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -65035,40 +65180,40 @@ AA
 AA
 yA
 Wg
-KC
-YB
-YB
-YB
-Kj
+xb
+Ki
+Si
+ka
 Fz
-qH
-hJ
-qH
-qH
-eR
-iL
-TQ
-rt
-EL
-Kj
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
+Fz
+Fz
+Fz
+Fz
+Fz
+ti
+KC
+Bb
+Bb
+Gs
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+CQ
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -65281,51 +65426,51 @@ bN
 wK
 Bb
 GB
-ql
-ql
-ql
-EX
-EX
-EX
+GB
+GB
+KC
+at
+at
+at
 KC
 AA
 AA
-yA
-Wg
-KC
-YB
+sf
+iA
+xO
+KU
 iA
 Fo
-FL
+Wg
 gF
-wq
-rE
-sf
-PP
-gu
-Oh
-Jg
-rt
-EL
-Kj
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
+Wg
+Wg
+Wg
+Wg
+Wg
+KC
+Bb
+Bb
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Gs
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -65534,37 +65679,37 @@ Hu
 Hu
 Rk
 dG
-YB
-cR
-YB
-YB
-YB
-YB
+Bb
+ce
+Bb
+Bb
+Bb
+Bb
 sO
 sx
 sx
-sx
+aO
 sO
 sO
 Xf
 yA
 Wg
 KC
-YB
-pq
-YB
+Kj
+Kj
+Xe
+CU
+Kj
+hM
+hM
+hM
 Kj
 Kj
 Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
-Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -65791,12 +65936,12 @@ Hu
 Hu
 Hu
 dG
-YB
-cR
-YB
-YB
-YB
-YB
+Bb
+ce
+Bb
+Bb
+Bb
+Bb
 sO
 EA
 Hy
@@ -65807,21 +65952,21 @@ Ea
 yA
 Wg
 KC
-YB
+KV
 pq
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+vr
+Me
+sq
+So
+So
+So
+io
+So
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -66048,12 +66193,12 @@ Hu
 Hu
 Hu
 dG
-YB
-cR
-YB
-YB
-YB
-YB
+Bb
+ce
+Bb
+Bb
+Bb
+Bb
 sO
 FB
 XL
@@ -66064,21 +66209,21 @@ wa
 gi
 Wg
 KC
-YB
-pq
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+LM
+KV
+SZ
+VK
+VK
+VK
+VK
+ki
+lz
+Nz
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -66305,12 +66450,12 @@ Hu
 Hu
 tX
 dG
-YB
-at
-sH
-sH
+Bb
+pb
+ur
+ur
 Kf
-YB
+Bb
 sO
 lh
 HC
@@ -66321,21 +66466,21 @@ TG
 oI
 Wg
 KC
-YB
-pq
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Ms
+Ms
+yF
+Ba
+Ba
+Ba
+Ba
+Tj
+lz
+Nz
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -66562,12 +66707,12 @@ Hu
 Hu
 Hu
 dG
-YB
-YB
-YB
-YB
-cR
-YB
+Bb
+Bb
+Bb
+Bb
+ce
+Bb
 sO
 uP
 Ks
@@ -66578,21 +66723,21 @@ KC
 jN
 KC
 KC
-YB
-pq
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+ML
+Ms
+vr
+So
+So
+Kg
+jk
+Lw
+lz
+bs
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -66819,37 +66964,37 @@ Hu
 Hu
 Rk
 dG
-ct
-ct
-ct
-YB
-cR
-YB
+Bf
+Bf
+Bf
+Bb
+ce
+Bb
 sO
 FF
 LA
 Tc
 DY
 sO
-YB
-YB
-YB
-YB
-YB
-pq
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Bb
+Bb
+Bb
+Kj
+Ms
+Ms
+vr
+So
+So
+Kg
+jk
+Lw
+lz
+Nz
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -67078,35 +67223,35 @@ Hu
 dG
 Mu
 Mu
-ct
-YB
-cR
-YB
+Bf
+Bb
+ce
+Bb
 sO
 sO
 OY
 sO
 sO
 sO
-YB
-YB
-YB
-YB
-YB
-pq
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Bb
+Bb
+Bb
+Kj
+Ni
+So
+vr
+So
+So
+Kg
+jk
+Lw
+lz
+Nz
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -67335,35 +67480,35 @@ Hu
 dG
 Mu
 Mu
-ct
-YB
+Bf
+Bb
+pb
+ur
+ur
+ur
 cR
-YB
-YB
-YB
-cR
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-pq
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+bN
+bN
+bN
+bN
+bN
+bN
+zr
+NF
+Tu
+hH
+yY
+Cl
+vd
+UW
+AF
+lz
+Nz
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -67592,35 +67737,35 @@ Hu
 dG
 Mu
 Mu
-ct
-YB
-at
-sH
-sH
-sH
-jd
-Fo
-Fo
-Fo
-Fo
-Fo
-Fo
-Fo
-Fo
-Op
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Bf
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Kj
+Kj
+Kj
+Kj
+Kj
+Kj
+Kj
+Kj
+Kj
+Kj
+Kj
+Kj
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -67849,35 +67994,35 @@ dG
 dG
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Bf
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -68106,35 +68251,35 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Bf
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -68363,35 +68508,35 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Bf
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bb
+Bf
 Mu
 Mu
 Mu
@@ -68620,35 +68765,35 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-ct
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
+Bf
 Mu
 Mu
 Mu
@@ -68877,25 +69022,25 @@ Mu
 Mu
 Mu
 Mu
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -10,12 +10,9 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "af" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "ag" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -144,29 +141,14 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "aB" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/storage/firstaid/regular,
-/obj/structure/reagent_dispensers/virusfood/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "aC" = (
 /obj/machinery/washing_machine,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
-"aD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "aE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -198,10 +180,6 @@
 /area/engineering/atmos/upper)
 "aO" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
-"aP" = (
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "aR" = (
@@ -452,9 +430,6 @@
 	icon_state = "wood-broken"
 	},
 /area/service/abandoned_gambling_den)
-"bT" = (
-/turf/open/openspace,
-/area/medical/virology)
 "bU" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
@@ -729,15 +704,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cU" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/machinery/camera{
-	c_tag = "Virology Break Room";
-	name = "Virology Camera";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "cV" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/effect/turf_decal/stripes/line{
@@ -792,17 +758,25 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "dk" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/item/storage/secure/safe/directional/south,
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/camera{
+	c_tag = "Virology Isolation A";
+	name = "Virology Camera";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dl" = (
-/obj/machinery/door/airlock{
-	id_tag = "medtoilet2";
-	name = "Stall B"
+/obj/structure/toilet{
+	dir = 1
 	},
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet2";
+	name = "Stall B Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "dm" = (
@@ -815,14 +789,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"dp" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Bathroom Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/break_room)
 "dq" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
@@ -1152,6 +1118,13 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"eK" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "eL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1250,21 +1223,18 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "fg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/table,
+/obj/item/storage/box/monkeycubes,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "fh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Virology Monkey Pen";
+	name = "Virology Camera";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "fi" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/north,
@@ -1275,7 +1245,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "fl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1413,7 +1383,8 @@
 /turf/closed/wall/r_wall,
 /area/medical/virology)
 "fM" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fN" = (
@@ -1503,32 +1474,13 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "fY" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "ga" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -1695,13 +1647,10 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "gG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "gH" = (
@@ -1938,13 +1887,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
-"hy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "hz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -2118,8 +2060,7 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "ih" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
 /turf/open/floor/plating,
 /area/medical/virology)
 "ii" = (
@@ -2302,12 +2243,11 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "iW" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "iX" = (
 /obj/structure/window{
 	dir = 8;
@@ -2320,14 +2260,12 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "iY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "iZ" = (
 /obj/structure/bed,
 /obj/item/radio/intercom/directional/north,
@@ -2377,13 +2315,6 @@
 /obj/item/toy/plush/supermatter,
 /turf/open/floor/iron,
 /area/security/prison)
-"jh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "jk" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
@@ -2482,6 +2413,19 @@
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/space)
+"jF" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -2671,6 +2615,10 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/space)
+"kp" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "kq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -3120,16 +3068,17 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "lD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "lE" = (
-/obj/structure/cable,
-/obj/structure/sink{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "lF" = (
@@ -3145,7 +3094,10 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "lH" = (
-/turf/open/space/basic,
+/obj/structure/cable,
+/obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "lJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3191,16 +3143,21 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "lS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "lT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/obj/machinery/camera{
+	c_tag = "Virology";
+	name = "Virology Camera";
+	network = list("ss13","medbay")
 	},
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "lU" = (
@@ -3236,14 +3193,15 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "lW" = (
-/obj/structure/chair/office/light{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/machinery/requests_console/directional/south{
+	department = "Virology";
+	departmentType = 2;
+	name = "Virology RC"
 	},
-/obj/effect/landmark/start/virologist,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "lX" = (
 /obj/structure/railing{
@@ -3493,12 +3451,13 @@
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
 "mP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/obj/machinery/camera{
+	c_tag = "Virology Break Room";
+	name = "Virology Camera";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "mT" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -3545,18 +3504,10 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
 "nb" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet2";
-	name = "Stall B Button";
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/machinery/newscaster/directional/east,
+/obj/structure/bed,
+/obj/item/bedsheet/green,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "nc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3597,6 +3548,12 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"ni" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "nj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -3604,7 +3561,13 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "nk" = (
-/obj/effect/landmark/blobstart,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nl" = (
@@ -3629,14 +3592,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "nq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "ns" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -3695,8 +3656,8 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "nA" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "nB" = (
 /obj/machinery/light/small/directional/west,
@@ -3810,15 +3771,14 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "nY" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/on{
-	dir = 4;
-	name = "Virology air supply valve"
-	},
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "nZ" = (
-/turf/closed/wall,
-/area/medical/medbay/zone2)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/medical/virology)
 "od" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -3866,13 +3826,9 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "on" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "oo" = (
 /obj/structure/urinal/directional/north,
 /turf/open/floor/iron/white,
@@ -3927,6 +3883,13 @@
 /obj/structure/ladder,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"oG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/science/robotics/mechbay)
 "oH" = (
 /obj/structure/railing{
 	dir = 4
@@ -3968,13 +3931,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
-"oP" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Virology";
-	name = "Virology Privacy Shutters"
-	},
+"oO" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
+/area/science/robotics/mechbay)
+"oP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "oQ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -4119,17 +4084,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"pn" = (
-/obj/structure/cable,
-/obj/machinery/disposal/bin,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/medical/virology)
 "po" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -4320,13 +4274,13 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "pQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/firstaid/regular,
+/obj/structure/reagent_dispensers/virusfood/directional/south,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "pU" = (
 /obj/effect/turf_decal/tile{
@@ -4380,8 +4334,8 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "qa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qb" = (
@@ -4507,7 +4461,8 @@
 /turf/open/floor/iron,
 /area/medical/medbay/zone2)
 "qr" = (
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/structure/table,
+/obj/item/toy/figure/virologist,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qs" = (
@@ -4701,14 +4656,17 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "rj" = (
-/obj/machinery/holopad,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/healthanalyzer,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "rk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -4735,18 +4693,21 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "ro" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/disposaloutlet{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/turf/open/floor/plating,
+/area/medical/virology)
 "rp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"rq" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "rr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -4900,6 +4861,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"rM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "rO" = (
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -4921,12 +4888,9 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "rS" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/camera{
-	c_tag = "Virology Isolation A";
-	name = "Virology Camera";
-	network = list("ss13","medbay")
-	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/orangejuice,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "rT" = (
@@ -5030,17 +4994,18 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "sr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/button/door/directional/west{
-	id = "Virology";
-	name = "Virology Shutters";
+/obj/structure/cable,
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -25;
+	pixel_y = -4;
 	req_access_txt = "39"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ss" = (
@@ -5171,17 +5136,20 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "sU" = (
-/obj/structure/table,
-/obj/item/storage/box/monkeycubes,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "sV" = (
 /turf/closed/wall,
 /area/service/abandoned_gambling_den)
 "sW" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Virology";
+	name = "Virology Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/virology)
 "sX" = (
 /obj/machinery/shower{
 	dir = 4
@@ -5193,10 +5161,16 @@
 /turf/open/floor/circuit/telecomms,
 /area/maintenance/department/science/xenobiology)
 "ta" = (
-/obj/machinery/door/airlock{
-	id_tag = "medtoilet1";
-	name = "Stall A"
+/obj/structure/toilet{
+	dir = 1
 	},
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet1";
+	name = "Stall A Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "tb" = (
@@ -5352,8 +5326,12 @@
 /area/security/prison)
 "tL" = (
 /obj/structure/cable,
-/obj/machinery/light/directional/north,
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tN" = (
@@ -5369,7 +5347,9 @@
 /turf/open/floor/plating,
 /area/service/hydroponics/upper)
 "tR" = (
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/door/airlock{
+	name = "Stall C"
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "tS" = (
@@ -5775,12 +5755,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"vk" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "vl" = (
 /obj/structure/chair{
 	dir = 4
@@ -5822,11 +5796,7 @@
 /turf/open/floor/iron/white,
 /area/maintenance/starboard)
 "vx" = (
-/obj/machinery/camera{
-	c_tag = "Virology Monkey Pen";
-	name = "Virology Camera";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vy" = (
@@ -5849,13 +5819,14 @@
 /area/medical/psychology)
 "vA" = (
 /obj/structure/cable,
+/obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "vB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -5911,11 +5882,14 @@
 /turf/open/floor/iron,
 /area/security/office)
 "vK" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light/directional/south,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/white,
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "vM" = (
 /obj/structure/sign/plaques/kiddie/badger{
@@ -5965,23 +5939,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/holodeck/rec_center)
-"vW" = (
-/obj/machinery/door/airlock/virology{
-	name = "Virology Break Room";
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "vX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Emergency Room"
@@ -6036,8 +5993,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wk" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wl" = (
@@ -6110,14 +6066,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "wt" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "wv" = (
 /obj/structure/chair/stool/directional/west,
@@ -6205,15 +6157,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "wL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "wM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Psychology Maintenance";
@@ -6315,11 +6263,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "xg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -6443,15 +6388,15 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xF" = (
-/obj/machinery/light/blacklight/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "xG" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -6536,8 +6481,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "xS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
@@ -6650,11 +6595,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"yr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "ys" = (
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
@@ -6668,9 +6608,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "yv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/machinery/computer/pandemic,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "yw" = (
 /obj/machinery/button/door/directional/north{
@@ -6739,9 +6684,8 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "yK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "yN" = (
@@ -7132,9 +7076,7 @@
 	},
 /area/medical/medbay/zone2)
 "Ah" = (
-/obj/machinery/door/airlock{
-	name = "Stall C"
-	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "Ai" = (
@@ -7330,15 +7272,21 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "AO" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/machinery/firealarm/directional/east,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/virology{
+	name = "Virology Break Room";
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "AP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -7522,11 +7470,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"Bv" = (
-/obj/structure/table,
-/obj/item/toy/figure/virologist,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "Bw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -7554,19 +7497,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"BF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "BG" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "BI" = (
-/obj/structure/curtain,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "BJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -7705,8 +7648,9 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/space)
 "Cj" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Ck" = (
@@ -7729,9 +7673,8 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "Cm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/orangejuice,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Cn" = (
@@ -7740,16 +7683,15 @@
 	},
 /area/cargo/warehouse)
 "Co" = (
-/obj/machinery/light/blacklight/directional/west,
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "Cp" = (
 /obj/structure/chair/office,
 /obj/structure/sign/poster/contraband/random{
@@ -7827,11 +7769,16 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "CC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Virology";
+	name = "Virology Shutters";
+	req_access_txt = "39"
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -7845,9 +7792,14 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "CG" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
+/obj/structure/sink{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/chemistry)
+/area/medical/virology)
 "CH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -8283,12 +8235,16 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "Ea" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/science/robotics/mechbay)
+/obj/structure/table/glass,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/firealarm/directional/east,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "Ec" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -8312,6 +8268,15 @@
 "Eg" = (
 /turf/closed/wall,
 /area/holodeck/rec_center)
+"Ei" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "Ej" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -8354,9 +8319,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Et" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Eu" = (
@@ -8552,7 +8520,9 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "ER" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ES" = (
@@ -8691,12 +8661,10 @@
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "Fm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/item/storage/secure/safe/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Fo" = (
@@ -8807,10 +8775,12 @@
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
 "FF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/robotics/mechbay)
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/machinery/light/directional/south,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "FG" = (
 /obj/structure/holohoop{
 	dir = 4
@@ -8833,18 +8803,23 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "FM" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
 	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet1";
-	name = "Stall A Button";
-	pixel_y = -7;
-	req_access_txt = "2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/camera{
+	c_tag = "Virology Airlock";
+	name = "Virology Camera";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "FN" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -8922,8 +8897,15 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "FX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
-/turf/open/floor/plating,
+/obj/structure/closet/l3closet/virology,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "FY" = (
 /obj/machinery/door/firedoor/border_only{
@@ -9096,13 +9078,11 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "GA" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Emergency Oxygen Supply"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/plating,
 /area/medical/virology)
 "GB" = (
 /turf/closed/wall/r_wall,
@@ -9133,9 +9113,9 @@
 /turf/open/floor/wood,
 /area/space)
 "GI" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron/white,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
 /area/medical/virology)
 "GK" = (
 /turf/open/floor/iron,
@@ -9380,10 +9360,9 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Hz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
-/area/science/robotics/mechbay)
+/area/medical/virology)
 "HA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -9506,21 +9485,13 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "HS" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Virology Airlock";
-	name = "Virology Camera";
-	network = list("ss13","medbay")
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -30
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "HU" = (
@@ -9683,19 +9654,14 @@
 /turf/open/openspace,
 /area/service/bar)
 "Ip" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Bathrooms";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/maintenance{
+	name = "Emergency Oxygen Supply"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "Iq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -9776,11 +9742,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "IE" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Bathroom Maintenance";
+	req_access_txt = "12"
 	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/break_room)
 "IG" = (
 /obj/structure/cable,
 /obj/machinery/vending/coffee,
@@ -10355,19 +10323,22 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "KC" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdoffice";
-	name = "Research Director's Shutters"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/command/heads_quarters/rd)
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "KD" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
 "KF" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A";
+	req_access_txt = "39"
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -10478,11 +10449,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
-"KZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "La" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -10536,8 +10502,16 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Lm" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation B";
+	req_access_txt = "39"
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Ln" = (
@@ -10605,23 +10579,30 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "LA" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/effect/landmark/start/scientist,
+/obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/white,
-/area/science/breakroom)
+/area/medical/break_room)
 "LC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"LD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "LF" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/oxygen,
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4;
+	name = "Virology air supply valve"
+	},
 /turf/open/floor/plating,
 /area/medical/virology)
 "LG" = (
@@ -10688,13 +10669,7 @@
 /turf/open/floor/iron,
 /area/security/office)
 "LQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "LU" = (
@@ -10716,14 +10691,13 @@
 /turf/open/floor/iron,
 /area/security/office)
 "LY" = (
-/obj/machinery/computer/pandemic,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "LZ" = (
 /obj/effect/turf_decal/tile{
@@ -10784,15 +10758,11 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "Mh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -30
-	},
-/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "Mi" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
@@ -10872,10 +10842,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Mz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/door/airlock/virology/glass{
+	name = "Monkey Pen";
+	req_access_txt = "39"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "MA" = (
@@ -11043,18 +11019,9 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "Nd" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/glass/reinforced,
-/area/command/heads_quarters/rd)
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "Ng" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -11107,10 +11074,8 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "Nm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/medical/virology)
 "No" = (
 /obj/effect/spawner/randomarcade{
@@ -11119,27 +11084,22 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Np" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/healthanalyzer,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/structure/chair/office/light{
+	dir = 1
 	},
+/obj/effect/landmark/start/virologist,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "Nq" = (
-/obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Nr" = (
@@ -11313,7 +11273,9 @@
 /turf/open/floor/wood,
 /area/space)
 "NY" = (
-/obj/machinery/newscaster/directional/north,
+/obj/structure/mirror/directional/north,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "NZ" = (
@@ -11617,12 +11579,16 @@
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
 "Pb" = (
+/obj/machinery/light/blacklight/directional/west,
+/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "Pc" = (
 /obj/structure/sink{
 	pixel_y = 25
@@ -11746,11 +11712,14 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "Pq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "Pr" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -11830,15 +11799,14 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "PC" = (
-/obj/machinery/camera{
-	c_tag = "Virology";
-	name = "Virology Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "PD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -11878,6 +11846,12 @@
 /area/space)
 "PH" = (
 /obj/machinery/light/blacklight/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "PI" = (
@@ -11938,15 +11912,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "PT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/structure/curtain,
 /turf/open/floor/iron/white,
-/area/science/breakroom)
+/area/medical/break_room)
 "PV" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -11980,25 +11948,23 @@
 /area/security/prison/safe)
 "Qb" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -25;
-	pixel_y = 25;
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"Qc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "Qd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -12207,14 +12173,6 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "QN" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A";
-	req_access_txt = "39"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -12228,15 +12186,19 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "QR" = (
-/obj/structure/cable,
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Bathrooms";
+	req_access_txt = "5"
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/breakroom)
+/area/medical/break_room)
 "QS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -12541,8 +12503,8 @@
 /turf/open/floor/iron/white,
 /area/commons/dorms)
 "RT" = (
-/obj/structure/sink{
-	pixel_y = 20
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
@@ -12739,6 +12701,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Ss" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
@@ -12752,16 +12717,8 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "Su" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation B";
-	req_access_txt = "39"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Sv" = (
@@ -12780,18 +12737,22 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "Sy" = (
-/obj/structure/cable,
-/obj/machinery/door_buttons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = -25;
-	pixel_y = -4;
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
 	req_access_txt = "39"
 	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Sz" = (
@@ -12822,22 +12783,24 @@
 /turf/open/floor/iron,
 /area/security/prison/work)
 "SI" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -25;
+	pixel_y = 25;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "SL" = (
@@ -12926,11 +12889,19 @@
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "Te" = (
-/obj/structure/disposaloutlet{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/fore)
 "Tg" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/item/bedsheet/qm,
@@ -13030,15 +13001,14 @@
 /area/command/heads_quarters/rd)
 "Tz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "TA" = (
 /turf/open/floor/glass/reinforced,
 /area/space)
@@ -13346,7 +13316,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "UK" = (
-/obj/machinery/light/blacklight/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "UL" = (
@@ -13393,19 +13369,12 @@
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "US" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/obj/machinery/door/airlock{
+	id_tag = "medtoilet1";
+	name = "Stall A"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/virology)
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "UT" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -13667,16 +13636,12 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "Vz" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/machinery/requests_console/directional/south{
-	department = "Virology";
-	departmentType = 2;
-	name = "Virology RC"
+/obj/machinery/door/airlock{
+	id_tag = "medtoilet2";
+	name = "Stall B"
 	},
-/turf/open/floor/iron/dark,
-/area/medical/virology)
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "VB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -13693,11 +13658,12 @@
 /turf/open/floor/iron/white,
 /area/security/prison/work)
 "VF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/turf/open/floor/glass/reinforced,
-/area/command/heads_quarters/rd)
+/turf/open/floor/iron/white,
+/area/maintenance/fore)
 "VG" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13766,7 +13732,7 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "VS" = (
-/obj/structure/closet/secure_closet/medical1,
+/obj/structure/table,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "VU" = (
@@ -13897,6 +13863,11 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"Ws" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/robotics/mechbay)
 "Wt" = (
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron,
@@ -14155,8 +14126,12 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Xj" = (
-/obj/structure/mirror/directional/north,
-/obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
@@ -14261,9 +14236,8 @@
 /turf/open/floor/glass/reinforced,
 /area/space)
 "XG" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/turf/open/openspace,
+/area/medical/break_room)
 "XH" = (
 /obj/structure/rack,
 /obj/item/circuitboard/aicore,
@@ -14342,11 +14316,8 @@
 /turf/open/floor/iron,
 /area/security/office)
 "XV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/breakroom)
+/turf/closed/wall,
+/area/medical/medbay/zone2)
 "XW" = (
 /turf/closed/wall,
 /area/engineering/atmos/upper)
@@ -14442,6 +14413,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"Yj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "Yk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -14607,16 +14589,9 @@
 /turf/closed/wall,
 /area/cargo/qm)
 "YK" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Monkey Pen";
-	req_access_txt = "39"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "YL" = (
@@ -14805,7 +14780,11 @@
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
 "Zu" = (
-/obj/machinery/atmospherics/components/tank/air,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/obj/machinery/space_heater,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/medical/virology)
 "Zv" = (
@@ -14933,12 +14912,30 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ZV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
 	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ZY" = (
@@ -55149,8 +55146,8 @@ HW
 HW
 HW
 HW
-HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -55406,8 +55403,8 @@ HW
 HW
 HW
 HW
-HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -55663,8 +55660,8 @@ HW
 HW
 HW
 HW
-HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -55911,7 +55908,6 @@ Mu
 Mu
 Mu
 Mu
-Mu
 ES
 ES
 ES
@@ -55922,6 +55918,7 @@ HW
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -56168,7 +56165,6 @@ ct
 ct
 ct
 ct
-ct
 ES
 JE
 JE
@@ -56179,6 +56175,7 @@ HW
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -56424,10 +56421,9 @@ PG
 PG
 PG
 PG
-PG
 YB
 ES
-NY
+KC
 JN
 JN
 ES
@@ -56436,6 +56432,7 @@ HW
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -56680,11 +56677,10 @@ nW
 nW
 nW
 nW
-nW
 HM
 YB
 ES
-PH
+LA
 JN
 JN
 ES
@@ -56693,6 +56689,7 @@ HW
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -56937,12 +56934,11 @@ YB
 YB
 YB
 YB
-YB
 HM
 YB
 ES
 ES
-BI
+PT
 ES
 ES
 ES
@@ -56950,6 +56946,7 @@ ES
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -57192,21 +57189,21 @@ ct
 ct
 ct
 ct
-ct
 YB
 YB
 HM
 YB
 ES
-RT
+Mh
 JN
 JN
+US
 ta
-FM
 ES
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -57448,22 +57445,22 @@ Mu
 Mu
 Mu
 Mu
-Mu
 ct
 YB
 YB
 nW
 YB
 ES
+Mh
 RT
 xS
-fh
 ES
 ES
 ES
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -57495,7 +57492,7 @@ lO
 nh
 nL
 yg
-Hz
+oO
 EX
 EX
 EX
@@ -57705,22 +57702,22 @@ Mu
 Mu
 Mu
 Mu
-Mu
 ct
 YB
 YB
 nW
 nW
-dp
+IE
+on
 Ss
-ro
 JN
+Vz
 dl
-nb
 ES
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -57751,8 +57748,8 @@ kB
 me
 nt
 nt
-FF
-Hz
+Ws
+oO
 EX
 EX
 EX
@@ -57962,22 +57959,22 @@ Mu
 Mu
 Mu
 Mu
-Mu
 ct
 YB
 YB
 YB
 YB
 ES
+Nd
 UK
 gG
-iW
 ES
 ES
 ES
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -58009,7 +58006,7 @@ mk
 nE
 nE
 CZ
-Hz
+oO
 EX
 EX
 EX
@@ -58219,22 +58216,22 @@ Mu
 Mu
 Mu
 Mu
-Mu
 ql
 ql
 ql
 ql
 ql
 ES
+NY
 Xj
 LQ
 tR
 Ah
-sW
 ES
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -58266,7 +58263,7 @@ mk
 nE
 nE
 CZ
-Hz
+oO
 EX
 EX
 EX
@@ -58481,10 +58478,9 @@ Mu
 Mu
 Mu
 Mu
-Mu
 ES
 ES
-Ip
+QR
 ES
 ES
 ES
@@ -58492,6 +58488,7 @@ ES
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -58523,7 +58520,7 @@ mk
 nE
 nE
 CZ
-Hz
+oO
 EX
 EX
 EX
@@ -58731,24 +58728,24 @@ Mu
 Mu
 Mu
 Mu
+nZ
+ro
 Mu
-Am
-Te
-lH
-lH
+Mu
 fK
 fK
 fK
 aK
+Pb
 Co
-aD
 fk
 fk
-lT
+VF
 HW
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -58773,14 +58770,14 @@ ce
 Bb
 Bb
 al
-Ea
+oG
 he
 lu
 mM
 nG
 nG
 zF
-Hz
+oO
 EX
 EX
 EX
@@ -58982,7 +58979,6 @@ Mu
 Mu
 Mu
 Mu
-Mu
 aK
 fK
 fK
@@ -58990,22 +58986,23 @@ fK
 fK
 mc
 mc
-oP
+sW
 fK
 fK
 fK
+FM
 HS
-Mh
 aK
+Pq
 nq
-jh
-bT
-bT
-aK
+XG
+XG
+ES
 HW
 HW
 HW
 FP
+Mu
 Mu
 Mu
 Mu
@@ -59037,7 +59034,7 @@ gE
 gE
 gE
 zF
-Hz
+oO
 EX
 EX
 EX
@@ -59239,15 +59236,15 @@ Mu
 Mu
 Mu
 Mu
-Mu
 mc
+af
 qa
-yr
-KF
 QN
 KF
+QN
 uT
 uT
+CC
 sr
 Sy
 SI
@@ -59256,13 +59253,13 @@ ZV
 fY
 on
 XG
-bT
-bT
-aK
+XG
+ES
 FP
 FP
 FP
 FP
+Mu
 Mu
 Mu
 Mu
@@ -59294,7 +59291,7 @@ nc
 in
 xn
 DZ
-Hz
+oO
 EX
 EX
 EX
@@ -59496,26 +59493,26 @@ Mu
 Mu
 Mu
 Mu
-Mu
 fK
+aB
 qr
-Bv
-KZ
-nA
+Cm
+Nm
 lC
 kb
 kb
 kb
-lE
+CG
 fK
+FX
 Nq
-CC
 aK
+PC
 iY
-hy
-bT
-bT
-aK
+XG
+XG
+ES
+Mu
 Mu
 Mu
 Mu
@@ -59551,7 +59548,7 @@ al
 al
 al
 al
-Hz
+oO
 EX
 EX
 EX
@@ -59753,26 +59750,26 @@ Mu
 Mu
 Mu
 Mu
-Mu
 fK
 aK
 aK
 aK
 aK
+lH
 tL
 vA
-pn
-vA
+tL
 Dn
 fK
 aK
-GA
+Ip
 aK
+PH
 xF
 wL
-vk
-vk
-aK
+wL
+ES
+Mu
 Mu
 Mu
 Mu
@@ -59815,12 +59812,12 @@ EX
 EX
 EX
 EX
-KC
+Ei
 iG
 gT
 gT
-Nd
-VF
+jF
+ni
 Ur
 bU
 EX
@@ -60010,26 +60007,26 @@ Mu
 Mu
 Mu
 Mu
-Mu
 mc
-qa
-BF
-Lm
+af
+fM
 Su
 Lm
+Su
+oP
 yv
 LY
 pQ
-aB
 fK
+GA
 LF
-nY
 aK
-aK
-US
-aK
-aK
-aK
+ES
+Te
+ES
+ES
+ES
+Mu
 Mu
 Mu
 Mu
@@ -60267,25 +60264,25 @@ Mu
 Mu
 Mu
 Mu
-Mu
 fK
+dk
 rS
 Cm
-KZ
+Nm
 nA
 nk
 rj
 Np
 lW
-Vz
 fK
+GI
 ih
-FX
 aK
 MF
 Zm
 MF
 Fx
+Mu
 Mu
 Mu
 Mu
@@ -60524,25 +60521,25 @@ Mu
 Mu
 Mu
 Mu
-Mu
 fK
 aK
 aK
 aK
 aK
-PC
+lT
 kb
+vK
 wt
 lS
-af
 fK
+Hz
 Zu
-mP
 aK
 MF
 Zm
 MF
 Fx
+Mu
 Mu
 Mu
 Mu
@@ -60781,17 +60778,16 @@ Mu
 Mu
 Mu
 Mu
-Mu
 fK
+fg
 sU
 lD
 Mz
 YK
 Et
-Fm
 kb
 lC
-AO
+Ea
 fK
 aK
 aK
@@ -60800,6 +60796,7 @@ MF
 Zm
 MF
 Fx
+Mu
 Mu
 Mu
 Mu
@@ -61038,16 +61035,15 @@ Mu
 Mu
 Mu
 Mu
-Mu
 mc
 lC
 lC
+iW
+aK
+aK
 Nm
-aK
-aK
-nA
-vW
-nA
+AO
+Nm
 aK
 fK
 MF
@@ -61056,6 +61052,7 @@ MF
 MF
 Zm
 MF
+Fx
 Fx
 Fx
 Fx
@@ -61295,23 +61292,23 @@ Mu
 Mu
 Mu
 Mu
-Mu
 mc
 lC
 lC
-Pb
+lE
 aK
-cU
-lD
+mP
+sU
+BI
 xg
 yK
-GI
 fK
 MF
 MF
 MF
 MF
 Zm
+MF
 MF
 MF
 MF
@@ -61552,23 +61549,23 @@ Mu
 Mu
 Mu
 Mu
-Mu
 mc
 lC
 lC
+iW
 Nm
-nA
+nb
+lC
 Cj
 lC
-IE
-lC
-dk
+Fm
 fK
 MF
 MF
 MF
 MF
-fg
+Tz
+TZ
 TZ
 TZ
 TZ
@@ -61809,18 +61806,18 @@ Mu
 Mu
 Mu
 Mu
-Mu
 fK
+fh
 vx
 ER
-Pq
 aK
+nY
 wk
 VS
-fM
 lC
-vK
+FF
 fK
+MF
 MF
 MF
 MF
@@ -62066,7 +62063,6 @@ Mu
 Mu
 Mu
 Mu
-Mu
 fK
 fK
 fK
@@ -62095,14 +62091,15 @@ Fx
 Fx
 Fx
 Fx
-nZ
+Fx
+XV
 GZ
-nZ
-nZ
-nZ
-nZ
-nZ
-nZ
+XV
+XV
+XV
+XV
+XV
+XV
 CL
 CL
 CL
@@ -62352,7 +62349,7 @@ Mu
 Mu
 Mu
 Mu
-nZ
+XV
 Yf
 ed
 oH
@@ -62389,7 +62386,7 @@ Bb
 Bb
 sO
 wq
-PT
+Qc
 Wg
 uC
 sO
@@ -62609,7 +62606,7 @@ Mu
 Mu
 Mu
 Mu
-nZ
+XV
 ov
 AM
 YS
@@ -62645,7 +62642,7 @@ Bb
 Bb
 Bb
 sO
-LA
+eK
 Ib
 sx
 uD
@@ -62866,7 +62863,7 @@ Mu
 Mu
 Mu
 Mu
-nZ
+XV
 Yh
 AM
 YS
@@ -63123,7 +63120,7 @@ Mu
 Mu
 Mu
 Mu
-nZ
+XV
 xC
 Vo
 Vo
@@ -63160,8 +63157,8 @@ Bb
 Bb
 sO
 wq
-QR
-XV
+LD
+rM
 uC
 sO
 EX
@@ -63380,7 +63377,7 @@ Mu
 Mu
 Mu
 Mu
-nZ
+XV
 ov
 Vo
 Vo
@@ -63637,7 +63634,7 @@ Mu
 Mu
 Mu
 Mu
-nZ
+XV
 zJ
 Es
 Es
@@ -64702,7 +64699,7 @@ Vf
 Ie
 sx
 sO
-Tz
+Yj
 sx
 XY
 pl
@@ -64960,7 +64957,7 @@ Ie
 sx
 xb
 Ki
-aP
+rq
 XY
 sx
 sx
@@ -67504,7 +67501,7 @@ Hu
 Hu
 Hu
 Hu
-CG
+kp
 Hu
 Hu
 Hu

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -87,7 +87,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/science)
+/area/science/breakroom)
 "au" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
@@ -739,6 +739,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "cZ" = (
@@ -991,6 +992,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "eb" = (
@@ -1180,7 +1182,7 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "eS" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -1340,7 +1342,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "fB" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1470,6 +1472,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "fV" = (
@@ -1588,7 +1591,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "gl" = (
 /turf/closed/wall,
 /area/service/library/private)
@@ -1600,7 +1603,7 @@
 "go" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "gp" = (
 /turf/open/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -1686,10 +1689,6 @@
 "gE" = (
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"gF" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/science)
 "gG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -2131,7 +2130,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "in" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -2218,7 +2217,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "iC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -2525,7 +2524,7 @@
 	req_one_access_txt = "47"
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/maintenance/starboard)
 "jO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -2606,7 +2605,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "kb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2964,6 +2963,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/space)
+"le" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "lf" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/tile{
@@ -3560,6 +3565,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "nd" = (
@@ -3569,6 +3575,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/range)
+"ne" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "nf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -3811,11 +3821,8 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "nZ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/robotics/mechbay)
+/turf/closed/wall,
+/area/medical/medbay/zone2)
 "od" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -3889,7 +3896,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "ov" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -3936,7 +3943,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "oK" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Laundry"
@@ -4109,7 +4116,7 @@
 "pl" = (
 /obj/structure/railing,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "pm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -4346,7 +4353,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "pW" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -5003,7 +5010,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "sh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -5224,7 +5231,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "tj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -5598,11 +5605,11 @@
 "uC" = (
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "uD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "uF" = (
 /obj/structure/railing{
 	dir = 8
@@ -5929,7 +5936,7 @@
 /obj/structure/table,
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "vQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -5988,7 +5995,6 @@
 /area/security/prison)
 "vZ" = (
 /obj/structure/chair,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "wa" = (
@@ -5997,7 +6003,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "wb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -6086,7 +6092,7 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "wr" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
@@ -6130,7 +6136,7 @@
 /obj/structure/table,
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "wA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6277,7 +6283,7 @@
 "xb" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "xc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -6504,7 +6510,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "xP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6695,16 +6701,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"yA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science)
 "yB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -6907,7 +6903,10 @@
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "zu" = (
 /obj/effect/turf_decal/siding/white{
@@ -6929,6 +6928,7 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/south,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "zz" = (
@@ -7012,7 +7012,10 @@
 	name = "RD's Secured Computers";
 	req_access_txt = "30"
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "zP" = (
 /obj/structure/window/reinforced{
@@ -7023,7 +7026,13 @@
 	dir = 1;
 	layer = 2.9
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "zQ" = (
 /obj/structure/chair{
@@ -7114,7 +7123,7 @@
 "Ae" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Ag" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7217,7 +7226,7 @@
 "Ax" = (
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Az" = (
 /obj/structure/bed,
 /obj/machinery/camera{
@@ -7231,7 +7240,7 @@
 /area/security/prison/safe)
 "AA" = (
 /turf/open/openspace,
-/area/science)
+/area/science/breakroom)
 "AC" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/moth,
@@ -7245,11 +7254,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/medical/chemistry)
 "AE" = (
 /obj/effect/landmark/start/research_director,
 /obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -7428,9 +7443,10 @@
 /obj/item/stamp/rd,
 /obj/item/cartridge/signal/toxins,
 /obj/item/cartridge/signal/toxins,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "Be" = (
@@ -7833,11 +7849,9 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "CG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/medical/chemistry)
 "CH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -8273,9 +8287,12 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "Ea" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/science/robotics/mechbay)
 "Ec" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -8293,9 +8310,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "Eg" = (
@@ -8505,7 +8520,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/science/xenobiology)
 "EM" = (
 /obj/structure/table,
 /obj/item/pen/fountain,
@@ -8693,7 +8708,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Fp" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck,
@@ -8752,7 +8767,7 @@
 "Fz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "FA" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -8796,10 +8811,10 @@
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
 "FF" = (
-/obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
+/turf/open/floor/iron,
+/area/science/robotics/mechbay)
 "FG" = (
 /obj/structure/holohoop{
 	dir = 4
@@ -8821,16 +8836,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research/abandoned)
-"FL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science)
 "FM" = (
 /obj/structure/toilet{
 	dir = 1
@@ -9252,7 +9257,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "He" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -9380,8 +9385,10 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Hz" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard/fore)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/robotics/mechbay)
 "HA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -9577,11 +9584,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Ic" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
@@ -9595,14 +9602,14 @@
 /area/science/xenobiology)
 "Ie" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "If" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -9765,7 +9772,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "ID" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Testing Room";
@@ -9934,7 +9941,7 @@
 /obj/structure/cable,
 /obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Jh" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Security";
@@ -10216,7 +10223,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Kj" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
@@ -10353,8 +10360,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "KC" = (
-/turf/closed/wall/r_wall,
-/area/science)
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "KD" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white,
@@ -10448,7 +10461,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "KV" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/iron/dark,
@@ -10597,13 +10610,10 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "LA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/chair{
+	pixel_y = -2
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "LC" = (
@@ -10958,7 +10968,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "MP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -11239,7 +11249,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "NL" = (
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "NN" = (
 /obj/structure/table,
@@ -11354,7 +11367,7 @@
 /area/service/abandoned_gambling_den)
 "Oh" = (
 /obj/structure/chair/office/light,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "Oi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11387,7 +11400,7 @@
 	name = "RD's Secured Computers";
 	req_access_txt = "30"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "Os" = (
 /obj/structure/table,
@@ -11584,12 +11597,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
 	req_one_access_txt = "47"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/white,
 /area/maintenance/starboard)
 "OZ" = (
 /obj/machinery/disposal/bin,
@@ -11922,11 +11934,18 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "PT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
 	},
-/turf/open/floor/iron/white,
-/area/science)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "PV" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -12100,7 +12119,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "QA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -12208,11 +12227,15 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "QR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "QS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -12243,7 +12266,7 @@
 /turf/open/floor/iron,
 /area/security/office)
 "QV" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/science/research/abandoned)
 "QW" = (
 /obj/structure/chair{
@@ -12391,7 +12414,6 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "Rx" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
@@ -12461,7 +12483,7 @@
 "RK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "RM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -12508,7 +12530,6 @@
 /area/space)
 "RR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
@@ -12644,7 +12665,7 @@
 "Si" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Sk" = (
 /obj/structure/railing{
 	dir = 4
@@ -12894,7 +12915,6 @@
 /area/medical/chemistry)
 "Tc" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Td" = (
@@ -13005,13 +13025,18 @@
 /obj/item/radio/intercom/directional/south,
 /obj/structure/cable,
 /obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "Tz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/science/robotics/mechbay)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "TA" = (
 /turf/open/floor/glass/reinforced,
 /area/space)
@@ -13044,7 +13069,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "TH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -13082,7 +13107,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "TP" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -13101,7 +13126,7 @@
 	name = "Research Director's RC Console"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "TR" = (
 /turf/closed/wall/r_wall,
@@ -13228,7 +13253,7 @@
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -13363,7 +13388,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "US" = (
 /obj/machinery/door/airlock/maintenance{
@@ -13471,7 +13496,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Vg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -13666,8 +13691,16 @@
 /turf/open/floor/iron/white,
 /area/security/prison/work)
 "VF" = (
-/turf/closed/wall/r_wall,
-/area/medical/psychology)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "VG" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13793,8 +13826,11 @@
 /turf/open/floor/iron,
 /area/security/office)
 "Wg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Wj" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -14104,7 +14140,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Xg" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/engineer,
@@ -14120,7 +14156,7 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Xj" = (
 /obj/structure/mirror/directional/north,
 /obj/machinery/power/apc/auto_name/east,
@@ -14309,9 +14345,11 @@
 /turf/open/floor/iron,
 /area/security/office)
 "XV" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/engine,
-/area/medical/chemistry)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "XW" = (
 /turf/closed/wall,
 /area/engineering/atmos/upper)
@@ -14333,7 +14371,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "Ya" = (
 /obj/machinery/atmospherics/pipe/multiz/cyan/visible/layer4{
 	dir = 1
@@ -14548,7 +14586,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/breakroom)
 "YG" = (
 /turf/open/floor/iron/white,
 /area/commons/dorms)
@@ -53838,11 +53876,11 @@ ry
 Eg
 Vq
 Eg
-Hz
-Hz
-Hz
-Hz
-Hz
+Fx
+Fx
+Fx
+Fx
+Fx
 Mu
 Mu
 Mu
@@ -54099,7 +54137,7 @@ MF
 MF
 MF
 MF
-Hz
+Fx
 Mu
 Mu
 Mu
@@ -54356,7 +54394,7 @@ MF
 MF
 MF
 MF
-Hz
+Fx
 Mu
 Mu
 Mu
@@ -54613,7 +54651,7 @@ MF
 MF
 MF
 MF
-Hz
+Fx
 Mu
 Mu
 Mu
@@ -54860,17 +54898,17 @@ Eg
 Eg
 Eg
 Eg
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
 MF
 MF
 MF
-Hz
+Fx
 Mu
 Mu
 Mu
@@ -55123,17 +55161,17 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 MF
 MF
-VF
-VF
-VF
-VF
-VF
-VF
-VF
+Jo
+Jo
+Jo
+Jo
+Jo
+Jo
+Jo
 Jo
 cv
 hv
@@ -55380,11 +55418,11 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 MF
 MF
-VF
+Jo
 Tk
 LI
 yh
@@ -55637,11 +55675,11 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 MF
 MF
-VF
+Jo
 fp
 ZN
 ZN
@@ -55894,11 +55932,11 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 MF
 MF
-VF
+Jo
 II
 zf
 RE
@@ -56151,11 +56189,11 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 MF
 MF
-VF
+Jo
 qx
 ZN
 wA
@@ -56408,11 +56446,11 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 MF
 MF
-VF
+Jo
 rH
 ZN
 rI
@@ -56665,7 +56703,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 Jp
 TZ
@@ -56922,23 +56960,23 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
-VF
+Jo
 EI
 vj
 gA
 Mc
 ym
 AC
-VF
+Jo
 Bb
 Bb
 Bb
 Bb
-ql
+ct
 EX
 EX
 EX
@@ -57179,18 +57217,18 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
-VF
-VF
-VF
+Jo
+Jo
+Jo
 IB
-VF
-VF
-VF
-VF
+Jo
+Jo
+Jo
+Jo
 Bb
 Bb
 Bb
@@ -57436,18 +57474,18 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
-VF
+Jo
 XA
 ZN
 gA
 St
 dW
 Nl
-VF
+Jo
 Bb
 Bb
 Bb
@@ -57460,7 +57498,7 @@ lO
 nh
 nL
 yg
-al
+Hz
 EX
 EX
 EX
@@ -57693,18 +57731,18 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
-VF
+Jo
 Zp
 ZN
 xL
 vz
 hL
 FZ
-VF
+Jo
 Bb
 Bb
 Bb
@@ -57715,9 +57753,9 @@ gE
 kB
 me
 nt
-nZ
-zF
-al
+nt
+FF
+Hz
 EX
 EX
 EX
@@ -57950,7 +57988,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
@@ -57974,7 +58012,7 @@ mk
 nE
 nE
 CZ
-al
+Hz
 EX
 EX
 EX
@@ -58207,18 +58245,18 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
-VF
+Jo
 Dz
 PF
 sS
 aL
 aL
 kj
-VF
+Jo
 Bb
 Nv
 bN
@@ -58231,7 +58269,7 @@ mk
 nE
 nE
 CZ
-al
+Hz
 EX
 EX
 EX
@@ -58464,18 +58502,18 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
-VF
-VF
-VF
+Jo
+Jo
+Jo
 sS
 aL
 aL
 kj
-VF
+Jo
 Bb
 ce
 Bb
@@ -58488,7 +58526,7 @@ mk
 nE
 nE
 CZ
-al
+Hz
 EX
 EX
 EX
@@ -58721,31 +58759,31 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 PV
 cT
 CL
-VF
+Jo
 hf
 ci
 ci
 ET
-VF
+Jo
 Bb
 ce
 Bb
 Bb
 al
-cn
+Ea
 he
 lu
 mM
 nG
 nG
-Tz
-al
+zF
+Hz
 EX
 EX
 EX
@@ -58978,18 +59016,18 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
 cT
 CL
-VF
+Jo
 eQ
 eQ
 eQ
 eQ
-VF
+Jo
 Bb
 ce
 Bb
@@ -59002,7 +59040,7 @@ gE
 gE
 gE
 zF
-al
+Hz
 EX
 EX
 EX
@@ -59235,7 +59273,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
@@ -59246,8 +59284,8 @@ CL
 CL
 CL
 CL
-GB
-GB
+Bf
+Bf
 ce
 Bb
 Bb
@@ -59259,7 +59297,7 @@ nc
 in
 xn
 DZ
-al
+Hz
 EX
 EX
 EX
@@ -59492,7 +59530,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
@@ -59504,7 +59542,7 @@ EX
 EX
 CL
 CL
-GB
+Bf
 ce
 Bb
 Bb
@@ -59516,7 +59554,7 @@ al
 al
 al
 al
-al
+Hz
 EX
 EX
 EX
@@ -59749,7 +59787,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
@@ -59761,7 +59799,7 @@ EX
 EX
 EX
 CL
-GB
+Bf
 ce
 Bb
 Bb
@@ -59780,12 +59818,12 @@ EX
 EX
 EX
 EX
-cC
+KC
 iG
 gT
 gT
-zt
-NL
+PT
+XV
 Ur
 bU
 EX
@@ -60006,7 +60044,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
@@ -60018,7 +60056,7 @@ CL
 CL
 CL
 CL
-GB
+Bf
 pb
 ur
 ur
@@ -60250,7 +60288,7 @@ aK
 MF
 Zm
 MF
-Hz
+Fx
 Mu
 Mu
 Mu
@@ -60263,7 +60301,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
@@ -60275,7 +60313,7 @@ EX
 EX
 EX
 CL
-GB
+Bf
 Bb
 Bb
 Bb
@@ -60507,7 +60545,7 @@ aK
 MF
 Zm
 MF
-Hz
+Fx
 Mu
 Mu
 Mu
@@ -60520,7 +60558,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
@@ -60764,7 +60802,7 @@ aK
 MF
 Zm
 MF
-Hz
+Fx
 Mu
 Mu
 Mu
@@ -60777,7 +60815,7 @@ Mu
 Mu
 Mu
 Mu
-Hz
+Fx
 MF
 pC
 MF
@@ -60812,7 +60850,7 @@ bo
 pp
 gT
 uV
-CG
+EC
 gT
 Vv
 cC
@@ -61021,20 +61059,20 @@ MF
 MF
 Zm
 MF
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
-Hz
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
+Fx
 MF
 pC
 MF
@@ -61319,9 +61357,9 @@ Yb
 Bb
 Bb
 Bb
+Bb
+Bb
 Yb
-Bb
-Bb
 bU
 bU
 ui
@@ -61576,8 +61614,8 @@ Bb
 Bb
 Bb
 Bb
-Yb
-Yb
+Bb
+Bb
 Yb
 Yb
 qe
@@ -61834,9 +61872,9 @@ Bb
 Bb
 Bb
 Yb
-Bb
-Bb
 Yb
+Yb
+Bb
 bU
 bU
 vy
@@ -62060,14 +62098,14 @@ Fx
 Fx
 Fx
 Fx
-Wy
+nZ
 GZ
-Wy
-Wy
-Wy
-Wy
-Wy
-Wy
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
 CL
 CL
 CL
@@ -62092,15 +62130,15 @@ ty
 ty
 ty
 GB
-Bb
 Yb
 Bb
-KC
+Bb
+sO
 vO
-FL
-Wg
+Ib
+sx
 Ae
-KC
+sO
 EX
 EX
 EX
@@ -62317,7 +62355,7 @@ Mu
 Mu
 Mu
 Mu
-Wy
+nZ
 Yf
 ed
 oH
@@ -62350,14 +62388,14 @@ EX
 EX
 ty
 Yb
-Yb
 Bb
-KC
+Bb
+sO
 wq
-FL
+QR
 Wg
 uC
-KC
+sO
 EX
 EX
 EX
@@ -62574,7 +62612,7 @@ Mu
 Mu
 Mu
 Mu
-Wy
+nZ
 ov
 AM
 YS
@@ -62609,12 +62647,12 @@ ty
 Bb
 Bb
 Bb
-KC
-wq
+sO
+LA
 Ib
-PT
+sx
 uD
-KC
+sO
 EX
 EX
 EX
@@ -62831,7 +62869,7 @@ Mu
 Mu
 Mu
 Mu
-Wy
+nZ
 Yh
 AM
 YS
@@ -62866,12 +62904,12 @@ ty
 Bb
 Bb
 Bb
-KC
+sO
 wq
 Ie
-QR
-Wg
-KC
+sx
+sx
+sO
 EX
 EX
 EX
@@ -63088,7 +63126,7 @@ Mu
 Mu
 Mu
 Mu
-Wy
+nZ
 xC
 Vo
 Vo
@@ -63123,12 +63161,12 @@ ty
 Yb
 Bb
 Bb
-KC
+sO
 wq
-FL
-Wg
+Tz
+le
 uC
-KC
+sO
 EX
 EX
 EX
@@ -63345,7 +63383,7 @@ Mu
 Mu
 Mu
 Mu
-Wy
+nZ
 ov
 Vo
 Vo
@@ -63380,12 +63418,12 @@ GB
 Yb
 Yb
 Yb
-KC
+sO
 wz
-FL
-Wg
-Wg
-KC
+Ib
+sx
+sx
+sO
 EX
 EX
 EX
@@ -63602,7 +63640,7 @@ Mu
 Mu
 Mu
 Mu
-Wy
+nZ
 zJ
 Es
 Es
@@ -63634,24 +63672,24 @@ EX
 EX
 EX
 GB
-KC
-KC
+sO
+sO
 rE
-KC
-KC
+sO
+sO
 IC
 xb
 xb
-KC
-KC
-KC
-KC
-KC
-KC
-KC
-KC
+sO
+sO
+sO
+sO
+sO
+sO
+sO
+sO
 GB
-GB
+Ui
 Ui
 CQ
 yI
@@ -63891,22 +63929,22 @@ EX
 EX
 EX
 EX
-KC
+sO
 Ae
-Ea
-Wg
-KC
-FL
-Wg
-Wg
+aO
+sx
+sO
+Ib
+sx
+sx
 Ax
-Wg
-Wg
-Wg
-Wg
-Wg
-Wg
-KC
+sx
+sx
+sx
+sx
+sx
+sx
+sO
 Bb
 Bb
 Ui
@@ -64148,11 +64186,11 @@ EX
 EX
 EX
 EX
-KC
+sO
 Xi
 TN
 uC
-KC
+sO
 Jg
 RK
 Hd
@@ -64405,13 +64443,13 @@ EX
 EX
 EX
 EX
-KC
+sO
 go
-yA
+Ie
 uD
-KC
+sO
 Ki
-Wg
+sx
 XY
 pl
 AA
@@ -64420,7 +64458,7 @@ AA
 AA
 pV
 ot
-KC
+sO
 Bb
 Bb
 Gs
@@ -64661,14 +64699,14 @@ EX
 EX
 EX
 EX
-KC
-KC
+sO
+sO
 Vf
-yA
-Wg
-KC
-Ki
-Wg
+Ie
+sx
+sO
+VF
+sx
 XY
 pl
 AA
@@ -64677,7 +64715,7 @@ AA
 AA
 pV
 eR
-KC
+sO
 Bb
 Bb
 Gs
@@ -64918,23 +64956,23 @@ EX
 EX
 EX
 EX
-KC
+sO
 AA
 AA
-yA
-Wg
+Ie
+sx
 xb
 Ki
-Wg
+ne
 XY
-Wg
-Wg
-Wg
-Wg
-Wg
-Wg
+sx
+sx
+sx
+sx
+sx
+sx
 ot
-KC
+sO
 Bb
 Bb
 Gs
@@ -65175,11 +65213,11 @@ EX
 EX
 EX
 EX
-KC
+sO
 AA
 AA
-yA
-Wg
+Ie
+sx
 xb
 Ki
 Si
@@ -65191,7 +65229,7 @@ Fz
 Fz
 Fz
 ti
-KC
+sO
 Bb
 Bb
 Gs
@@ -65428,11 +65466,11 @@ Bb
 GB
 GB
 GB
-KC
+sO
 at
 at
 at
-KC
+sO
 AA
 AA
 sf
@@ -65441,14 +65479,14 @@ xO
 KU
 iA
 Fo
-Wg
-gF
-Wg
-Wg
-Wg
-Wg
-Wg
-KC
+sx
+Tc
+sx
+sx
+sx
+sx
+sx
+sO
 Bb
 Bb
 Gs
@@ -65692,9 +65730,9 @@ aO
 sO
 sO
 Xf
-yA
-Wg
-KC
+Ie
+sx
+sO
 Kj
 Kj
 Xe
@@ -65948,10 +65986,10 @@ Hy
 Oz
 Fy
 YW
-Ea
-yA
-Wg
-KC
+aO
+Ie
+sx
+sO
 KV
 pq
 vr
@@ -66207,8 +66245,8 @@ Tq
 Uy
 wa
 gi
-Wg
-KC
+sx
+sO
 LM
 KV
 SZ
@@ -66464,8 +66502,8 @@ zw
 sO
 TG
 oI
-Wg
-KC
+sx
+sO
 Ms
 Ms
 yF
@@ -66719,10 +66757,10 @@ Ks
 vZ
 KL
 sO
-KC
+sO
 jN
-KC
-KC
+sO
+sO
 ML
 Ms
 vr
@@ -66971,8 +67009,8 @@ Bb
 ce
 Bb
 sO
-FF
-LA
+sx
+Ks
 Tc
 DY
 sO
@@ -67469,7 +67507,7 @@ Hu
 Hu
 Hu
 Hu
-Hu
+CG
 Hu
 Hu
 Hu
@@ -68233,7 +68271,7 @@ Mu
 dG
 AZ
 AZ
-XV
+AZ
 AZ
 AZ
 dG

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -200,6 +200,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"aP" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "aR" = (
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/engine,
@@ -1536,6 +1540,7 @@
 /area/service/abandoned_gambling_den)
 "gb" = (
 /obj/machinery/mecha_part_fabricator/maint,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "gc" = (
@@ -2865,6 +2870,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "kS" = (
@@ -2963,12 +2969,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/space)
-"le" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "lf" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/tile{
@@ -3575,10 +3575,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/range)
-"ne" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "nf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -4140,7 +4136,6 @@
 /area/security/prison/visit)
 "pp" = (
 /obj/machinery/suit_storage_unit/rd,
-/obj/machinery/light/blacklight/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
@@ -4165,6 +4160,7 @@
 /obj/structure/closet/secure_closet/research_director,
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "pt" = (
@@ -9169,7 +9165,6 @@
 /obj/item/book/manual/wiki/plumbing,
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "GQ" = (
@@ -11048,9 +11043,18 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "Nd" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "Ng" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -11934,18 +11938,15 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "PT" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/glass/reinforced,
-/area/command/heads_quarters/rd)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "PV" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -12228,10 +12229,10 @@
 /area/service/hydroponics/upper)
 "QR" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -13028,13 +13029,14 @@
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "Tz" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "TA" = (
@@ -13691,16 +13693,11 @@
 /turf/open/floor/iron/white,
 /area/security/prison/work)
 "VF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "VG" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -14345,11 +14342,11 @@
 /turf/open/floor/iron,
 /area/security/office)
 "XV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/glass/reinforced,
-/area/command/heads_quarters/rd)
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "XW" = (
 /turf/closed/wall,
 /area/engineering/atmos/upper)
@@ -59822,8 +59819,8 @@ KC
 iG
 gT
 gT
-PT
-XV
+Nd
+VF
 Ur
 bU
 EX
@@ -62392,7 +62389,7 @@ Bb
 Bb
 sO
 wq
-QR
+PT
 Wg
 uC
 sO
@@ -63163,8 +63160,8 @@ Bb
 Bb
 sO
 wq
-Tz
-le
+QR
+XV
 uC
 sO
 EX
@@ -64705,7 +64702,7 @@ Vf
 Ie
 sx
 sO
-VF
+Tz
 sx
 XY
 pl
@@ -64963,7 +64960,7 @@ Ie
 sx
 xb
 Ki
-ne
+aP
 XY
 sx
 sx
@@ -65199,7 +65196,7 @@ Hu
 Hu
 Hu
 Hu
-Nd
+Hu
 Hu
 Hu
 dG

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -19,6 +19,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ai" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/robotics/mechbay)
 "aj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -397,6 +402,12 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
+"bI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "bL" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -903,6 +914,19 @@
 	},
 /turf/open/floor/plating,
 /area/service/abandoned_gambling_den)
+"dL" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/command/heads_quarters/rd)
 "dO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -1118,13 +1142,6 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"eK" = (
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "eL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2413,19 +2430,6 @@
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/space)
-"jF" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/glass/reinforced,
-/area/command/heads_quarters/rd)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -2615,10 +2619,6 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/space)
-"kp" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "kq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -3548,12 +3548,6 @@
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"ni" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/glass/reinforced,
-/area/command/heads_quarters/rd)
 "nj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -3883,13 +3877,6 @@
 /obj/structure/ladder,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"oG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/science/robotics/mechbay)
 "oH" = (
 /obj/structure/railing{
 	dir = 4
@@ -3931,11 +3918,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
-"oO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
 "oP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -4704,10 +4686,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"rq" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "rr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -4861,12 +4839,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
-"rM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "rO" = (
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -4935,6 +4907,11 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/space)
+"sb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/science/robotics/mechbay)
 "sc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -5095,6 +5072,12 @@
 "sI" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
+/area/engineering/atmos/upper)
+"sN" = (
+/obj/machinery/atmospherics/pipe/multiz/cyan/visible/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "sO" = (
 /turf/closed/wall/r_wall,
@@ -5420,6 +5403,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"uc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "ud" = (
 /turf/open/floor/iron/grimy,
 /area/space)
@@ -8268,15 +8261,6 @@
 "Eg" = (
 /turf/closed/wall,
 /area/holodeck/rec_center)
-"Ei" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdoffice";
-	name = "Research Director's Shutters"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/command/heads_quarters/rd)
 "Ej" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -10473,6 +10457,16 @@
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/medical/medbay/zone2)
+"Ld" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "Le" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/airalarm/directional/south,
@@ -10588,16 +10582,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"LD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "LF" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -11218,6 +11202,13 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"NM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/science/robotics/mechbay)
 "NN" = (
 /obj/structure/table,
 /obj/item/coin/iron,
@@ -11360,6 +11351,15 @@
 "On" = (
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"Oo" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "rdoffice";
+	name = "Research Director's Shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/rd)
 "Op" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -11955,16 +11955,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"Qc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "Qd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -12044,6 +12034,17 @@
 "Qp" = (
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
+"Qq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "Qr" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -13227,6 +13228,10 @@
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"Ut" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -13863,11 +13868,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
-"Ws" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/robotics/mechbay)
 "Wt" = (
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron,
@@ -14341,11 +14341,9 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Ya" = (
-/obj/machinery/atmospherics/pipe/multiz/cyan/visible/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "Yb" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -14413,17 +14411,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"Yj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/north,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "Yk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -14799,6 +14786,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"Zy" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "Zz" = (
 /obj/structure/railing{
 	dir = 4
@@ -14829,6 +14823,12 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ZH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "ZI" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/east,
@@ -40816,7 +40816,7 @@ DG
 gS
 cs
 gS
-gS
+sN
 pK
 gS
 gS
@@ -41073,7 +41073,7 @@ DG
 gS
 cs
 gS
-Ya
+gS
 oE
 gS
 gS
@@ -57492,7 +57492,7 @@ lO
 nh
 nL
 yg
-oO
+sb
 EX
 EX
 EX
@@ -57748,8 +57748,8 @@ kB
 me
 nt
 nt
-Ws
-oO
+ai
+sb
 EX
 EX
 EX
@@ -58006,7 +58006,7 @@ mk
 nE
 nE
 CZ
-oO
+sb
 EX
 EX
 EX
@@ -58263,7 +58263,7 @@ mk
 nE
 nE
 CZ
-oO
+sb
 EX
 EX
 EX
@@ -58520,7 +58520,7 @@ mk
 nE
 nE
 CZ
-oO
+sb
 EX
 EX
 EX
@@ -58770,14 +58770,14 @@ ce
 Bb
 Bb
 al
-oG
+NM
 he
 lu
 mM
 nG
 nG
 zF
-oO
+sb
 EX
 EX
 EX
@@ -59034,7 +59034,7 @@ gE
 gE
 gE
 zF
-oO
+sb
 EX
 EX
 EX
@@ -59291,7 +59291,7 @@ nc
 in
 xn
 DZ
-oO
+sb
 EX
 EX
 EX
@@ -59548,7 +59548,7 @@ al
 al
 al
 al
-oO
+sb
 EX
 EX
 EX
@@ -59812,12 +59812,12 @@ EX
 EX
 EX
 EX
-Ei
+Oo
 iG
 gT
 gT
-jF
-ni
+dL
+bI
 Ur
 bU
 EX
@@ -62386,7 +62386,7 @@ Bb
 Bb
 sO
 wq
-Qc
+Ld
 Wg
 uC
 sO
@@ -62642,7 +62642,7 @@ Bb
 Bb
 Bb
 sO
-eK
+Zy
 Ib
 sx
 uD
@@ -63157,8 +63157,8 @@ Bb
 Bb
 sO
 wq
-LD
-rM
+uc
+ZH
 uC
 sO
 EX
@@ -64699,7 +64699,7 @@ Vf
 Ie
 sx
 sO
-Yj
+Qq
 sx
 XY
 pl
@@ -64957,7 +64957,7 @@ Ie
 sx
 xb
 Ki
-rq
+Ut
 XY
 sx
 sx
@@ -67501,7 +67501,7 @@ Hu
 Hu
 Hu
 Hu
-kp
+Ya
 Hu
 Hu
 Hu

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -40587,6 +40587,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"dpl" = (
+/obj/machinery/light/blacklight/directional/south,
+/turf/open/floor/iron/white,
+/area/science)
 "dpr" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 8
@@ -41250,6 +41254,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"fYN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "fZf" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line,
@@ -41772,6 +41783,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"icq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "icD" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42523,13 +42540,10 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"ljb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
+"lhv" = (
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/misc_lab)
 "ljM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -42733,17 +42747,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"mmw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
 "mnv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/neutral{
@@ -43027,6 +43030,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
+"njW" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron,
+/area/science)
 "nke" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43037,6 +43044,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"nko" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "nkw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -43754,10 +43766,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qCC" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43977,11 +43985,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"rxl" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/science)
 "rEd" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -44164,6 +44167,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"sdQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "sgD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -45184,12 +45198,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"wTU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science)
 "wVc" = (
 /obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -45316,7 +45324,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"xrV" = (
+"xur" = (
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
+"xuU" = (
+/turf/closed/wall/r_wall,
+/area/science/explab)
+"xvg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -45324,12 +45338,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science)
-"xur" = (
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"xuU" = (
-/turf/closed/wall/r_wall,
-/area/science/explab)
 "xyD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -45381,10 +45389,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"xFa" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
-/area/science)
 "xGE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -88572,7 +88576,7 @@ bRH
 bTm
 bSR
 ccT
-xFa
+njW
 ciJ
 bOz
 civ
@@ -90374,8 +90378,8 @@ cXE
 cXE
 ciu
 cha
-xrV
-wTU
+xvg
+icq
 cnz
 cpa
 cpA
@@ -91660,7 +91664,7 @@ ciu
 ciu
 cmz
 ckV
-rxl
+nko
 cnz
 cqP
 cpI
@@ -92161,7 +92165,7 @@ aVm
 ldq
 cBY
 ldq
-ljb
+fYN
 ldq
 ldq
 aVm
@@ -92940,7 +92944,7 @@ beG
 cbB
 chk
 caw
-bOz
+bSX
 bQn
 bOz
 chh
@@ -93705,7 +93709,7 @@ bQn
 bOz
 ccA
 bPR
-mmw
+sdQ
 bXU
 bVL
 bXU
@@ -93971,7 +93975,7 @@ caw
 bOz
 bOz
 btP
-bOz
+dpl
 bVN
 bpS
 cez
@@ -94479,7 +94483,7 @@ bZP
 bWS
 bXU
 bXX
-qCC
+lhv
 caO
 caw
 bOz
@@ -94739,7 +94743,7 @@ bXU
 bXU
 blt
 caw
-bOz
+bSX
 bOz
 btP
 bOz

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -1423,6 +1423,7 @@
 "ahT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ahU" = (
@@ -1619,6 +1620,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "ajw" = (
@@ -4231,6 +4233,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "asi" = (
@@ -5148,14 +5153,12 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "avK" = (
-/obj/machinery/computer/cargo/request{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/iron,
-/area/science)
+/area/hallway/secondary/exit/departure_lounge)
 "avL" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
@@ -9733,11 +9736,6 @@
 /area/commons/fitness/recreation)
 "aKD" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -9749,6 +9747,11 @@
 	id_tag = "scidoor";
 	name = "Security Post - Science";
 	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
@@ -9976,14 +9979,11 @@
 	},
 /area/maintenance/port/fore)
 "aLK" = (
-/obj/machinery/modular_computer/console/preset/cargochat/science{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/science)
+/area/hallway/secondary/exit/departure_lounge)
 "aLM" = (
 /obj/structure/window,
 /turf/open/floor/iron/dark,
@@ -10010,10 +10010,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aLU" = (
@@ -10047,10 +10047,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aMa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aMb" = (
@@ -10223,6 +10226,12 @@
 	req_one_access_txt = "47"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aMI" = (
@@ -10408,6 +10417,15 @@
 	req_access_txt = "47"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aNq" = (
@@ -10522,6 +10540,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aNG" = (
@@ -10665,9 +10692,11 @@
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "aOp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -11187,14 +11216,15 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aQm" = (
-/obj/machinery/camera{
-	c_tag = "Research Hall - Server Room";
-	dir = 1;
-	name = "Research Camera";
-	network = list("ss13","rd")
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/science)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aQp" = (
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
@@ -12174,6 +12204,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "aTN" = (
@@ -12301,16 +12340,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"aUm" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/turf/open/floor/iron/white,
-/area/science)
-"aUn" = (
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron/white,
-/area/science)
 "aUo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -12621,17 +12650,21 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aVl" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/science)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "aVm" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "aVn" = (
@@ -12835,6 +12868,15 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "aVT" = (
@@ -13387,10 +13429,6 @@
 "aYz" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"aYA" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/science)
 "aYB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Law Office Maintenance";
@@ -13595,14 +13633,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aZD" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "aZO" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -13684,7 +13720,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bai" = (
-/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "baj" = (
@@ -13900,11 +13938,12 @@
 /area/medical/surgery)
 "bbD" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
@@ -13920,6 +13959,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bbO" = (
@@ -13950,10 +13990,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"bci" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/science)
 "bcj" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -14062,8 +14098,8 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "bcI" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bcJ" = (
@@ -14382,12 +14418,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bef" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bet" = (
 /turf/open/space/basic,
 /area/maintenance/port/fore)
@@ -14486,10 +14521,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "beG" = (
-/obj/structure/rack,
-/obj/item/integrated_circuit/loaded/speech_relay,
-/obj/item/integrated_circuit/loaded/hello_world,
-/obj/machinery/newscaster/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "beI" = (
@@ -14517,27 +14554,25 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "beM" = (
-/obj/structure/rack,
-/obj/item/controller,
-/obj/item/compact_remote,
-/obj/item/compact_remote,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/explab)
 "beO" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "beR" = (
-/obj/machinery/vending/assist,
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science)
 "beT" = (
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
+/obj/machinery/computer/scan_consolenew{
+	dir = 1
 	},
-/obj/structure/displaycase/labcage,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "beU" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/paramedic,
@@ -14551,9 +14586,13 @@
 /area/medical/medbay/central)
 "beW" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science)
 "beX" = (
@@ -14818,13 +14857,14 @@
 /turf/closed/wall,
 /area/medical/morgue)
 "bgj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1;
+	piping_layer = 3
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "bgk" = (
@@ -15075,15 +15115,18 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bhv" = (
-/obj/machinery/computer/scan_consolenew,
+/obj/structure/rack,
+/obj/item/controller,
+/obj/item/compact_remote,
+/obj/item/compact_remote,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/misc_lab)
 "bhw" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks,
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/vending/assist,
+/obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/misc_lab)
 "bhx" = (
 /obj/structure/table/glass,
 /obj/item/scalpel,
@@ -15092,12 +15135,9 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "bhy" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/storage/pill_bottle/mutadone,
-/obj/machinery/light/directional/north,
+/obj/machinery/component_printer,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/misc_lab)
 "bhz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -15121,12 +15161,10 @@
 /turf/closed/wall,
 /area/medical/medbay/lobby)
 "bhE" = (
-/obj/structure/table/glass,
-/obj/item/storage/pill_bottle/mannitol,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker,
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/misc_lab)
 "bhF" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -16242,11 +16280,21 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "blt" = (
-/obj/item/food/grown/banana,
-/obj/machinery/light/directional/north,
-/turf/open/floor/grass,
-/area/science/genetics)
+/obj/structure/table/reinforced,
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice,
+/obj/machinery/light/blacklight/directional/south,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "blu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science)
+"blv" = (
 /obj/structure/rack,
 /obj/item/rack_parts,
 /obj/item/rack_parts,
@@ -16254,17 +16302,10 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"blv" = (
-/obj/structure/rack,
-/obj/item/screwdriver,
-/obj/item/screwdriver,
-/obj/item/wrench,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "blw" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/science)
 "blx" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/chapel,
@@ -16335,7 +16376,7 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "blK" = (
-/obj/item/trash/boritos,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "blL" = (
@@ -16392,6 +16433,9 @@
 /area/medical/medbay/lobby)
 "blS" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "blT" = (
@@ -16436,18 +16480,9 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bmb" = (
-/obj/machinery/door/airlock/research{
-	name = "Genetics Lab";
-	req_access_txt = "47; 9"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/structure/noticeboard/directional/south,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "bmc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -16795,12 +16830,22 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bng" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/research{
+	name = "Genetics Lab";
+	req_access_txt = "47; 9"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bnh" = (
@@ -17199,11 +17244,16 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "boD" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks,
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/misc_lab)
 "boE" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -17215,10 +17265,19 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "boG" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
+/obj/machinery/door/airlock/research{
+	name = "Genetics Lab";
+	req_access_txt = "47; 9"
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "boI" = (
@@ -17348,17 +17407,14 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "bph" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/structure/window{
-	pixel_y = -3
-	},
-/turf/open/floor/grass,
-/area/science/genetics)
+/turf/open/floor/iron/white,
+/area/science)
 "bpi" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/pipe,
@@ -17556,7 +17612,9 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "bpS" = (
-/obj/machinery/light/directional/north,
+/obj/structure/sign/warning/chemdiamond{
+	pixel_y = 33
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bpT" = (
@@ -17752,7 +17810,9 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "bqy" = (
-/obj/effect/landmark/blobstart,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -30
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bqz" = (
@@ -18117,8 +18177,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "brN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -18174,12 +18236,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "brT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "brU" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -18333,11 +18393,12 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "bsl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bsm" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Customs Desk";
@@ -18702,13 +18763,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"btC" = (
-/obj/structure/chair/office/light{
-	color = "#990099"
-	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
 "btD" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -18759,44 +18813,45 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "btP" = (
-/obj/structure/cable,
-/obj/structure/chair/office/light{
-	color = "#990099"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/landmark/start/geneticist,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "btQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "btR" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "btS" = (
-/obj/structure/grille/broken,
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/server)
 "btU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "btV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/science)
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/camera{
+	c_tag = "R&D Server Room";
+	name = "Research Camera";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/dark,
+/area/science/server)
 "btX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -18918,13 +18973,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "but" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/monkeycubes,
-/obj/item/storage/box/monkeycubes,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/server)
 "buu" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -19077,19 +19132,27 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bva" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
-/obj/item/folder/white,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "bvb" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
-/obj/item/folder/blue,
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'SERVER ROOM'.";
+	name = "SERVER ROOM";
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 10
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/science/server)
 "bvc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -19102,9 +19165,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bvd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "bvg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -19135,11 +19197,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bvm" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/toggle/labcoat,
-/obj/item/clothing/suit/toggle/labcoat,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/structure/stairs/east,
+/turf/open/floor/iron/dark,
+/area/science/server)
 "bvo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -19207,9 +19267,8 @@
 /area/space)
 "bvw" = (
 /obj/structure/rack,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/weldingtool,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/item/clothing/suit/toggle/labcoat,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bvx" = (
@@ -19252,9 +19311,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bvJ" = (
-/obj/structure/stairs/north,
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/storage/pill_bottle/mutadone,
+/obj/machinery/light/directional/north,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/genetics)
 "bvL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -19734,14 +19798,9 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "bwZ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/sign/warning/chemdiamond{
-	pixel_y = 33
-	},
+/obj/machinery/computer/scan_consolenew,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/genetics)
 "bxa" = (
 /turf/closed/wall,
 /area/service/kitchen)
@@ -19869,11 +19928,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bxs" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/server)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "bxt" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -20001,8 +20060,10 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bxI" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/starboard)
+/obj/machinery/light/directional/north,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "bxJ" = (
 /turf/closed/wall,
 /area/maintenance/department/engine)
@@ -22290,9 +22351,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bEB" = (
-/obj/item/toy/toy_xeno,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "bEC" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -22379,9 +22443,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bES" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "bET" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris{
@@ -23389,6 +23454,10 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bIC" = (
@@ -23481,10 +23550,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bIR" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/firealarm/directional/north,
+/obj/effect/landmark/start/geneticist,
+/obj/structure/chair/office/light{
+	color = "#990099";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bIS" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen";
@@ -24214,6 +24290,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bLy" = (
@@ -24385,38 +24465,6 @@
 "bMG" = (
 /turf/closed/wall,
 /area/science/robotics)
-"bMH" = (
-/obj/machinery/suit_storage_unit/rd,
-/obj/machinery/keycard_auth{
-	pixel_x = -5;
-	pixel_y = 25
-	},
-/obj/machinery/light/directional/east{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/east{
-	id = "rdoffice";
-	name = "RD Shutter Control";
-	pixel_x = 7;
-	pixel_y = 24;
-	req_access_txt = "30"
-	},
-/obj/machinery/button/door/directional/east{
-	id = "nanite";
-	name = "Nanites Shutters Control Button";
-	pixel_x = 7;
-	pixel_y = 37;
-	req_access_txt = "30"
-	},
-/obj/machinery/button/door/directional/east{
-	id = "toxinsrd";
-	name = "Toxins Shield Button";
-	pixel_x = -5;
-	pixel_y = 37;
-	req_access_txt = "30"
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "bMM" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
@@ -24686,7 +24734,6 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bOt" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/camera{
 	c_tag = "Research Hall - West";
 	name = "Research Camera";
@@ -24722,15 +24769,6 @@
 /obj/item/toy/plush/ratplush,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bOK" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/science/server)
 "bON" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -24740,6 +24778,7 @@
 "bOO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "bOP" = (
@@ -24757,12 +24796,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bPa" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/science/server)
 "bPd" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
@@ -24896,16 +24929,10 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bPR" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/pen/fountain,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/misc_lab)
 "bPT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -25228,27 +25255,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bRz" = (
-/obj/machinery/door/airlock/command{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/dark,
-/area/science/server)
-"bRA" = (
-/obj/machinery/computer/mecha{
-	dir = 4
-	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/misc_lab)
+"bRA" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/disks,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "bRC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -25256,14 +25271,14 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bRG" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bRH" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
-/turf/open/floor/iron/dark/telecomms,
+/turf/open/floor/iron/white,
+/area/science/genetics)
+"bRH" = (
+/obj/machinery/rnd/server,
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "bRM" = (
 /turf/open/space/basic,
@@ -25444,13 +25459,11 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bSV" = (
-/obj/effect/landmark/start/research_director,
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
+/obj/item/folder/blue,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bSX" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
@@ -25492,12 +25505,14 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "bTf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/item/kirbyplants/random,
+/obj/machinery/requests_console/directional/north{
+	name = "Circuits Requests Console";
+	pixel_x = 30;
+	pixel_y = 0
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "bTg" = (
 /obj/structure/closet/emcloset,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -25524,8 +25539,8 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bTm" = (
-/obj/machinery/rnd/server,
-/turf/open/floor/circuit/telecomms/server,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "bTn" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
@@ -25625,8 +25640,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bTM" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "bTO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -25656,50 +25678,21 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bTR" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit/telecomms/server,
-/area/science/server)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "bTS" = (
-/obj/machinery/computer/security/telescreen/rd{
-	dir = 8;
-	pixel_x = 30;
-	pixel_y = 3
+/obj/structure/window{
+	dir = 1
 	},
-/obj/machinery/requests_console/directional/south{
-	announcementConsole = 1;
-	department = "Research Director's Desk";
-	departmentType = 5;
-	name = "Research Director's RC";
-	pixel_x = -30;
-	pixel_y = 0;
-	receive_ore_updates = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bTT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/science/genetics)
 "bTU" = (
-/obj/machinery/door/airlock/command{
-	name = "Server Room";
-	req_access_txt = "30"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
@@ -25708,25 +25701,20 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/electrical)
 "bTW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/window{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/turf/open/floor/grass,
+/area/science/genetics)
 "bTX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/window/westleft{
+	dir = 1;
+	name = "Monkey Pen";
+	req_access_txt = "9"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/turf/open/floor/grass,
+/area/science/genetics)
 "bTY" = (
 /obj/structure/chair{
 	dir = 4
@@ -25739,48 +25727,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"bTZ" = (
-/obj/machinery/door/airlock/command{
-	name = "Research Director's Office";
-	req_access_txt = "30"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "bUa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science)
 "bUb" = (
-/obj/machinery/camera{
-	c_tag = "Research Hall - Toxins";
-	dir = 4;
-	name = "Research Camera";
-	network = list("ss13","rd")
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/science)
 "bUc" = (
@@ -25794,13 +25751,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"bUf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "bUh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -25809,7 +25759,7 @@
 /area/science/misc_lab)
 "bUn" = (
 /obj/machinery/disposal/bin,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bUq" = (
@@ -25853,13 +25803,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"bUA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "bUB" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -26078,42 +26021,28 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bVz" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
+/obj/machinery/computer/rdservercontrol{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bVA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
+/obj/structure/chair/office{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bVB" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'SERVER ROOM'.";
-	name = "SERVER ROOM";
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bVC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bVD" = (
@@ -26131,37 +26060,31 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bVE" = (
-/obj/machinery/computer/rdconsole{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
+/obj/item/folder/white,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bVF" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bVG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/turf/open/floor/iron/white,
+/area/science/genetics)
 "bVH" = (
-/obj/machinery/modular_computer/console/preset/research,
-/obj/machinery/camera{
-	c_tag = "Research Director";
-	name = "RD Camera";
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bVI" = (
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/modular_computer/console/preset/id,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bVJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -26355,16 +26278,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bWr" = (
-/obj/structure/table,
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/machinery/camera{
-	c_tag = "R&D Server Room";
-	name = "Research Camera";
-	network = list("ss13","rd")
-	},
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/stairs/east,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bWs" = (
@@ -26401,9 +26316,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bWw" = (
-/obj/structure/closet/secure_closet/research_director,
+/obj/machinery/vending/wardrobe/gene_wardrobe,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bWx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26458,10 +26373,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bWH" = (
-/obj/machinery/computer/rdservercontrol{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/science/server)
 "bWI" = (
 /obj/structure/table,
@@ -26471,52 +26384,41 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bWJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/coldtemp,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/science/server)
 "bWK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/door/airlock/command{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bWL" = (
-/obj/machinery/computer/robotics{
-	dir = 4
-	},
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/mannitol,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/radio/intercom/directional/west,
+/obj/item/radio/headset/headset_medsci,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bWM" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bWN" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "RD's Secured Computers";
-	req_access_txt = "30"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bWO" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bWP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"bWR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bWS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bWT" = (
@@ -26656,10 +26558,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bXI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/coldtemp,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "bXK" = (
 /obj/effect/turf_decal/bot,
@@ -26673,9 +26575,15 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bXN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/geneticist,
+/obj/structure/chair/office/light{
+	color = "#990099"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bXO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -26689,53 +26597,37 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bXP" = (
-/obj/machinery/component_printer,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
-"bXQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = -8;
-	pixel_y = 9
+/obj/structure/chair/office/light{
+	color = "#990099"
 	},
-/obj/machinery/light/directional/south,
+/obj/effect/landmark/start/geneticist,
+/turf/open/floor/iron/white,
+/area/science/genetics)
+"bXQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bXR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/electrical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bXS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/science/server)
-"bXT" = (
-/obj/item/kirbyplants/dead,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "bXU" = (
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"bXV" = (
-/obj/machinery/door/airlock/research{
-	name = "Nanite Lab";
-	req_access_txt = "47"
-	},
-/turf/open/floor/plating,
-/area/science/nanite)
 "bXX" = (
-/obj/structure/table/reinforced,
-/obj/item/multitool/circuit{
-	pixel_x = -8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/item/multitool/circuit,
-/obj/item/multitool/circuit{
-	pixel_x = 7
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bYb" = (
@@ -26780,12 +26672,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bYo" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/obj/machinery/recharger,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/science/misc_lab)
+/area/science/genetics)
 "bYp" = (
 /obj/machinery/blackbox_recorder,
 /obj/structure/cable,
@@ -26996,11 +26887,13 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "bZj" = (
-/obj/structure/rack,
-/obj/item/circuitboard/aicore,
-/obj/item/aicard,
+/obj/structure/table/glass,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bZl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -27012,16 +26905,12 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bZm" = (
-/obj/structure/table/glass,
-/obj/item/stamp/denied,
-/obj/item/stamp/rd,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bZo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bZp" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/vendor,
@@ -27039,15 +26928,17 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bZu" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "bZx" = (
-/obj/machinery/light/directional/east,
-/obj/structure/filingcabinet/filingcabinet,
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/requests_console/directional/north{
+	department = "Genetics";
+	name = "Genetics Requests Console";
+	pixel_x = 30;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "bZD" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -27183,16 +27074,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "caq" = (
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/rd)
-"car" = (
 /obj/structure/table/glass,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/item/storage/box/disks,
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
+"car" = (
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/science/genetics)
 "cat" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -27215,8 +27108,9 @@
 /area/science/misc_lab)
 "cay" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/analyzer,
+/obj/item/screwdriver,
+/obj/item/screwdriver,
+/obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "caz" = (
@@ -27270,13 +27164,18 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "caO" = (
-/obj/structure/window{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/multitool/circuit{
+	pixel_x = -8
 	},
-/obj/structure/flora/ausbushes/lavendergrass,
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
-/area/science/genetics)
+/obj/item/multitool/circuit,
+/obj/item/multitool/circuit{
+	pixel_x = 7
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "caP" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
@@ -27392,30 +27291,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"cbp" = (
-/obj/structure/table,
-/obj/item/storage/box/disks_nanite,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"cbr" = (
-/obj/structure/table,
-/obj/item/nanite_remote,
-/obj/item/nanite_scanner,
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "cbs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"cbt" = (
-/obj/machinery/computer/nanite_chamber_control{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Research Hall - Xenobiology";
+	name = "Research Camera";
+	network = list("ss13","rd")
 	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/turf/open/floor/iron/white,
+/area/science)
 "cbu" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -27430,63 +27313,48 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "cbv" = (
-/obj/structure/table/glass,
-/obj/item/cartridge/signal/toxins,
-/obj/item/cartridge/signal/toxins,
-/obj/item/paper_bin,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"cbw" = (
-/obj/structure/table/glass,
-/obj/item/folder/blue,
-/obj/item/toy/figure/rd,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/science/genetics)
 "cby" = (
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
-"cbB" = (
-/obj/machinery/door/airlock/research{
-	name = "Nanite Lab";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"cbC" = (
-/obj/machinery/nanite_chamber,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/turf/open/floor/iron/white,
+/area/science/genetics)
+"cbB" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "cbF" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
+"cbG" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/pointybush,
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/science/genetics)
-"cbG" = (
-/obj/structure/sign/departments/nanites{
-	pixel_y = 32
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/science)
 "cbH" = (
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/science/genetics)
+/obj/structure/rack,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/analyzer,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "cbI" = (
-/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/science/genetics)
 "cbJ" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/science/genetics)
-"cbK" = (
 /obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"cbK" = (
+/obj/item/trash/boritos,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "cbL" = (
@@ -27497,12 +27365,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "cbR" = (
-/obj/machinery/computer/nanite_chamber_control,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/science/genetics)
 "cbT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -27514,13 +27385,6 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"cbW" = (
-/obj/structure/rack,
-/obj/item/taperecorder,
-/obj/item/tape,
-/obj/item/paicard,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "cbY" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/ce)
@@ -27664,27 +27528,22 @@
 "ccF" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/toxins,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"ccH" = (
-/obj/machinery/nanite_program_hub,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "ccJ" = (
 /obj/structure/table,
-/obj/item/storage/box/disks_nanite,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"ccK" = (
-/obj/structure/chair/office/light{
-	color = "#990099";
-	dir = 1
+/obj/item/hand_labeler,
+/obj/structure/sign/poster/random{
+	pixel_y = 30
 	},
-/obj/effect/landmark/start/geneticist,
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/turf/open/floor/iron,
+/area/science)
+"ccK" = (
+/obj/machinery/computer/cargo/request,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/science)
 "ccL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -27692,60 +27551,33 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ccO" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdoffice";
-	name = "Research Director's Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/command/heads_quarters/rd)
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/science/genetics)
 "ccP" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "ccS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/sign/poster/random{
+	pixel_y = 30
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "ccT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Monkey Pen";
-	req_access_txt = "9"
-	},
-/turf/open/floor/grass,
-/area/science/genetics)
+/obj/machinery/modular_computer/console/preset/cargochat/science,
+/turf/open/floor/iron,
+/area/science)
 "ccU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/window{
-	pixel_y = -3
-	},
-/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/ausbushes/palebush,
+/obj/machinery/light/directional/west,
 /turf/open/floor/grass,
 /area/science/genetics)
 "ccW" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -30
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/item/food/grown/banana,
+/turf/open/floor/grass,
+/area/science/genetics)
 "ccX" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/sunglasses,
@@ -28108,21 +27940,14 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ceu" = (
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"cev" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/turf/open/floor/iron,
+/area/science)
 "cew" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/turf/open/floor/iron,
+/area/science)
 "cex" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/requests_console/directional/north{
@@ -28145,6 +27970,9 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "ceA" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -28185,12 +28013,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ceE" = (
-/obj/machinery/door/airlock/research{
-	name = "Genetics Lab";
-	req_access_txt = "47; 9"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass,
 /area/science/genetics)
 "ceH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -28203,23 +28028,18 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "ceI" = (
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
+/obj/structure/stairs/east,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "ceJ" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/genetics)
-"ceL" = (
-/turf/closed/wall,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
 /area/maintenance/department/science)
+"ceL" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "ceN" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -28230,10 +28050,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ceT" = (
-/obj/structure/rack,
-/obj/item/storage/wallet/random,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/science)
 "ceV" = (
 /obj/machinery/power/solar{
 	id = "aftport";
@@ -28254,9 +28075,13 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cfa" = (
-/obj/effect/spawner/bundle/costume/commie,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "cfb" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server";
@@ -28399,29 +28224,20 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cfO" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /obj/structure/table,
-/obj/item/nanite_remote,
-/obj/item/nanite_scanner,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"cfP" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/turf/open/floor/iron,
+/area/science)
 "cfQ" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/area/maintenance/department/science)
 "cfR" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "rdoffice";
-	name = "Research Director's Shutters"
-	},
 /turf/open/floor/plating,
-/area/command/heads_quarters/rd)
+/area/science/genetics)
 "cfS" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
@@ -28454,9 +28270,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cfX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/genetics)
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/science)
 "cga" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -28464,13 +28280,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cge" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/atmos{
-	name = "Xenobiology Atmos";
-	req_access_txt = "47"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/turf/open/floor/iron,
+/area/science)
 "cgj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -28499,17 +28313,8 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cgq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/airlock/atmos{
-	name = "Xenobiology Atmos";
-	req_access_txt = "47"
-	},
-/turf/open/floor/plating,
+/obj/structure/lattice,
+/turf/closed/wall,
 /area/maintenance/department/science/xenobiology)
 "cgr" = (
 /obj/machinery/telecomms/server/presets/command,
@@ -28685,47 +28490,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"cgZ" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "cha" = (
-/obj/machinery/status_display/ai/directional/west,
-/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science)
 "chb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"chc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/turf/open/floor/iron,
+/area/science)
 "chd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/white,
+/area/science)
 "che" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -28747,27 +28525,27 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "chh" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch/directional/west{
-	pixel_x = 0;
-	pixel_y = -26
+/obj/structure/sign/warning/explosives{
+	pixel_y = -30
 	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "chj" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/genetics)
+/obj/structure/grille/broken,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "chk" = (
-/obj/machinery/dna_scannernew,
+/obj/structure/rack,
+/obj/item/integrated_circuit/loaded/speech_relay,
+/obj/item/integrated_circuit/loaded/hello_world,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science/misc_lab)
 "chl" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/department/science/xenobiology)
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/science)
 "chn" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/xenobiology)
@@ -28783,9 +28561,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "chw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron/white,
 /area/science)
 "chx" = (
@@ -28806,8 +28582,9 @@
 /area/engineering/storage_shared)
 "chz" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/weldingtool,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "chA" = (
@@ -28880,9 +28657,10 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "chL" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell,
-/obj/machinery/cell_charger,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "chM" = (
@@ -28977,14 +28755,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cif" = (
-/obj/structure/chair,
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/beaker,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/area/maintenance/department/science)
 "cih" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/effect/landmark/start/scientist,
+/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "cij" = (
@@ -29005,53 +28786,41 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "cim" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/science)
 "cin" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"cio" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"cip" = (
-/obj/machinery/nanite_programmer,
-/turf/open/floor/iron/dark,
-/area/science/nanite)
 "cit" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ciu" = (
-/obj/machinery/status_display/evac/directional/north,
+/turf/closed/wall,
+/area/science/genetics)
+"civ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science)
-"civ" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "ciw" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/structure/filingcabinet,
+/obj/item/toy/figure/ninja,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cix" = (
-/obj/item/stack/spacecash/c50,
-/obj/structure/closet/toolcloset,
+/obj/effect/spawner/lootdrop/crate_spawner,
+/obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ciy" = (
@@ -29109,8 +28878,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "ciH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/spawner/randomarcade{
 	dir = 8
 	},
@@ -29121,11 +28888,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ciJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/science)
 "ciK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden{
 	dir = 8
@@ -29133,7 +28898,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "ciL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -29144,7 +28909,9 @@
 /area/maintenance/department/science/xenobiology)
 "ciN" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/masks,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ciP" = (
@@ -29503,28 +29270,45 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "cke" = (
-/obj/structure/sign/departments/nanites{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
+/obj/item/extinguisher,
+/obj/structure/closet/l3closet/scientist,
 /turf/open/floor/iron/white,
 /area/science)
 "ckf" = (
 /turf/closed/wall,
 /area/maintenance/disposal)
 "ckg" = (
-/obj/machinery/camera{
-	c_tag = "Research Hall - Xenobiology";
-	name = "Research Camera";
-	network = list("ss13","rd")
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/science)
-"ckh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
+"ckh" = (
+/obj/machinery/door/airlock/command{
+	name = "Server Room";
+	req_access_txt = "30"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/science/server)
 "cki" = (
 /obj/structure/closet/emcloset,
 /obj/item/storage/wallet/random,
@@ -29753,37 +29537,41 @@
 /obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"ckT" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/extinguisher,
-/obj/structure/closet/l3closet/scientist,
-/turf/open/floor/iron/white,
-/area/science)
 "ckU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "ckV" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/science)
-"ckX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
+"ckX" = (
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "ckY" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -29793,23 +29581,31 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ckZ" = (
-/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
 "cla" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Lab";
+	req_access_txt = "7"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/mixing)
 "clb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Disposal Access";
@@ -29834,39 +29630,33 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
-	dir = 1;
 	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
+	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "clf" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"clh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/sign/departments/xenobio{
+	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science)
+"clh" = (
+/obj/structure/sign/departments/xenobio{
+	pixel_y = -30
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "cli" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -29909,8 +29699,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "clp" = (
-/obj/item/toy/figure/ninja,
-/obj/structure/closet/firecloset,
+/obj/effect/loot_site_spawner,
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "clu" = (
@@ -30088,13 +29878,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"clW" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "clX" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
@@ -30130,9 +29913,21 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cmb" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/door/airlock/research{
+	name = "Xenobiology Lab";
+	req_access_txt = "47"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	dir = 1;
+	name = "Science purple corner"
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#990099";
+	name = "Science purple corner"
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "cmc" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -30170,13 +29965,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "cmm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cmn" = (
@@ -30210,20 +30005,15 @@
 /turf/open/floor/iron/white,
 /area/science)
 "cmt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/chem_master,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/xenobiology)
 "cmu" = (
-/obj/structure/sign/departments/xenobio{
-	pixel_y = -30
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/monkey_recycler,
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/xenobiology)
 "cmv" = (
 /obj/structure/noticeboard{
 	dir = 8;
@@ -30243,11 +30033,16 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cmx" = (
-/obj/structure/sign/departments/xenobio{
-	pixel_y = -30
-	},
+/obj/structure/rack,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/clothing/suit/hooded/wintercoat/science,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/machinery/light/directional/north,
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/xenobiology)
 "cmy" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
@@ -30268,30 +30063,32 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cmE" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
-	req_access_txt = "7"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
-	},
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/xenobiology)
 "cmI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 5
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/reagent_containers/glass/beaker/large,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/xenobiology)
 "cmK" = (
-/obj/structure/closet/body_bag,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "cmL" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -30305,13 +30102,15 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "cmN" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
-/obj/machinery/light/directional/south,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cmO" = (
@@ -30366,12 +30165,7 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cna" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cnb" = (
@@ -30485,41 +30279,22 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "cnA" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cnB" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cnC" = (
-/obj/machinery/door/airlock/research{
-	name = "Xenobiology Lab";
-	req_access_txt = "47"
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	dir = 1;
-	name = "Science purple corner"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#990099";
-	name = "Science purple corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -30533,14 +30308,18 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "cnG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/structure/rack,
+/obj/item/storage/box/masks{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/item/storage/box/gloves{
+	pixel_x = -4;
+	pixel_y = 8
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/science/mixing)
+/area/science/xenobiology)
 "cnI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -30705,104 +30484,72 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"cor" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"cos" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 5
-	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/reagent_containers/glass/beaker/large,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"cot" = (
-/obj/machinery/chem_master,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "cou" = (
-/obj/machinery/monkey_recycler,
-/obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cow" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"cox" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/suit/hooded/wintercoat/science,
-/obj/item/clothing/suit/hooded/wintercoat/science,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coy" = (
-/obj/machinery/disposal/bin,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coz" = (
-/obj/structure/rack,
-/obj/item/storage/box/masks{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/gloves{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/machinery/airalarm/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife,
+/obj/item/wrench,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coA" = (
-/obj/machinery/smartfridge/petri/preloaded,
+/obj/structure/table/reinforced,
+/obj/structure/microscope,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coB" = (
-/obj/machinery/smartfridge/organ,
+/obj/structure/table/reinforced,
+/obj/item/biopsy_tool{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/book/manual/wiki/cytology{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
+	},
 /obj/structure/cable,
-/obj/machinery/button/ignition{
-	id = "xenoignite";
-	name = "Pen Igniter button";
-	pixel_x = 37;
-	pixel_y = 25
-	},
-/obj/machinery/computer/security/telescreen{
-	name = "Test Chamber Monitor";
-	network = list("xeno");
-	pixel_y = 25
-	},
-/obj/machinery/button/door/directional/north{
-	id = "Xtestlab";
-	name = "Test Chamber Blast Doors";
-	pixel_x = 24;
-	req_access_txt = "55"
-	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coD" = (
-/obj/structure/window/reinforced,
-/obj/machinery/power/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable,
+/obj/machinery/door/window/southleft{
+	dir = 8;
+	name = "Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coE" = (
@@ -30816,14 +30563,8 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "coF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/sparker{
-	id = "xenoignite";
-	pixel_y = 30
-	},
-/turf/open/floor/engine,
+/obj/machinery/smartfridge/petri/preloaded,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coG" = (
 /obj/structure/lattice/catwalk,
@@ -30901,11 +30642,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "coQ" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -30987,10 +30725,8 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cpa" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cpf" = (
 /obj/structure/cable,
@@ -31061,9 +30797,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cpz" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -31071,25 +30806,38 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cpB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/chair/office/light{
+	color = "#990099";
 	dir = 4
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cpD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/button/ignition{
+	id = "xenoignite";
+	name = "Pen Igniter button";
+	pixel_x = 37;
+	pixel_y = 25
+	},
+/obj/machinery/computer/security/telescreen{
+	name = "Test Chamber Monitor";
+	network = list("xeno");
+	pixel_y = 25
+	},
+/obj/machinery/button/door/directional/north{
+	id = "Xtestlab";
+	name = "Test Chamber Blast Doors";
+	pixel_x = 24;
+	req_access_txt = "55"
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cpE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/structure/window/reinforced,
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cpG" = (
@@ -31393,67 +31141,60 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cqP" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Xenobiology Maintenance";
-	req_access_txt = "55"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/department/science/xenobiology)
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "cqS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Xenobiology - Main";
+	dir = 1;
+	name = "Xenobiology Camera";
+	network = list("ss13","rd","xeno")
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/button/door/directional/south{
+	id = "rdxeno";
+	name = "Xenobiology Containment Control";
+	req_access_txt = "30"
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cqU" = (
-/obj/structure/table/reinforced,
-/obj/structure/microscope,
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cqV" = (
-/obj/structure/table/reinforced,
-/obj/item/biopsy_tool{
-	pixel_x = 8;
-	pixel_y = 2
+/obj/structure/rack,
+/obj/item/storage/box/petridish{
+	pixel_x = 5;
+	pixel_y = 3
 	},
-/obj/item/book/manual/wiki/cytology{
-	pixel_x = -4;
-	pixel_y = 4
+/obj/item/storage/box/petridish{
+	pixel_x = -5;
+	pixel_y = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cqW" = (
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Test Chamber";
-	req_access_txt = "55"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/machinery/power/shieldwallgen/xenobiologyaccess,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cqX" = (
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Test Chamber";
-	req_access_txt = "55"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Xtestlab";
-	name = "test chamber blast door"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
+	},
+/obj/machinery/sparker{
+	id = "xenoignite";
+	pixel_y = 30
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -31538,11 +31279,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cry" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology - Test Chamber";
-	dir = 8;
-	name = "Xenobiology Camera";
-	network = list("ss13","rd","xeno")
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -31688,35 +31426,31 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "crX" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/science/xenobiology)
+/area/science/mixing)
 "crY" = (
-/obj/structure/chair/office/light{
-	color = "#990099";
-	dir = 8
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "crZ" = (
-/obj/machinery/processor/slime,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"csa" = (
-/obj/structure/chair/office/light{
-	color = "#990099";
-	dir = 4
-	},
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"csb" = (
-/obj/machinery/computer/camera_advanced/xenobio{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
+/area/science/xenobiology)
+"csa" = (
+/obj/structure/window/reinforced,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
+"csb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "csc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -31727,17 +31461,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "csd" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/poddoor/preopen{
+	id = "rdxeno";
+	name = "Xenobiology Containment Door"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cse" = (
-/obj/structure/chair/office/light{
-	color = "#990099";
-	dir = 1
-	},
-/turf/open/floor/iron/white,
+/obj/item/toy/toy_xeno,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "csf" = (
 /obj/machinery/disposal/bin,
@@ -32011,74 +31744,63 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ctb" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/obj/structure/sign/departments/xenobio{
-	pixel_y = -30
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "ctc" = (
-/obj/structure/table/glass,
-/obj/item/slime_scanner,
-/obj/item/storage/box/monkeycubes,
-/obj/machinery/light/directional/south,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ctd" = (
-/obj/machinery/smartfridge/extract/preloaded,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/obj/structure/rack,
+/obj/item/storage/wallet/random,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cte" = (
-/obj/structure/table/glass,
-/obj/item/slime_scanner,
-/obj/item/storage/box/monkeycubes,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"ctf" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
-"ctg" = (
-/obj/machinery/camera{
-	c_tag = "Xenobiology - Main";
-	dir = 1;
-	name = "Xenobiology Camera";
-	network = list("ss13","rd","xeno")
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
+"ctf" = (
+/obj/effect/spawner/bundle/costume/commie,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
+"ctg" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Xenobiology Maintenance";
+	req_access_txt = "55"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/button/door/directional/south{
-	id = "rdxeno";
-	name = "Xenobiology Containment Control";
-	req_access_txt = "30"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/science/xenobiology)
-"cth" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/area/maintenance/department/science/xenobiology)
 "ctk" = (
-/obj/structure/closet/secure_closet/cytology,
-/turf/open/floor/iron/white,
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Test Chamber";
+	req_access_txt = "55"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Xtestlab";
+	name = "test chamber blast door"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/science/xenobiology)
 "ctl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 4
-	},
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ctm" = (
@@ -32189,8 +31911,11 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "ctD" = (
-/obj/structure/window/reinforced,
-/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/bz,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ctI" = (
@@ -32245,7 +31970,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ctS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/obj/machinery/camera{
+	c_tag = "Xenobiology - Test Chamber";
+	dir = 8;
+	name = "Xenobiology Camera";
+	network = list("ss13","rd","xeno")
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ctT" = (
@@ -32390,53 +32120,34 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cut" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
-/obj/structure/closet/crate/trashcart/laundry,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white,
+/area/science/mixing)
 "cuu" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdxeno";
-	name = "Xenobiology Containment Door"
+/obj/structure/chair/office/light{
+	color = "#990099";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cuv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdxeno";
-	name = "Xenobiology Containment Door"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cuw" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "rdxeno";
-	name = "Xenobiology Containment Door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/requests_console/directional/east{
-	department = "Xenobiology Lab";
-	name = "Xenobiology RC"
-	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cuy" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cuA" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 4;
-	name = "plasma mixer"
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cuC" = (
@@ -32751,28 +32462,31 @@
 /turf/open/floor/iron,
 /area/engineering/transit_tube)
 "cvL" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
+	},
+/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cvM" = (
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cvN" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cvO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cvQ" = (
@@ -32870,7 +32584,10 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cwh" = (
-/obj/structure/stairs/south,
+/obj/structure/chair/office/light{
+	color = "#990099";
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cwi" = (
@@ -33144,9 +32861,13 @@
 /turf/open/floor/iron,
 /area/space)
 "cxa" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/structure/table/glass,
+/obj/item/slime_scanner,
+/obj/item/storage/box/monkeycubes,
+/obj/machinery/light/directional/south,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "cxb" = (
 /obj/item/stack/cable_coil/five,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -33721,10 +33442,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "czj" = (
-/obj/structure/table/reinforced,
-/obj/item/kitchen/knife,
-/obj/item/wrench,
-/obj/structure/cable,
+/obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "czm" = (
@@ -33852,7 +33570,7 @@
 /area/engineering/main)
 "czW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
+	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -33986,8 +33704,13 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cAq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "cAr" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -34059,14 +33782,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cAD" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/engine/atmos";
-	dir = 8;
-	name = "Atmospherics Maint APC";
-	pixel_x = -25;
-	pixel_y = 1
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cAE" = (
@@ -34265,8 +33984,8 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cBk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
@@ -34300,14 +34019,18 @@
 /turf/open/space/basic,
 /area/space)
 "cBp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
+/obj/structure/table/glass,
+/obj/item/slime_scanner,
+/obj/item/storage/box/monkeycubes,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cBq" = (
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
-/turf/open/floor/engine,
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cBs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
@@ -34321,6 +34044,7 @@
 /area/engineering/atmos)
 "cBu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "cBv" = (
@@ -34484,7 +34208,7 @@
 /turf/open/floor/iron,
 /area/space)
 "cCc" = (
-/obj/machinery/atmospherics/components/trinary/filter{
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -34761,7 +34485,7 @@
 /area/space)
 "cDj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
@@ -35572,10 +35296,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cGS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/structure/sign/departments/xenobio{
+	pixel_y = -30
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "cGT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36179,21 +35904,28 @@
 /turf/open/floor/iron,
 /area/space)
 "cIb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/obj/structure/sign/departments/xenobio{
+	pixel_y = -30
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cIf" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "rdxeno";
+	name = "Xenobiology Containment Door"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/machinery/door/firedoor,
+/obj/machinery/requests_console/directional/east{
+	department = "Xenobiology Lab";
+	name = "Xenobiology RC"
+	},
+/turf/open/floor/iron/white,
+/area/science/xenobiology)
 "cIh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -36410,27 +36142,26 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cJa" = (
-/obj/effect/landmark/blobstart,
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cJc" = (
-/obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 8
-	},
+/obj/effect/spawner/bundle/costume/wizard,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cJd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 1
-	},
+/obj/structure/closet/masks,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cJe" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
 	},
+/obj/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cJf" = (
@@ -36653,7 +36384,10 @@
 /area/maintenance/disposal/incinerator)
 "cJG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/door/airlock/atmos{
+	name = "Xenobiology Atmos";
+	req_one_access_txt = "47;55"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cJH" = (
@@ -36661,10 +36395,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cJI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
-/obj/structure/cable,
+/obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cJN" = (
@@ -36768,18 +36499,26 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos/upper)
 "cKs" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cKu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Xenobiology Atmos";
+	req_one_access_txt = "47;55"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cKw" = (
@@ -37198,12 +36937,11 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "cMa" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
@@ -37235,9 +36973,7 @@
 /turf/open/floor/iron,
 /area/space)
 "cMe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cMf" = (
@@ -37451,19 +37187,19 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cMX" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/obj/structure/cable,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNa" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cNb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
@@ -37505,13 +37241,12 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cNl" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -5
+/obj/machinery/power/shieldwallgen,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
 	},
-/obj/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cNm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -37523,31 +37258,17 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cNn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Auxiliary Gas Mixing"
-	},
-/obj/structure/cable,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNt" = (
@@ -37612,20 +37333,23 @@
 /turf/open/space/basic,
 /area/space)
 "cNH" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible,
+/obj/structure/table,
+/obj/item/stock_parts/cell,
+/obj/machinery/cell_charger,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNK" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 8
-	},
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNL" = (
@@ -37683,19 +37407,15 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "cNW" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/heater{
-	dir = 8
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
 	},
-/obj/machinery/light/small/directional/south,
+/obj/structure/filingcabinet,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cNY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/item/stack/spacecash/c50,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cOa" = (
@@ -37733,19 +37453,9 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"cOh" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "cOn" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -5
-	},
-/obj/structure/grille/broken,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/masks,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cOo" = (
@@ -37778,57 +37488,45 @@
 /turf/open/space/basic,
 /area/engineering/main)
 "cOs" = (
-/obj/structure/closet/masks,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"cOu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cOv" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -5
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cOw" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 4;
+	name = "plasma mixer"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cOx" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cOy" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cOz" = (
-/obj/item/target,
+/obj/item/target/alien/anchored,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "cOA" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cOB" = (
 /obj/machinery/camera{
 	c_tag = "External Engine SMES";
@@ -37857,22 +37555,19 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cOE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/engine/atmos";
+	dir = 8;
+	name = "Atmospherics Maint APC";
+	pixel_x = -25;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cOF" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
@@ -37888,13 +37583,9 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "cOJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/structure/closet/emcloset,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cOK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -37903,64 +37594,68 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"cOL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "cOM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"cON" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"cOO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"cOP" = (
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
-"cOR" = (
+"cON" = (
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
+"cOO" = (
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
+"cOP" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
+"cOR" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cOT" = (
-/obj/structure/table,
-/obj/item/gun/energy/laser/practice,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cOV" = (
-/obj/structure/table,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cOW" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cOX" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
@@ -37987,12 +37682,16 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cPe" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPf" = (
-/obj/effect/loot_site_spawner,
-/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPg" = (
@@ -38031,14 +37730,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cPj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPm" = (
 /obj/machinery/camera{
@@ -38068,8 +37764,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cPp" = (
-/obj/effect/spawner/lootdrop/glowstick,
-/obj/machinery/light/directional/south,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPq" = (
@@ -38113,86 +37809,57 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cPw" = (
-/obj/structure/rack,
-/obj/item/tank/jetpack,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/binary/valve,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPz" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
+/obj/machinery/door/airlock/maintenance{
+	name = "Auxiliary Gas Mixing"
 	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPA" = (
-/obj/structure/rack,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPB" = (
-/obj/structure/rack,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPD" = (
-/obj/structure/rack,
-/obj/item/tank/jetpack,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPF" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cPI" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/mass_driver/trash,
@@ -38224,112 +37891,85 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cPN" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/rglass,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPO" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPP" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "cPQ" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cPR" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cPS" = (
-/obj/structure/rack,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cPT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
-"cPU" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/cable_coil,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cPV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"cPW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+"cPR" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
+"cPS" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"cPT" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/science/misc_lab/range)
+"cPU" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/science/misc_lab/range)
+"cPV" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"cPW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cPX" = (
 /obj/effect/turf_decal/stripes/full,
@@ -38341,28 +37981,38 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cQc" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cQd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
+/obj/item/target,
 /turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/area/science/misc_lab/range)
+"cQd" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/iron,
+/area/science/misc_lab/range)
 "cQe" = (
+/obj/machinery/door/airlock/command{
+	name = "Auxiliary E.V.A. Storage";
+	req_access_txt = "18"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cQh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/sign/warning/firingrange{
+	pixel_x = -30
 	},
 /turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/area/science/misc_lab/range)
 "cQi" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+/obj/structure/sign/warning/firingrange{
+	pixel_x = 30
+	},
+/turf/open/floor/iron,
+/area/science/misc_lab/range)
 "cQk" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube,
@@ -38379,100 +38029,108 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cQp" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cQr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cQt" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/closet/l3closet,
+/obj/item/toy/mecha/mauler,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cQu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -30
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_y = 30
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cQv" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cQD" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"cQE" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
-"cQL" = (
-/obj/machinery/door/airlock/command{
-	name = "Auxiliary E.V.A. Storage";
-	req_access_txt = "18"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
-"cQM" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/sign/warning/firingrange{
-	pixel_x = -30
+"cQD" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"cQE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"cQL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"cQM" = (
+/obj/structure/table,
+/obj/item/gun/energy/laser/practice,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "cQN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "cQO" = (
-/obj/structure/sign/warning/firingrange{
-	pixel_x = 30
-	},
+/obj/structure/table,
+/obj/item/gun/energy/laser/practice,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
 "cQS" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cQT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cQU" = (
-/obj/structure/closet/l3closet,
-/obj/item/toy/mecha/mauler,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cQV" = (
-/obj/machinery/power/shieldwallgen,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"cQW" = (
 /obj/structure/table,
 /obj/item/gun/energy/laser/practice,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
+"cQT" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"cQU" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
+"cQV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"cQW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "cQZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38603,10 +38261,13 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRv" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cRw" = (
 /obj/machinery/camera{
@@ -38746,14 +38407,22 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cRU" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cRV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
@@ -38826,12 +38495,10 @@
 /turf/closed/wall,
 /area/science/misc_lab/range)
 "cSi" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "cSj" = (
@@ -40439,12 +40106,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cWY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
@@ -40468,18 +40131,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "cXc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cXd" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/area/science/misc_lab/range)
 "cXe" = (
 /obj/machinery/camera{
 	c_tag = "Engine Airlock";
@@ -40521,16 +40183,17 @@
 /area/maintenance/starboard/fore)
 "cXi" = (
 /obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight,
+/obj/item/tank/jetpack,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cXk" = (
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"cXl" = (
-/turf/closed/wall/r_wall,
-/area/science/nanite)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/science)
 "cXn" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40672,13 +40335,8 @@
 /turf/open/floor/iron,
 /area/space)
 "cXE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "rdoffice";
-	name = "Research Director's Shutters"
-	},
-/turf/open/floor/plating,
-/area/science/nanite)
+/turf/open/floor/grass,
+/area/science/genetics)
 "cXF" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -40859,9 +40517,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "ddJ" = (
-/obj/item/target/clown,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/science/misc_lab/range)
+/area/maintenance/department/science/xenobiology)
 "deu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
@@ -40925,9 +40585,6 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "dqB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "duA" = (
@@ -40950,9 +40607,28 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dBV" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "dDa" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -41091,10 +40767,20 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ehC" = (
-/obj/item/target/alien/anchored,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/structure/rack,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "eiV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -41102,7 +40788,9 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
 "eiW" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/rack,
+/obj/item/tank/jetpack,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "ejT" = (
@@ -41112,12 +40800,9 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "ekq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light/directional/south,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/area/science/misc_lab/range)
 "els" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -41133,7 +40818,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ene" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/rglass,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "ept" = (
@@ -41147,17 +40835,9 @@
 /turf/open/space/basic,
 /area/space)
 "erc" = (
-/obj/structure/rack,
-/obj/item/storage/box/petridish{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/storage/box/petridish{
-	pixel_x = -5;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "erB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -41324,9 +41004,28 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "fpK" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/science)
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "fqS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41533,9 +41232,10 @@
 /turf/open/floor/iron,
 /area/space)
 "fZf" = (
-/obj/item/target/syndicate,
-/turf/open/floor/iron,
-/area/science/misc_lab/range)
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "fZz" = (
 /obj/machinery/camera{
 	c_tag = "Minisat Exterior SSW";
@@ -41553,12 +41253,31 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "gaH" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "gbK" = (
 /obj/structure/table,
@@ -41657,15 +41376,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "gtK" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/item/target/clown,
+/turf/open/floor/iron,
+/area/science/misc_lab/range)
 "gtO" = (
 /obj/structure/stairs/north,
 /turf/open/space/basic,
@@ -41718,23 +41431,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "gGz" = (
-/obj/structure/sign/departments/xenobio{
-	pixel_y = -30
-	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "gJn" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gKm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "gKu" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -41801,15 +41511,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hdk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "hdQ" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 30
@@ -41827,9 +41533,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "hfS" = (
-/obj/structure/cable,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/area/science/misc_lab/range)
 "hgf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -42017,9 +41723,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "hTK" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/science)
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "hUZ" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
@@ -42097,16 +41808,9 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "inh" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/power/shieldwallgen/xenobiologyaccess,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "iog" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42391,9 +42095,9 @@
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "jxx" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "jEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -42679,11 +42383,9 @@
 /area/hallway/secondary/command)
 "kOH" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 10
 	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_y = 30
-	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "kQJ" = (
@@ -42744,9 +42446,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kXE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
-/area/science/genetics)
+/area/science)
 "kYQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -42783,8 +42491,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "leP" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -30
+	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "lgJ" = (
@@ -42903,8 +42613,9 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "lIQ" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
 "lJc" = (
 /obj/machinery/light/directional/south,
@@ -43046,12 +42757,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "msL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "mti" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43100,15 +42808,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mvL" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/item/target/syndicate,
+/turf/open/floor/iron,
+/area/science/misc_lab/range)
 "mxv" = (
 /obj/structure/window,
 /obj/machinery/hydroponics/constructable,
@@ -43309,15 +43011,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"nlO" = (
-/obj/machinery/requests_console/directional/north{
-	name = "Circuits Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
 "nnm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -43377,14 +43070,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nwJ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/bz,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron/white,
-/area/science/xenobiology)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -43653,12 +43338,6 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"oGd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science)
 "oHG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -44003,8 +43682,8 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "qva" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "qwp" = (
@@ -44846,6 +44525,7 @@
 "tXD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "tXG" = (
@@ -45255,8 +44935,8 @@
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
 "vUt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
@@ -45413,6 +45093,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wMF" = (
@@ -45505,8 +45188,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xjf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/stairs/south,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "xjp" = (
@@ -45577,6 +45259,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "xur" = (
@@ -45585,15 +45270,6 @@
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
-"xuV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "xyD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -87565,10 +87241,10 @@ cLo
 cLo
 cLo
 cLo
-cLo
-cmm
 sBD
-chb
+cmm
+chq
+chq
 chq
 ckf
 coL
@@ -87796,7 +87472,7 @@ lET
 bQb
 lET
 lET
-nno
+bsl
 brN
 nno
 lET
@@ -87809,15 +87485,13 @@ cfW
 chg
 bSP
 bSP
-cmb
-cmK
-chn
-chn
-chn
-cqP
-chn
-chn
-chn
+cnz
+cnz
+cnz
+ctg
+cnz
+cnz
+cnz
 chq
 chq
 chq
@@ -87825,7 +87499,9 @@ chq
 ckk
 cyj
 ckj
-chc
+cNa
+cNo
+cNo
 cga
 clb
 coO
@@ -87837,8 +87513,8 @@ cPM
 ckf
 aak
 aak
-aak
-aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88049,40 +87725,40 @@ auI
 byY
 bWG
 bMF
-bxI
+bxx
 bQg
-bxI
-bxI
+bxx
 bSR
-bxs
-bSR
+btS
 bSR
 bSR
 bSR
 bSR
-cXl
-cXl
-cXl
-cXl
-cXl
+bSR
+bSR
+bxx
+bxx
+bxx
 bxx
 bxx
 bxx
 cnz
-cor
+cmE
+crY
+cou
 cpz
 cIb
-crX
-ctb
 cnz
+chq
+chq
 cko
-chq
-chq
-chq
+cjb
 ckk
 cyj
 ckj
-cPV
+cNH
+chq
+chq
 chq
 ckf
 ckf
@@ -88093,9 +87769,9 @@ ckf
 ckf
 ckf
 ckj
-ckj
-ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88305,41 +87981,39 @@ bxt
 bIn
 byY
 bIn
-bxI
-bxI
+bxx
+bxx
 bPP
 bOz
-avK
 bSR
+btV
 bVz
 bWH
-bXS
 bZi
-bTm
+bRH
+bZi
 bSR
-cgZ
-ceu
 cXk
-cgZ
-cXl
+ceu
+cge
+bOz
+bOz
 cms
-ckT
-cms
-cnA
-cos
+ckU
+cmI
 cpA
-cIb
-crY
-ctc
+cou
+cuu
+cxa
 cnz
-cAK
-chq
-chq
-chq
+ctc
+ckj
+ckj
+ckj
 ckk
 cyj
 ckj
-cPV
+cNH
 chq
 chq
 chq
@@ -88350,9 +88024,11 @@ chq
 chq
 chq
 chq
-chq
+cMX
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88562,41 +88238,41 @@ bxt
 bIr
 bJI
 bLk
-bxI
+bxx
 jKC
 bPP
 bOz
-aLK
 bSR
+but
 bVA
-bOK
-bXS
+bWH
 bZi
-bTM
+bZi
+bZi
 bSR
-ccH
-cev
-cio
-ccH
-cXl
+ccK
+cew
+ciJ
+bOz
+cim
 cke
 ckU
 cmt
-cnA
-cot
 cpA
-cIb
-crZ
-ctd
+cou
+cuv
+czj
 cnz
-ceT
-cfQ
-cjb
-chq
-ckk
-cmN
+ctd
 ckj
-chd
+chq
+ckj
+ckk
+cKs
+ckj
+cmN
+sBD
+sBD
 cLo
 cLo
 cLo
@@ -88605,11 +88281,11 @@ cLo
 cLo
 cLo
 cLo
-cLo
-cLo
-cOE
+cPF
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88823,37 +88499,35 @@ aek
 oYi
 bPP
 bOz
-aQm
 bSR
+bvb
 bVB
 bWJ
 bXI
 bRH
 bTm
 bSR
-cip
+ccT
 cew
 ciJ
-cip
-cXl
 bOz
-ckV
-cmu
+civ
+clf
 cnz
+cmu
+cpA
 cou
 cpB
-cIb
-csa
-cte
+cBp
 cnz
-chn
-chn
-chn
-chn
-cge
-cgq
 ckj
-chl
+ckj
+cJc
+ckj
+cJG
+cKu
+ckj
+cgq
 ckj
 ckj
 ckj
@@ -88864,9 +88538,11 @@ chq
 chq
 chq
 ckk
-cyj
+cPN
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89084,36 +88760,34 @@ ckh
 bTU
 bVC
 bWK
-bRz
 bZi
-bTR
+bZi
+bZi
 bSR
 ccJ
-bUf
+cew
 ciJ
-cbp
-cXl
-ckg
+bOz
 bEi
 bOz
-cnB
+cmb
 cpA
+cnB
+cou
 vUt
-cIb
-csb
-ctf
+cBq
 cnz
-cfa
+ctf
 ckj
-chq
-chq
+ckj
+ckj
 ckk
 cyj
 ctm
+cNJ
+cNY
 chL
 cix
-clf
-cut
 chq
 chq
 chq
@@ -89124,6 +88798,8 @@ ckk
 cyj
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89337,28 +89013,26 @@ bMG
 bSX
 uaU
 bOz
-hTK
 bSR
+bvm
 bWr
-bPa
-bXS
+bWH
 bZi
-bTM
+bZu
+bZi
 bSR
 cfO
-bUf
-ciJ
-cbr
-cXl
+ceT
+chb
 bOz
-ckX
+ckg
 bTs
+ckX
+cmK
 cnC
 cow
-cpD
-cqS
 cpA
-ctg
+cqS
 cnz
 cnz
 cnz
@@ -89367,7 +89041,7 @@ chq
 ckk
 cyj
 ctm
-cif
+cna
 chq
 chq
 chq
@@ -89381,6 +89055,8 @@ ckk
 cyj
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89594,50 +89270,50 @@ bMG
 bOr
 qaf
 bRC
-aUm
-bSR
-bSR
-bSR
 bXS
 bXS
-bSR
-bSR
-cfP
-bUA
-bVG
+bXS
+bXS
+bXS
+bXS
+bXS
+bXS
+ciu
+ciu
+ciu
 cbs
-cbB
-ckh
-cla
+bxG
+clh
+cnz
 cmx
-cnz
-cox
-cpE
-cIb
+crZ
+coy
 cpA
-cth
-cuu
-cwh
+cpA
+csd
+xjf
 cnz
 chq
 chq
-lIQ
-cna
+cJI
+cMa
 ctm
-cif
+cna
 chq
 chq
+cOA
+cOR
 cJa
-cON
-cPp
 ckj
-chq
+cPp
 chq
 chq
 ckk
 cyj
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89851,50 +89527,50 @@ bMG
 aPA
 bxG
 bOz
-bOz
+ciu
 caq
 bVE
 bWL
 bRA
 bZj
-cfR
-cbC
-cXk
-cXk
-cXk
-cbC
-cXl
-bOz
+car
+cXE
+ccU
+cXE
+ciu
+bOv
 bQn
 cmy
 cnz
-coy
+cnA
 cpA
-hdk
+coy
+cuw
+cpA
 csd
 xjf
-cuv
-cwh
 cnz
 ctm
 ctm
 ctm
 ctm
 ckj
-civ
+cNK
 chq
 chq
 chq
-cPe
+cOT
 chq
 ckj
 ckj
 chq
 chq
 ckk
-cOF
+cPO
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90105,53 +89781,53 @@ bIh
 bAR
 bKR
 bMG
-bOz
-bxG
-bOz
-cmy
-caq
+beR
+beW
+cmz
+ciu
+bvJ
 bVF
-bWM
-cby
-cby
-cfR
+bZo
+bXP
+bZm
+cbG
 cbR
-cXk
-cXk
-cXk
-cbt
-cXl
+cXE
+cXE
+ciu
 bOz
 bQn
 bOz
 cnz
+cnG
+cpA
 coz
 cpA
-czj
 cpA
-cpA
-cuw
-cwh
+cIf
+xjf
 cnz
 aak
 aak
 aak
 aak
 ckj
+cNW
+cOn
 ciw
 ciN
 clp
-cOw
-cPf
 chq
 chq
 chq
 chq
 chq
 ckk
-cOF
+cPO
 ckj
 aak
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90363,30 +90039,28 @@ bJA
 bKS
 bMG
 bOt
-bPR
-cmz
-cmz
-caq
+bxG
+bOz
+cfR
+bZm
 aZD
-bWN
+bZo
 bef
 beT
-caq
+car
 cXE
 cXE
-cXl
-bXV
-cXl
-cXl
-cbG
-ckZ
+ccO
+ciu
+cmz
+ckV
 cmz
 cnz
-coA
+coF
 cpA
+coA
+cwh
 cqU
-cse
-ctk
 cnz
 cnz
 cnz
@@ -90402,18 +90076,20 @@ ckj
 ckj
 ckj
 ckj
-ckj
-chl
-ckj
+cgq
+chq
+chq
 ckk
-cyj
+cPQ
 ckj
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
+aak
+aak
+aak
+aak
+aak
+aak
+aak
 aaa
 aaa
 aaa
@@ -90622,28 +90298,26 @@ bIl
 bOz
 bxG
 bOz
-bOz
-caq
+cfR
+bwZ
 bIR
-bWO
-bWO
+bZo
+bYo
 bSV
 bTS
 cbv
-cfR
-bOz
-bOz
+cXE
+cXE
+ciu
 cha
-bOz
-bOz
 bQn
 bOz
 cnz
+cpa
+cpA
 coB
 cpA
 cqV
-cpA
-erc
 cnz
 aak
 aak
@@ -90653,24 +90327,26 @@ aaa
 aak
 aak
 aak
-aak
-ckj
+ctm
+cOs
+cOE
+cOV
 cuy
 cAD
-cGS
-cJG
-cNH
-cNH
 ckj
+chq
+chq
 ckk
-cyj
+cPQ
+ckj
+ckj
+ckj
+ckj
+ckj
+ckj
+ckj
 ckj
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -90879,28 +90555,26 @@ bIl
 bOz
 bxG
 bOz
-aUn
-caq
+cfR
+bZo
 bVH
-bWP
+bZo
 bXN
 bZm
 car
-cbw
-cfR
-bOz
-bOz
-bOz
-bOz
+cXE
+ccW
+cXE
+ciu
 bOz
 bQn
 bOz
 cnz
+cpD
+coy
 coC
 ceA
 czW
-gKm
-msL
 cnz
 aak
 aaa
@@ -90909,31 +90583,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aak
-ckj
+ctm
+cOw
+cDj
+cOW
 cuA
 cMe
-cIf
-cJI
-cNJ
-cNJ
 ckj
+chq
+chq
 ckk
+cPQ
+ckj
 cOJ
+cQT
+cXi
+ene
+gGz
+inh
 ckj
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91134,30 +90810,28 @@ npH
 bKV
 bIl
 bOz
-bxG
-bOz
-bOz
-caq
+bgj
+bTs
+bng
+bxs
 bVI
 cby
 bRG
-cby
-bTT
-cby
+beT
+car
+cbI
 ccO
-bOz
-bOz
-bOz
-bOz
+cXE
+ciu
 bOz
 bQn
 bOz
 cnz
+cpE
+csa
 coD
 ctD
 cqW
-nwJ
-inh
 cnz
 aak
 aaa
@@ -91166,31 +90840,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aak
-ckj
+ctm
+cOx
+cOF
+cPe
 cvN
 cBk
-cJc
-cKs
-cNK
-cNK
 ckj
+chq
+chq
 ckk
-cOJ
-ckj
-ckj
-ckj
-ckj
-ckj
-ckj
-ckj
-ckj
-ckj
-ckj
-ckj
+cPQ
+ctm
+cQr
+cQV
+ddJ
+ddJ
+gKm
+jxx
 ckj
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91393,26 +91069,24 @@ bMG
 bSX
 bxG
 bOz
-bOz
-caq
-bMH
-bWR
+boG
+bZo
+bZo
+bZo
 bZo
 bZo
 bTW
-cby
-ccO
-bOz
-bOz
-bOz
-bOz
-bOz
+cXE
+cXE
+cXE
+ciu
+chl
 bQn
 bOz
 cnz
 cnz
 fZI
-cqX
+ctk
 fZI
 cnz
 cnz
@@ -91423,31 +91097,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aak
-ckj
+ctm
+cOy
+cON
+cPf
 cvO
 cCc
-cJd
-cKu
-cNW
-cNW
 ckj
+cAK
+chq
 ckk
-cOJ
-chq
-chq
-chq
-chq
-ckj
-cQS
-cRv
-cPw
-cPN
-cQc
-cQv
+cPQ
+ctm
+cQt
+cQW
+dqB
+erc
+hdk
+kOH
 ckj
 aak
+aak
+aak
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91649,27 +91325,25 @@ bLo
 bMG
 bOv
 bxG
-bOz
-aYA
-caq
+blw
+ciu
+bxI
 bWw
-cby
-bXT
+bZo
+bZo
 bZx
 bTX
-cbW
-cfR
-bOz
-bOz
-bOz
-bOz
-bOz
+cXE
+ceE
+cXE
+ciu
+chw
 bQn
+blw
+cnz
 hTK
-cnz
+csb
 coQ
-ctS
-cBp
 cpI
 cpI
 cnz
@@ -91681,30 +91355,32 @@ aak
 aak
 aak
 aak
-aak
-ckj
-ckP
-cDj
-cJe
-cMX
-cMe
-cMe
-ckj
-ckk
-cOJ
-chq
-chq
-chq
-chq
 ctm
-cQT
-cRU
-cPO
-cPO
-cQd
-eiW
+ckP
+cOP
+cPj
+cPw
+cDj
 ckj
-aak
+cMX
+chq
+ckk
+cyj
+ckj
+cQu
+cRv
+dBV
+fpK
+dqB
+leP
+ctm
+ctm
+ctm
+ctm
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91906,30 +91582,33 @@ bIl
 bMG
 bOz
 bxG
-bOz
-bci
-caq
-cfR
-cfR
-cfR
-caq
-bTZ
-cfR
-caq
+bmb
 ciu
-bOz
-bOz
-bOz
+cfR
+cfR
+cfR
+cfR
+ciu
+ciu
+ciu
+ciu
+ciu
+ciu
 bOz
 bQn
 cmy
 cnz
+cqP
+cpI
 ctl
 cpI
-cBq
 cpI
-cpI
-chn
+cnz
+aak
+ckj
+ckj
+ctm
+ctm
 ckj
 ctm
 ctm
@@ -91937,33 +91616,30 @@ ckj
 ctm
 ctm
 ckj
-ctm
-ctm
+cPz
 ckj
 ckj
-ctm
-ctm
 cNn
-ckj
-ckj
-ckj
-ckk
-cOJ
-chq
-chq
-chq
-chq
-ctm
-cQU
-cRV
+cPB
+cga
+cPR
 cQe
+cQv
+cRU
+ehC
+fZf
+cPV
+lIQ
+cQU
+ckk
+ckk
 cPP
-dqB
-cQr
-ckj
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92165,30 +91841,30 @@ bOz
 bxG
 bOz
 bOz
-fpK
+cmz
+bOz
+bUa
 bOz
 bOz
 bOz
 cmz
-bgj
 bOz
-bUb
-bOz
-bOz
-cmt
-bOz
+bUa
+chd
 bOz
 bQn
 bOz
 cnz
-coF
+cqX
 cpI
 cpI
 cpI
 cpI
-chn
+cnz
+aak
+ckj
 cvL
-chq
+cJe
 chq
 czC
 chq
@@ -92197,30 +91873,30 @@ chq
 chq
 chq
 chq
+ckk
 chq
+ckj
 chq
+cPD
 chq
 ckk
 ckj
-chq
-cxa
-ckk
-cOJ
-chq
+cQE
+cRV
 cOM
-qva
-cOu
-ckj
-kOH
-cSi
-cPz
-cPQ
-cQe
-cQu
+gaH
+cPV
+leP
 ctm
 ctm
 ctm
 ctm
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92417,67 +92093,67 @@ bHd
 cme
 jJv
 uvU
-cgv
+aVm
 ldq
 cBY
 ldq
 cgv
+bEB
+ldq
+aVm
 ldq
 ldq
+ldq
+bEB
+ldq
+cfa
+aVm
 cgv
-ldq
-beW
-bUa
-ldq
-uvU
-cgv
-ldq
-btV
-ldq
-cgv
-oGd
+ckZ
 bOz
 cnz
-cpa
-bEB
+cry
+cse
 cpI
 cpI
-gGz
-chn
+cGS
+cnz
+aak
+ckj
+cJd
+chq
+cga
+cga
+cga
+cga
+cga
+cga
+cga
+cga
+cga
+cLo
+cPA
+cNo
+ybn
 chq
 ckk
-ckk
-ckk
-ckk
-ckk
-ckk
-ckk
-ckk
-ckk
-ckk
-ckk
-ckk
-cNo
-mvL
-cMa
-ckk
-ckk
-cOL
-ckk
+ctm
+cOO
+cSi
 cPV
-ckk
+cPV
 cvM
 cQL
-xuV
-cPj
-cPA
-cPR
-hfS
-cQt
-gaH
-ckk
-ckk
-gtK
+ckj
+aak
+aak
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92674,67 +92350,67 @@ cmv
 bOz
 aAX
 bPP
-bOz
+bai
 bOz
 bQn
 bOz
 bOz
-bOz
-bai
-bOz
-bez
 cmz
 bOz
-bOz
-bEi
-bPT
-bOz
-chw
-bpQ
+bUb
 bez
-bxG
+bOz
+bOz
+cmz
+bOz
+bPP
+bai
+bOz
+bpQ
 bOz
 cnz
 cpI
-bES
-cry
+ctb
+ctS
 cpI
 cpI
-chn
+cnz
+aak
+ckj
+ciP
+cko
 chq
-cim
-qva
 ciH
-clW
 qva
+chq
+chq
+chq
+chq
+chq
+chq
 qva
-qva
-qva
-qva
-qva
-qva
-qva
+ckj
 cNp
-ckj
-cNY
-qva
-qva
+chq
+chq
+ckk
+ctm
 cOO
-qva
-cPW
-cOh
-cOv
-ckj
-cOP
 cWY
-cPB
-cPS
-hfS
-cQu
-ctm
-ctm
-ctm
-ctm
+cPW
+cPW
+cOv
+msL
+ckj
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92941,16 +92617,16 @@ caw
 caw
 caw
 caw
-cfX
-cfX
-bmb
-ceE
-cfX
+caw
+caw
+bOz
+bQn
+bOz
 cfX
 bVN
 bVN
-cle
-cmE
+bVN
+bVN
 bVN
 bVN
 cpP
@@ -92972,26 +92648,26 @@ ckj
 ckj
 ckj
 ckj
-ckj
-ckj
-ckj
-cOn
-cNl
+chq
 chq
 ckk
+ckj
+cNl
+cXc
+eiW
 cQp
 cQD
-ctm
-cOR
-cXc
-hfS
-hfS
-leP
-ekq
+inh
 ckj
 aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93197,16 +92873,16 @@ bUh
 bbD
 bcI
 beG
-caw
+cbB
 chk
-cAq
-ccS
-kXE
-cAq
+caw
+bOz
+bQn
+bOz
 chh
 bVN
-bvJ
-clh
+csH
+csH
 csH
 cnD
 coI
@@ -93228,25 +92904,25 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
 ckj
-cOs
-chq
-chq
-ckk
-chq
-cQE
-ctm
-cOR
-cXd
-cPT
-cPT
-cQh
-ene
 ckj
+cSh
+cPS
+cSh
+cSh
+cSh
+cSh
+cSh
+cSh
+cSh
+cSh
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93453,17 +93129,17 @@ bZP
 bUn
 bVL
 bXU
-beM
-caw
+bVL
+bXU
 bhv
-ccK
-ccS
-kXE
-cAq
-but
-bVN
-bvJ
-clh
+caw
+bOz
+bQn
+bOz
+bOz
+cla
+csH
+csH
 csH
 csH
 bCH
@@ -93484,26 +93160,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aak
-ckj
-ciP
-cko
-chq
-ckk
-ckk
-ckk
-ckj
-cQV
-cXi
-cPD
-cPU
-cQi
-cQv
-ckj
 aak
+aak
+cSh
+cPT
+cQh
+cQM
+cXd
+cRa
+cRa
+hfS
+mvL
+cSh
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93707,22 +93383,22 @@ cmz
 aRm
 cmz
 ccA
+bES
+bTM
 bXU
 bVL
 bXU
-beR
-caw
 bhw
-cAq
-ccS
+caw
+bOz
 kXE
 cAq
 bva
-bVN
-bvJ
-clh
-csH
-csH
+cle
+cpT
+cpT
+crX
+cte
 coJ
 cpP
 cto
@@ -93743,24 +93419,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-ckj
-ckj
-ckj
-ckj
-ckj
+aak
 cSh
-cNa
-cSh
-cSh
-cSh
-cSh
-cSh
-cSh
-cSh
+cPU
+cRa
+cQN
+cXd
+ekq
+cRa
+cRa
+cRa
 cSh
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93964,22 +93640,22 @@ bOz
 bQn
 bOz
 ccA
+bPR
+bTM
 bXU
 bVL
 bXU
-bXP
-caw
 bhy
-cAq
+caw
 ccS
-kXE
-cAq
-chk
+bOz
+btP
+chh
 bVN
-bwZ
-cli
-cmI
-cnG
+csH
+cnp
+csH
+bLv
 bCJ
 cpP
 bQK
@@ -94000,24 +93676,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aak
 cSh
-cOx
-cQM
-cOT
-cQN
+cQc
+cRa
+cQO
+cXd
+cRa
+gtK
 cRa
 cRa
-dBV
-fZf
 cSh
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94221,17 +93897,17 @@ bOz
 bQn
 bOz
 ccA
-bXU
+bRz
 bbJ
 bXU
 bXQ
-caw
+bXU
 boD
-cAq
-bng
-brT
-btC
-boG
+caw
+bOz
+bOz
+btP
+bOz
 bVN
 bpS
 cez
@@ -94258,23 +93934,23 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
 cSh
-cOy
+cQd
 cRa
-cOW
 cQN
-cPF
+cXd
+cRa
 cRa
 cRa
 cRa
 cSh
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94474,27 +94150,27 @@ ayt
 bKd
 bLs
 bMP
-bOz
-bQn
-bOz
+bOr
+blu
+bRC
 ccA
-bXU
+bTf
 cih
 bXU
 bXR
-caw
+bXU
 bhE
-cAq
-ccS
-kXE
-cAq
-bvb
+caw
+bOz
+bOz
+btP
+bOz
 bVN
 cBu
 clk
 bzo
 cnI
-csH
+cut
 cpP
 bQL
 csn
@@ -94514,24 +94190,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aak
 cSh
+cQd
+cQi
+cQS
+cXd
+cRa
+cRa
 cOz
 cRa
-cOV
-cQN
-cRa
-ddJ
-cRa
-cRa
 cSh
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94735,17 +94411,17 @@ bOz
 bQn
 bOz
 ccA
-bXU
+bZP
 bWS
 bXU
 bXX
-caw
+bXU
 caO
-cbH
-ccT
-ceI
-kXE
-chk
+caw
+bOz
+bOz
+btP
+bOz
 bVN
 cdq
 cll
@@ -94771,24 +94447,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aak
 cSh
-cOA
-cRa
-cOW
-cQN
-cRa
-cRa
-cRa
-cRa
+cSh
+cSh
+cSh
+cSh
+cSh
+cSh
+cSh
+cSh
 cSh
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94990,19 +94666,19 @@ aLf
 bMN
 bOz
 bQk
-aVl
-ccA
-bXU
-bXU
-bXU
-bYo
-caw
-blt
-cbI
+aUw
 bph
-bsl
+bZP
+bTR
+bXU
+bXU
+bXU
+blt
+caw
+bOz
+bOz
 btP
-chj
+bOz
 bVN
 bpV
 cln
@@ -95035,17 +94711,17 @@ aak
 aak
 aak
 aak
-cSh
-cOA
-cQO
-cQW
-cQN
-cRa
-cRa
-ehC
-cRa
-cSh
 aak
+aak
+aak
+aak
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95247,17 +94923,17 @@ aLh
 bMN
 bOz
 bQn
-aVm
+bPT
+brT
 bZP
-nlO
 bXU
 bXU
-bZu
-caw
+bXU
+bXU
 cbF
-cbJ
-ccU
-ceJ
+caw
+bOz
+bOz
 btR
 bvd
 ciK
@@ -95291,18 +94967,18 @@ aaa
 aaa
 aaa
 aaa
-aak
-cSh
-cSh
-cSh
-cSh
-cSh
-cSh
-cSh
-cSh
-cSh
-cSh
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95510,13 +95186,13 @@ bZP
 bXU
 bXU
 bXU
+bXU
+ceL
 caw
-ceL
-ceL
-ceL
-ceL
-ceL
-ceL
+ceI
+ceI
+ceI
+ceI
 ciL
 bVa
 bza
@@ -95548,18 +95224,18 @@ aaa
 aaa
 aaa
 aaa
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95768,12 +95444,12 @@ bcj
 bXe
 bcj
 bZP
-blu
-blw
-ccW
-jxx
-btS
-bvm
+bZP
+bZP
+bxx
+bxx
+bxx
+bxx
 bVN
 cex
 clj
@@ -96028,8 +95704,8 @@ bZP
 blv
 blK
 bqy
-bBg
-bBg
+cfQ
+chj
 bvw
 bVN
 cey
@@ -96284,7 +95960,7 @@ bYu
 bZP
 cay
 cbK
-bBg
+ceJ
 bBg
 bBg
 chz
@@ -96539,12 +96215,12 @@ bZP
 bZP
 bZP
 bZP
+cbH
+cbJ
 bBg
 bBg
 bBg
-bBg
-bBg
-bBg
+cif
 bxD
 bxD
 bxD
@@ -97038,12 +96714,12 @@ bxD
 bBg
 bGr
 bEz
-bTf
+bzv
 bBg
 xuU
 aBP
 nTn
-azv
+beM
 azv
 aSd
 bTd
@@ -97813,7 +97489,7 @@ wMl
 bBg
 xuU
 aGw
-aBt
+aMa
 azv
 aQY
 bTd
@@ -98070,7 +97746,7 @@ wMl
 bBg
 xuU
 aIN
-aBt
+aMa
 bnc
 aQZ
 aUl
@@ -98577,14 +98253,14 @@ bvx
 bvx
 bvx
 bvx
-bvx
+avK
 ahT
 ajv
 bOO
 bBg
 bBg
 bBg
-bHe
+aQm
 bBg
 bBg
 bBg
@@ -98834,14 +98510,14 @@ bvz
 bvz
 bvz
 bvz
-bvz
+aLK
 bCP
 bmm
 ash
 tXD
 tXD
 tXD
-tXD
+aVl
 tXD
 tXD
 tXD

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -9753,6 +9753,7 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "aKE" = (
@@ -10426,6 +10427,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aNq" = (
@@ -10549,6 +10551,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aNG" = (
@@ -10698,6 +10701,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aOs" = (
@@ -11078,6 +11082,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "aPE" = (
@@ -12877,6 +12882,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "aVT" = (
@@ -13959,7 +13965,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bbO" = (
@@ -14564,7 +14569,6 @@
 /area/medical/medbay/central)
 "beR" = (
 /obj/machinery/newscaster/directional/north,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "beT" = (
@@ -14585,14 +14589,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "beW" = (
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "beX" = (
@@ -16481,6 +16479,7 @@
 /area/medical/morgue)
 "bmb" = (
 /obj/structure/noticeboard/directional/south,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "bmc" = (
@@ -16846,6 +16845,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bnh" = (
@@ -17278,6 +17278,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "boI" = (
@@ -19954,6 +19955,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/robotics)
 "bxv" = (
@@ -20160,6 +20162,7 @@
 	name = "Science purple corner"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "bxW" = (
@@ -21085,6 +21088,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "bAN" = (
@@ -21303,6 +21307,9 @@
 	name = "Science Requests Console";
 	receive_ore_updates = 1
 	},
+/obj/structure/table/glass,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/iron/white,
 /area/science/research)
 "bBx" = (
@@ -21745,6 +21752,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "bCM" = (
@@ -23826,6 +23834,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/robotics)
 "bJS" = (
@@ -24490,8 +24499,14 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bNc" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "bNd" = (
@@ -24731,6 +24746,7 @@
 /area/science)
 "bOs" = (
 /obj/machinery/bounty_board/directional/west,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science)
 "bOt" = (
@@ -26418,7 +26434,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bWT" = (
@@ -27297,6 +27312,7 @@
 	name = "Research Camera";
 	network = list("ss13","rd")
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "cbu" = (
@@ -28053,6 +28069,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/science)
 "ceV" = (
@@ -28492,6 +28509,7 @@
 /area/hallway/primary/aft)
 "cha" = (
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/science)
 "chb" = (
@@ -28764,8 +28782,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/start/scientist,
-/obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "cij" = (
@@ -29542,15 +29558,14 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ckV" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "ckX" = (
@@ -29570,6 +29585,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "ckY" = (
@@ -29655,6 +29671,7 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_y = -30
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
 "cli" = (
@@ -29926,6 +29943,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cmc" = (
@@ -40192,6 +40210,7 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/science)
 "cXn" = (
@@ -40670,6 +40689,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"dMC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "dMF" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -40965,6 +40995,13 @@
 /obj/structure/reflector/box,
 /turf/open/floor/engine,
 /area/engineering/main)
+"fcw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "fdV" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -41152,6 +41189,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fIV" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron,
+/area/science)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -43549,6 +43590,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"pKB" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "pKL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -43609,6 +43655,12 @@
 /obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pZL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "pZN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -43717,6 +43769,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"qCD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44875,6 +44935,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"vGs" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "vHB" = (
 /turf/closed/wall/r_wall,
 /area/cargo/storage)
@@ -88508,7 +88572,7 @@ bRH
 bTm
 bSR
 ccT
-cew
+fIV
 ciJ
 bOz
 civ
@@ -89282,7 +89346,7 @@ ciu
 ciu
 ciu
 cbs
-bxG
+bNc
 clh
 cnz
 cmx
@@ -89782,8 +89846,8 @@ bAR
 bKR
 bMG
 beR
-beW
-cmz
+bxG
+bOz
 ciu
 bvJ
 bVF
@@ -90052,9 +90116,9 @@ cXE
 cXE
 ccO
 ciu
-cmz
-ckV
-cmz
+bOz
+bQn
+bOz
 cnz
 coF
 cpA
@@ -90310,8 +90374,8 @@ cXE
 cXE
 ciu
 cha
-bQn
-bOz
+qCD
+pZL
 cnz
 cpa
 cpA
@@ -91580,8 +91644,8 @@ bIl
 bJP
 bIl
 bMG
-bOz
-bxG
+cmz
+bNc
 bmb
 ciu
 cfR
@@ -91594,9 +91658,9 @@ ciu
 ciu
 ciu
 ciu
-bOz
-bQn
-cmy
+cmz
+ckV
+pKB
 cnz
 cqP
 cpI
@@ -91831,7 +91895,7 @@ bzm
 bAT
 bxx
 bOs
-bOz
+beW
 bOz
 bEi
 bOz
@@ -91840,8 +91904,8 @@ blS
 bOz
 bxG
 bOz
-bOz
 cmz
+bOz
 bOz
 bUa
 bOz
@@ -92097,8 +92161,8 @@ aVm
 ldq
 cBY
 ldq
-cgv
-bEB
+fcw
+ldq
 ldq
 aVm
 ldq
@@ -92354,8 +92418,8 @@ bai
 bOz
 bQn
 bOz
-bOz
 cmz
+bOz
 bOz
 bUb
 bez
@@ -93121,7 +93185,7 @@ bHC
 axE
 bKc
 aKy
-bNc
+bOz
 bOz
 bQn
 cmy
@@ -93641,7 +93705,7 @@ bQn
 bOz
 ccA
 bPR
-bTM
+dMC
 bXU
 bVL
 bXU
@@ -94415,7 +94479,7 @@ bZP
 bWS
 bXU
 bXX
-bXU
+vGs
 caO
 caw
 bOz
@@ -95179,8 +95243,8 @@ xuU
 xuU
 xuU
 aPD
-bQn
-bOz
+ckV
+cmz
 bxx
 bZP
 bXU

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -18828,6 +18828,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "btS" = (
@@ -19166,6 +19169,9 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bvd" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science)
 "bvg" = (
@@ -23466,6 +23472,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bIC" = (
@@ -24303,6 +24310,7 @@
 	color = "#990099";
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bLy" = (
@@ -26419,6 +26427,7 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bWL" = (
@@ -29323,6 +29332,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "cki" = (
@@ -29620,6 +29630,7 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "clb" = (
@@ -29656,6 +29667,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "clf" = (
@@ -40587,10 +40599,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"dpl" = (
-/obj/machinery/light/blacklight/directional/south,
-/turf/open/floor/iron/white,
-/area/science)
 "dpr" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 8
@@ -41254,13 +41262,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"fYN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/science)
 "fZf" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line,
@@ -41733,6 +41734,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hME" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "hPD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -41783,12 +41790,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"icq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science)
 "icD" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42504,6 +42505,12 @@
 "kZs" = (
 /turf/closed/wall,
 /area/security/interrogation)
+"lah" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "laG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -42540,10 +42547,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
-"lhv" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
 "ljM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -42657,6 +42660,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
+"lIX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "lJc" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -43030,10 +43044,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
-"njW" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
-/area/science)
 "nke" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43044,11 +43054,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"nko" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/science)
 "nkw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -43716,6 +43721,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
+"qna" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "qqq" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
@@ -43773,6 +43782,11 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/service/bar)
+"qGo" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "qGF" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -44134,6 +44148,13 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"rVW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "rWX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -44167,17 +44188,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"sdQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
 "sgD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -44378,6 +44388,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
+"tkj" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron,
+/area/science)
 "tmp" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -44682,6 +44696,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"uwW" = (
+/obj/machinery/light/blacklight/directional/south,
+/turf/open/floor/iron/white,
+/area/science)
 "uys" = (
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
@@ -44781,6 +44799,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"uWr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "uWs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -45330,14 +45356,6 @@
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
-"xvg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science)
 "xyD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -88576,7 +88594,7 @@ bRH
 bTm
 bSR
 ccT
-njW
+tkj
 ciJ
 bOz
 civ
@@ -90378,8 +90396,8 @@ cXE
 cXE
 ciu
 cha
-xvg
-icq
+uWr
+lah
 cnz
 cpa
 cpA
@@ -91664,7 +91682,7 @@ ciu
 ciu
 cmz
 ckV
-nko
+qGo
 cnz
 cqP
 cpI
@@ -92165,7 +92183,7 @@ aVm
 ldq
 cBY
 ldq
-fYN
+rVW
 ldq
 ldq
 aVm
@@ -93709,7 +93727,7 @@ bQn
 bOz
 ccA
 bPR
-sdQ
+lIX
 bXU
 bVL
 bXU
@@ -93975,7 +93993,7 @@ caw
 bOz
 bOz
 btP
-dpl
+uwW
 bVN
 bpS
 cez
@@ -94483,7 +94501,7 @@ bZP
 bWS
 bXU
 bXX
-lhv
+qna
 caO
 caw
 bOz
@@ -95000,8 +95018,8 @@ bXU
 bXU
 cbF
 caw
-bOz
-bOz
+hME
+hME
 btR
 bvd
 ciK

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -40689,17 +40689,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"dMC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/chair/stool/bar/directional/south,
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
 "dMF" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -40995,13 +40984,6 @@
 /obj/structure/reflector/box,
 /turf/open/floor/engine,
 /area/engineering/main)
-"fcw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/science)
 "fdV" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -41189,10 +41171,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fIV" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron,
-/area/science)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -42545,6 +42523,13 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron,
 /area/maintenance/port/fore)
+"ljb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "ljM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -42748,6 +42733,17 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"mmw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/misc_lab)
 "mnv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/neutral{
@@ -43590,11 +43586,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"pKB" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/science)
 "pKL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -43655,12 +43646,6 @@
 /obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pZL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science)
 "pZN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -43769,14 +43754,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"qCD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+"qCC" = (
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
-/area/science)
+/area/science/misc_lab)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43996,6 +43977,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"rxl" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/science)
 "rEd" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -44935,10 +44921,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"vGs" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/white,
-/area/science/misc_lab)
 "vHB" = (
 /turf/closed/wall/r_wall,
 /area/cargo/storage)
@@ -45202,6 +45184,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"wTU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science)
 "wVc" = (
 /obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -45328,6 +45316,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xrV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/science)
 "xur" = (
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
@@ -45385,6 +45381,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"xFa" = (
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron,
+/area/science)
 "xGE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -88572,7 +88572,7 @@ bRH
 bTm
 bSR
 ccT
-fIV
+xFa
 ciJ
 bOz
 civ
@@ -90374,8 +90374,8 @@ cXE
 cXE
 ciu
 cha
-qCD
-pZL
+xrV
+wTU
 cnz
 cpa
 cpA
@@ -91660,7 +91660,7 @@ ciu
 ciu
 cmz
 ckV
-pKB
+rxl
 cnz
 cqP
 cpI
@@ -92161,7 +92161,7 @@ aVm
 ldq
 cBY
 ldq
-fcw
+ljb
 ldq
 ldq
 aVm
@@ -93705,7 +93705,7 @@ bQn
 bOz
 ccA
 bPR
-dMC
+mmw
 bXU
 bVL
 bXU
@@ -94479,7 +94479,7 @@ bZP
 bWS
 bXU
 bXX
-vGs
+qCC
 caO
 caw
 bOz


### PR DESCRIPTION
Nanites got removed and I didn't want to leave a big empty fucking space, so I re-did science for the third fucking time.

Xenobiology was moved 2 tiles up
Xenobio south maints was made more compact
RD's office moved to the second floor
Genetics moved to where RD's office used to be
Toxins entrance moved
Science second floor's stairs are now connected, quick travel!
Circuits room expanded
Toxins' freezers clip into the walls less
Adds more directionals around Science
Adds more lights around Science

Now Science has RD's office, toxins storage. break room and mech lab on the second floor, as well as an abandoned Robotics.
Doesn't look much but it's still quite a bit of second floor'ing.
Also, RD's office can watch over a ton of the first floor.