### PR TITLE
Medbay part 2 & Engineering Foyer

### DIFF
--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -171,12 +171,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
-"aD" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "aE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -287,6 +281,12 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"bb" = (
+/obj/machinery/modular_computer/console/preset/cargochat/medical{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "bd" = (
 /turf/closed/wall,
 /area/hallway/primary/upper)
@@ -508,6 +508,12 @@
 	icon_state = "wood-broken"
 	},
 /area/service/abandoned_gambling_den)
+"bT" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "bU" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
@@ -1364,10 +1370,6 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/zone2)
-"eK" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "eL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -2032,12 +2034,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"hb" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "hc" = (
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
@@ -2311,6 +2307,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/prison)
+"hU" = (
+/obj/structure/frame/machine{
+	color = "#B392CB"
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron{
+	initial_gas_mix = "n2=104;TEMP=293.15"
+	},
+/area/medical/medbay/zone2)
 "hV" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/iron,
@@ -2809,10 +2814,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"jG" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -2892,6 +2893,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/space)
+"jT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "jV" = (
 /obj/item/radio/intercom/directional/north{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
@@ -3253,10 +3263,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"kV" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "kW" = (
 /obj/structure/railing{
 	dir = 6
@@ -5494,6 +5500,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
+"sj" = (
+/obj/structure/sign/departments/restroom{
+	pixel_x = -30
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "sk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -5675,15 +5687,6 @@
 "sO" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
-"sP" = (
-/obj/structure/frame/machine{
-	color = "#B392CB"
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron{
-	initial_gas_mix = "n2=104;TEMP=293.15"
-	},
-/area/medical/medbay/zone2)
 "sQ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -5779,6 +5782,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
+"tf" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "tg" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -7153,10 +7164,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
-"xJ" = (
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "xK" = (
 /obj/structure/curtain,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -7297,15 +7304,6 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"ye" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "yf" = (
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
@@ -7493,6 +7491,10 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"yU" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "yV" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -30
@@ -8228,6 +8230,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"Bk" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "Bl" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8625,6 +8633,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"CJ" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "CK" = (
 /obj/machinery/door/airlock{
 	name = "Crematorium";
@@ -8969,6 +8981,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"DL" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/white,
+/area/maintenance/starboard/fore)
 "DM" = (
 /obj/effect/turf_decal/arrows/white{
 	dir = 4
@@ -9989,13 +10005,6 @@
 "GK" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
-"GL" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "GM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
@@ -10222,14 +10231,6 @@
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
-"Hs" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "Ht" = (
 /obj/structure/frame/machine{
 	color = "#B392CB"
@@ -10452,10 +10453,6 @@
 "HW" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"HX" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "HY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -12022,6 +12019,13 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"MZ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Na" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -14018,6 +14022,10 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"SP" = (
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "SQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -14426,6 +14434,10 @@
 /obj/item/exodrone,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
+"Uf" = (
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Ug" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
@@ -14469,12 +14481,6 @@
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
-"Us" = (
-/obj/machinery/modular_computer/console/preset/cargochat/medical{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "Ut" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
@@ -57252,7 +57258,7 @@ Jx
 Nf
 gC
 mv
-kV
+CJ
 Wp
 aQ
 Wh
@@ -57765,7 +57771,7 @@ lK
 Vo
 oD
 Vo
-aD
+bT
 JR
 Ho
 wu
@@ -58022,8 +58028,8 @@ PU
 Vo
 oD
 Vo
-aD
-Us
+bT
+bb
 Ho
 xj
 Yj
@@ -58279,8 +58285,8 @@ TI
 Bj
 cy
 Vo
-hb
-Hs
+Bk
+tf
 Ho
 bD
 Jz
@@ -58541,7 +58547,7 @@ Nd
 Cx
 KP
 WH
-GL
+MZ
 Lu
 PV
 MF
@@ -59039,7 +59045,7 @@ wM
 ES
 Vo
 ov
-Vo
+sj
 jE
 XV
 XV
@@ -60067,7 +60073,7 @@ fK
 aK
 Pb
 Co
-HX
+yU
 Vo
 VF
 VF
@@ -60336,7 +60342,7 @@ on
 qN
 Vo
 cd
-eK
+Uf
 rQ
 ZX
 jz
@@ -61100,7 +61106,7 @@ Vo
 dT
 dT
 Ft
-jG
+DL
 XV
 cW
 Vo
@@ -61622,7 +61628,7 @@ Vo
 Vo
 Vo
 Bj
-ye
+jT
 Vo
 Mg
 XV
@@ -64709,7 +64715,7 @@ ct
 xV
 Vo
 Vo
-xJ
+SP
 Vo
 Vo
 Vo
@@ -64719,7 +64725,7 @@ Ir
 jt
 Nj
 Gu
-sP
+hU
 Dw
 EX
 EX

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -13441,7 +13441,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "PV" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/security/checkpoint/medical)
 "PW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -59277,8 +59277,8 @@ yj
 SY
 wS
 PM
-XV
-XV
+Wy
+Wy
 PV
 VA
 VA
@@ -59539,7 +59539,7 @@ MM
 bE
 ou
 qA
-XV
+Wy
 MF
 MF
 MF
@@ -59796,7 +59796,7 @@ zy
 aa
 Oq
 vP
-XV
+Wy
 MF
 Lj
 TZ
@@ -60053,7 +60053,7 @@ wU
 ZE
 uk
 vt
-XV
+Wy
 MF
 Qs
 MF
@@ -60310,7 +60310,7 @@ iV
 aa
 tp
 tC
-XV
+Wy
 MF
 Qs
 Fx
@@ -60567,7 +60567,7 @@ aM
 aa
 aa
 Ru
-XV
+Wy
 MF
 Qs
 cT
@@ -60824,7 +60824,7 @@ Uf
 rQ
 ZX
 jz
-XV
+Wy
 MF
 LR
 cT
@@ -61081,7 +61081,7 @@ Jl
 TO
 bK
 PE
-XV
+Wy
 MF
 LR
 cT
@@ -61333,12 +61333,12 @@ hF
 Vo
 qN
 RD
-XV
+Wy
 cd
 ek
 cd
 cd
-XV
+Wy
 MF
 LR
 cT

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -658,6 +658,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "cz" = (
@@ -2286,6 +2287,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/space)
+"hS" = (
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "hT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3506,6 +3511,15 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
+"lN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "lO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5752,6 +5766,7 @@
 /area/science/research/abandoned)
 "th" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "ti" = (
@@ -6975,6 +6990,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "xk" = (
@@ -7448,6 +7464,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"yW" = (
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "yY" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -8182,6 +8202,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"Bm" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8401,6 +8425,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/landmark/start/virologist,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Ck" = (
@@ -59987,7 +60012,7 @@ fK
 aK
 Pb
 Co
-Vo
+Bm
 Vo
 VF
 VF
@@ -60256,7 +60281,7 @@ on
 qN
 Vo
 cd
-Vo
+yW
 rQ
 ZX
 jz
@@ -61542,7 +61567,7 @@ Vo
 Vo
 Vo
 Bj
-dp
+lN
 Vo
 Mg
 XV
@@ -64629,7 +64654,7 @@ ct
 xV
 Vo
 Vo
-Vo
+hS
 Vo
 Vo
 Vo
@@ -67715,7 +67740,7 @@ TY
 Hu
 zX
 Hu
-Hu
+xz
 Hu
 NC
 Hu

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -1,4 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "ab" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/visit)
@@ -19,6 +22,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ah" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ai" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -179,6 +193,10 @@
 "aL" = (
 /turf/open/openspace,
 /area/medical/psychology)
+"aM" = (
+/obj/machinery/suit_storage_unit/cmo,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "aN" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -187,16 +205,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"aP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+"aQ" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "aR" = (
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/engine,
@@ -206,14 +218,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"aT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "aV" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -350,13 +354,6 @@
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"br" = (
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "bs" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/directional/south,
@@ -401,6 +398,12 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"bA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "bB" = (
 /obj/machinery/button/door/directional/south{
 	id = "permafrontshutters";
@@ -409,6 +412,21 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"bD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"bE" = (
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer"
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "bF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -433,27 +451,11 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
-"bJ" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Access";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "bK" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/turf/open/openspace,
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "bL" = (
 /obj/structure/industrial_lift,
@@ -541,6 +543,14 @@
 /obj/machinery/plate_press,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"cd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "CMO Office"
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/zone2)
 "ce" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -585,8 +595,11 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "cl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/openspace,
 /area/medical/medbay/zone2)
 "cm" = (
 /obj/structure/chair/office{
@@ -634,7 +647,7 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/hallway/primary/upper)
-"cx" = (
+"cy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -710,6 +723,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"cI" = (
+/obj/structure/table/optable,
+/obj/item/toy/figure/md,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "cJ" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -782,25 +801,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
-"cW" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp/cmo,
-/obj/item/stamp/denied,
-/obj/machinery/keycard_auth{
-	pixel_x = -5;
-	pixel_y = -25
-	},
-/obj/machinery/button/door/directional/east{
-	id = "cmoprivacy";
-	name = "CMO Shutter Control";
-	pixel_x = 8;
-	pixel_y = -24;
-	req_access_txt = "40"
-	},
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
 "cZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance";
@@ -827,18 +827,20 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "dc" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/machinery/door/airlock/medical{
+	name = "Surgery B";
+	req_access_txt = "5"
 	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet2";
-	name = "Stall B Button";
-	pixel_y = -7;
-	req_access_txt = "2"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "dd" = (
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
@@ -887,6 +889,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"dp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "dq" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
@@ -903,6 +913,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"ds" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "dt" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -929,16 +945,6 @@
 "dw" = (
 /turf/open/floor/iron,
 /area/cargo/office)
-"dx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "dA" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -1025,15 +1031,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
-"dM" = (
-/obj/machinery/button/door/directional/east{
-	id = "surgeryblock";
-	name = "Privacy Button";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "dO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -1052,6 +1049,13 @@
 "dS" = (
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"dT" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "dU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -1074,6 +1078,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"dX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dY" = (
 /obj/machinery/camera{
 	c_tag = "Restroom - Unisex";
@@ -1141,6 +1155,12 @@
 /obj/machinery/gibber,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
+"eg" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "eh" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -1154,11 +1174,20 @@
 /turf/open/floor/iron,
 /area/security/office)
 "ek" = (
-/obj/structure/chair{
-	pixel_y = -2
+/obj/machinery/door/airlock/command{
+	name = "Chief Medical Officer's Office";
+	req_access_txt = "40"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/medbay/zone2)
 "el" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/white,
@@ -1189,6 +1218,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/space)
+"es" = (
+/obj/structure/table,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "et" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Xenobiology Kill Room";
@@ -1258,6 +1299,14 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"eJ" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "eL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1282,15 +1331,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"eP" = (
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/camera{
-	c_tag = "CMO";
-	dir = 1;
-	name = "CMO Camera";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/glass/reinforced,
+"eO" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "eQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1337,21 +1381,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
-"eX" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
-"eY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "eZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -1368,6 +1397,16 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"fe" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/starboard/fore)
 "ff" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -1415,6 +1454,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"fn" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet1";
+	name = "Stall A Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "fo" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1429,6 +1481,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"fu" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "fv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -1525,12 +1586,6 @@
 "fK" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"fL" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "fM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1564,19 +1619,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"fP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/multiz/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"fR" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/openspace,
-/area/medical/medbay/zone2)
 "fS" = (
 /obj/structure/railing{
 	dir = 4
@@ -1705,28 +1763,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"gk" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "gl" = (
 /turf/closed/wall,
 /area/service/library/private)
-"gm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "gn" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -1801,10 +1840,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"gz" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "gA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1823,12 +1858,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "gC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/structure/table/glass,
+/obj/item/scalpel,
+/obj/item/retractor,
+/obj/effect/turf_decal/siding/blue{
+	color = "#73c2fb";
+	name = "medical blue"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
@@ -1980,6 +2015,12 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"hj" = (
+/obj/machinery/defibrillator_mount{
+	pixel_x = -28
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "hk" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -2107,6 +2148,24 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
+"hF" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"hG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "hH" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -2150,11 +2209,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"hN" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "hO" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -2181,10 +2235,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/space)
-"hS" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "hT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2192,10 +2242,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/prison)
-"hU" = (
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "hV" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/iron,
@@ -2269,12 +2315,17 @@
 	},
 /turf/open/floor/carpet/green,
 /area/space)
-"ik" = (
-/obj/structure/railing/corner{
-	dir = 1
+"ij" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/medbay/zone2)
 "il" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -2343,6 +2394,10 @@
 /obj/item/kitchen/knife/plastic,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"iw" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "iy" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Freezer";
@@ -2401,6 +2456,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"iJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "iK" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -2435,6 +2496,16 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/space)
+"iR" = (
+/obj/machinery/camera{
+	c_tag = "Surgery B";
+	dir = 4;
+	name = "Surgery B Camera";
+	network = list("ss13","medbay")
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "iS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -2451,12 +2522,9 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "iV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/closet/secure_closet/chief_medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "iW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2530,23 +2598,10 @@
 /obj/item/toy/plush/supermatter,
 /turf/open/floor/iron,
 /area/security/prison)
-"jj" = (
-/obj/machinery/modular_computer/console/preset/id,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "jk" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"jl" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "jm" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
@@ -2562,11 +2617,8 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "jp" = (
-/obj/item/toy/cattoy,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "jr" = (
@@ -2641,6 +2693,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
+"jz" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "jB" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
@@ -2649,20 +2706,8 @@
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/space)
-"jD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
-"jG" = (
-/obj/structure/table/glass,
-/obj/item/scalpel,
-/obj/item/retractor,
-/obj/effect/turf_decal/siding/blue{
-	color = "#73c2fb";
-	name = "medical blue"
-	},
+"jE" = (
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "jH" = (
@@ -2752,17 +2797,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"jW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "jX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -2894,15 +2928,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"ks" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	dir = 4;
-	name = "Security Medbay monitor";
-	network = list("medbay")
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "kt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -2977,6 +3002,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"kC" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "kD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -2985,9 +3017,14 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
-"kE" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/airalarm/directional/south,
+"kF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "kG" = (
@@ -3031,13 +3068,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"kL" = (
-/obj/machinery/light/directional/south,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "kM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -3182,16 +3212,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/space)
-"le" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "lf" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/tile{
@@ -3205,6 +3225,16 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"lg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lh" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -3230,16 +3260,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/garden)
-"ll" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "ln" = (
 /turf/closed/wall,
 /area/security/prison/work)
@@ -3390,18 +3410,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"lK" = (
+/obj/structure/table,
+/obj/item/gun/syringe,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "lL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
-"lM" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/openspace,
-/area/medical/medbay/zone2)
 "lO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3434,10 +3454,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
-"lR" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "lS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -3561,11 +3577,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"mg" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
 "mh" = (
 /obj/structure/table/glass,
 /obj/item/stack/ducts/fifty,
@@ -3650,21 +3661,6 @@
 "mw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/medical/medbay/zone2)
-"mx" = (
-/obj/machinery/door/airlock/medical{
-	name = "Surgery B";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "my" = (
 /obj/structure/bed,
@@ -3770,16 +3766,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"mQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
+"mS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/psychology)
 "mT" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Emergency Room";
@@ -3802,9 +3798,7 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "mW" = (
-/obj/structure/table/glass,
-/obj/item/hemostat,
-/obj/item/cautery,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "mX" = (
@@ -3912,11 +3906,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
-"np" = (
-/obj/structure/table,
-/obj/item/gun/syringe,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/clothing/neck/stethoscope,
+"no" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "nq" = (
@@ -3925,12 +3918,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
-"nr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/glass/reinforced,
 /area/medical/medbay/zone2)
 "ns" = (
 /obj/structure/table,
@@ -3946,10 +3933,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"nu" = (
-/obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "nv" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
@@ -4117,17 +4100,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/medical/virology)
-"ob" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Virology Access";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "od" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -4186,14 +4158,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/service/library/printer)
-"oq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "os" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -4206,6 +4170,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"ou" = (
+/obj/machinery/light/directional/west,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "ov" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -4237,7 +4209,13 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "oD" = (
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "oE" = (
@@ -4258,8 +4236,7 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "oJ" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
+/obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "oK" = (
@@ -4428,6 +4405,11 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"pk" = (
+/obj/structure/table/optable,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "pl" = (
 /obj/structure/railing,
 /turf/open/floor/iron/white,
@@ -4565,6 +4547,13 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"pG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Security Post Maint";
+	req_access_txt = "63;12"
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/starboard/fore)
 "pH" = (
 /obj/structure/sign/warning/xeno_mining{
 	pixel_x = 30
@@ -4672,6 +4661,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"pY" = (
+/obj/structure/table/wood,
+/obj/machinery/camera{
+	c_tag = "Psychology";
+	name = "Psychology Camera";
+	network = list("ss13","medbay")
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "pZ" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -4799,13 +4800,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"qp" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
 "qq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -4862,16 +4856,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/security/office)
-"qw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/starboard)
 "qx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -4886,6 +4870,25 @@
 	},
 /turf/open/floor/wood,
 /area/service/theater)
+"qA" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stamp/cmo,
+/obj/item/stamp/denied,
+/obj/machinery/keycard_auth{
+	pixel_x = -5;
+	pixel_y = -25
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cmoprivacy";
+	name = "CMO Shutter Control";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access_txt = "40"
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "qB" = (
 /obj/structure/window{
 	dir = 4
@@ -4915,6 +4918,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
+"qH" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "qI" = (
 /obj/structure/chair{
 	dir = 4
@@ -4942,13 +4949,14 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "qN" = (
-/obj/machinery/requests_console/directional/west{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/glass/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "qQ" = (
 /obj/structure/table/wood,
@@ -4956,11 +4964,6 @@
 /obj/item/storage/fancy/cigarettes/cigars,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"qR" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "qS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5070,6 +5073,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"rm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ro" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -5082,6 +5094,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"rq" = (
+/obj/structure/table/glass,
+/obj/item/surgical_drapes,
+/obj/item/book/manual/wiki/surgery,
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "rr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -5099,13 +5118,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"rt" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/openspace,
-/area/medical/medbay/zone2)
 "rv" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -5237,6 +5249,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"rN" = (
+/obj/structure/table/glass,
+/obj/item/hemostat,
+/obj/item/cautery,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "rO" = (
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -5251,6 +5269,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"rQ" = (
+/obj/item/toy/cattoy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "rR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -5297,10 +5323,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"rX" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "rY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -5309,12 +5331,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/space)
-"sa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "sb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -5374,14 +5390,16 @@
 /obj/item/toy/mecha/ripley,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
-"so" = (
-/obj/machinery/light/directional/west,
-/obj/structure/chair/office/light{
-	dir = 4
+"sn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
+/turf/open/floor/iron/white,
+/area/maintenance/starboard)
 "sq" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
@@ -5407,15 +5425,6 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"st" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "su" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/blue,
@@ -5468,6 +5477,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/service/theater)
+"sF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "sG" = (
 /obj/structure/window{
 	dir = 1
@@ -5502,13 +5521,8 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
-"sJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+"sM" = (
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "sN" = (
@@ -5581,6 +5595,15 @@
 "sY" = (
 /turf/open/floor/circuit/telecomms,
 /area/maintenance/department/science/xenobiology)
+"sZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ta" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -5673,11 +5696,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "tp" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/obj/machinery/holopad,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "tq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5702,6 +5723,12 @@
 "tv" = (
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"tx" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "ty" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -5720,6 +5747,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"tC" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/camera{
+	c_tag = "CMO";
+	dir = 1;
+	name = "CMO Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "tD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -5744,12 +5781,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"tJ" = (
+"tK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/medbay/zone2)
 "tL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -5760,6 +5802,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"tM" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Access";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "tN" = (
 /obj/machinery/light/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -5896,10 +5953,15 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "uk" = (
-/obj/structure/table/optable,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
 /area/medical/medbay/zone2)
+"ul" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "um" = (
 /obj/structure/bed/dogbed/cayenne{
 	name = "Lia's bed"
@@ -6003,10 +6065,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"uy" = (
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "uA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard/fifty,
@@ -6026,12 +6084,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"uE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "uF" = (
 /obj/structure/railing{
 	dir = 8
@@ -6052,12 +6104,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
-"uJ" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "uK" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet/green,
@@ -6209,11 +6255,6 @@
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"vk" = (
-/obj/structure/cable,
-/obj/machinery/light/blacklight/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "vl" = (
 /obj/structure/chair{
 	dir = 4
@@ -6221,6 +6262,17 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
+"vm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Virology Access";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "vo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/chair/office,
@@ -6244,6 +6296,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"vt" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "vv" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -6340,6 +6399,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/office)
+"vJ" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "vK" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -6366,6 +6430,16 @@
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"vP" = (
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "vQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -6394,37 +6468,15 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/service/bar)
-"vU" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "vV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/holodeck/rec_center)
 "vW" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychology";
-	req_access_txt = "70"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/medbay/zone2)
 "vX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Emergency Room"
@@ -6453,11 +6505,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "wd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -6466,31 +6517,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
-"wf" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office";
-	req_access_txt = "40"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
-"wg" = (
-/obj/machinery/camera{
-	c_tag = "Surgery B";
-	dir = 4;
-	name = "Surgery B Camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "wh" = (
 /obj/machinery/camera{
 	c_tag = "Security Office - Table";
@@ -6591,6 +6617,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"wu" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "wv" = (
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
@@ -6655,12 +6686,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"wF" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "wH" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -6725,6 +6750,14 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"wS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "wT" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6735,6 +6768,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wU" = (
+/obj/machinery/modular_computer/console/preset/id,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "wW" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
@@ -6802,8 +6839,13 @@
 /turf/open/floor/iron/white,
 /area/commons/dorms)
 "xj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "xk" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6842,12 +6884,6 @@
 /obj/machinery/mechpad,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"xo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "xp" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -7034,19 +7070,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
-"xV" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet1";
-	name = "Stall A Button";
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "xW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -7119,6 +7142,16 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"yj" = (
+/obj/structure/closet/secure_closet/medical3,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"yk" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ym" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
@@ -7178,10 +7211,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
-"yx" = (
-/obj/machinery/computer/med_data,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "yz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -7208,11 +7237,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/cargo/warehouse)
-"yD" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "yF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -7252,6 +7276,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"yO" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "yP" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry W";
@@ -7276,13 +7308,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"yU" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "yV" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -30
@@ -7296,16 +7321,6 @@
 "yZ" = (
 /turf/open/openspace,
 /area/hallway/secondary/service)
-"za" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "zb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -7316,12 +7331,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"zc" = (
-/obj/structure/table/optable,
-/obj/item/toy/figure/md,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "zf" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
@@ -7365,11 +7374,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"zj" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+"zk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "surgeryblock";
+	name = "Surgery B Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "zl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -7384,18 +7396,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
-"zn" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "zo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -7459,6 +7459,23 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"zx" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet2";
+	name = "Stall B Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
+"zy" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zz" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/structure/cable,
@@ -7490,12 +7507,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"zC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "zD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -7512,14 +7523,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"zH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "CMO Office"
-	},
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "zI" = (
 /obj/machinery/camera{
 	c_tag = "Prison - Court E";
@@ -7543,12 +7546,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "zK" = (
-/obj/structure/table/glass,
-/obj/item/surgical_drapes,
-/obj/item/book/manual/wiki/surgery,
-/obj/machinery/vending/wallmed/directional/south,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/security/checkpoint/medical)
 "zL" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light/directional/east,
@@ -7566,11 +7566,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
-"zO" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/status_display/ai/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "zP" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -8045,6 +8040,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/space)
+"Bj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Bl" = (
 /obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8094,13 +8093,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
-"By" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "Bz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -8117,6 +8109,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"BF" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "BG" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
@@ -8141,18 +8138,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"BL" = (
-/obj/structure/table,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "BM" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
@@ -8199,13 +8184,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
-"BU" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Security Post Maint";
-	req_access_txt = "63;12"
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
 "BV" = (
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -8634,12 +8612,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
-"Dh" = (
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Di" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8859,6 +8831,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"DU" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "DV" = (
 /obj/machinery/camera{
 	c_tag = "Security Office";
@@ -8908,10 +8885,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"Ed" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Ee" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -8947,6 +8920,20 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/space)
+"El" = (
+/obj/machinery/door/airlock/medical{
+	name = "Psychology";
+	req_access_txt = "70"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "Eo" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -9351,6 +9338,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"Ft" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "Fv" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -9417,6 +9416,23 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"FD" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "FE" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -9796,8 +9812,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "GP" = (
+/obj/structure/table/glass,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medigel/sterilizine,
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/medbay/zone2)
 "GQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -9834,10 +9854,6 @@
 /obj/structure/urinal/directional/north,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"GV" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
 "GW" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -9956,6 +9972,19 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/commons/dorms)
+"Ho" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
+"Hp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "Hq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/tequila{
@@ -9971,11 +10000,6 @@
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
-"Hs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Ht" = (
 /obj/structure/frame/machine{
 	color = "#B392CB"
@@ -10155,6 +10179,15 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"HT" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	dir = 4;
+	name = "Security Medbay monitor";
+	network = list("medbay")
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "HU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -10255,17 +10288,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/wood,
 /area/service/library/printer)
-"Ii" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Ij" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -10592,16 +10614,27 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"Jk" = (
+"Jj" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"Jl" = (
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/runtime,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"Jm" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Jn" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio2";
@@ -10624,10 +10657,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
-"Jq" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Jr" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_x = -32
@@ -10649,23 +10678,27 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"Jx" = (
+/obj/machinery/button/door/directional/east{
+	id = "surgeryblock";
+	name = "Privacy Button";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Jy" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "Jz" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/security/checkpoint/medical)
 "JA" = (
 /turf/open/floor/plating/airless,
 /area/commons/toilet)
 "JB" = (
-/obj/structure/cable/multilayer/multiz,
+/obj/structure/noticeboard/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "JC" = (
@@ -10760,7 +10793,7 @@
 /turf/open/floor/iron,
 /area/security/prison/work)
 "JR" = (
-/obj/machinery/vending/medical,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "JT" = (
@@ -10914,13 +10947,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"Kp" = (
-/obj/structure/table/glass,
-/obj/item/surgical_drapes,
-/obj/item/reagent_containers/medigel/sterilizine,
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Kq" = (
 /obj/machinery/door/airlock{
 	id_tag = "Green Dorm";
@@ -11035,12 +11061,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"KI" = (
-/obj/machinery/defibrillator_mount{
-	pixel_x = -28
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "KL" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -11078,9 +11098,12 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "KP" = (
-/obj/machinery/suit_storage_unit/cmo,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/security/checkpoint/medical)
 "KQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -11206,6 +11229,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"Lj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "Lk" = (
 /obj/effect/spawner/lootdrop/prison_contraband,
 /obj/structure/table,
@@ -11213,11 +11246,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"Ll" = (
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Lm" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
@@ -11282,6 +11310,12 @@
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
+"Lu" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Lv" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -11290,29 +11324,31 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"Lx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "surgeryblock";
+	name = "Surgery B Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/zone2)
 "Ly" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"Lz" = (
-/obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Psychology";
-	name = "Psychology Camera";
-	network = list("ss13","medbay")
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "LC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"LD" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "LF" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -11402,15 +11438,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
-"LT" = (
-/obj/structure/table/glass,
-/obj/item/cartridge/medical,
-/obj/item/cartridge/medical,
-/obj/item/cartridge/medical,
-/obj/item/cartridge/chemistry,
-/obj/item/toy/figure/cmo,
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
+"LR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "LU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -11496,6 +11532,14 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"Mg" = (
+/obj/structure/sink{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Mh" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -11579,11 +11623,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "My" = (
-/obj/structure/table,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/bodybags,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/psychology)
 "Mz" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -11626,14 +11670,6 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/iron/white,
 /area/service/theater)
-"MD" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/openspace,
-/area/medical/medbay/zone2)
 "ME" = (
 /turf/open/floor/plating,
 /area/cargo/warehouse)
@@ -11669,16 +11705,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"MK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ML" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -11688,21 +11714,10 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "MM" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/computer/crew,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "MN" = (
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -11743,14 +11758,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"MT" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
-"MU" = (
-/obj/machinery/computer/operating,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "MV" = (
 /obj/structure/sign/poster/official/space_cops{
 	pixel_y = 30
@@ -11862,19 +11869,9 @@
 /turf/open/floor/plating,
 /area/medical/virology)
 "Nn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/machinery/light/directional/north,
+/obj/machinery/computer/operating,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/medbay/zone2)
 "No" = (
 /obj/effect/spawner/randomarcade{
 	dir = 8
@@ -11948,16 +11945,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"NA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "NB" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -12009,10 +11996,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"NG" = (
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "NH" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -12054,7 +12037,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "NP" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/shower{
+	dir = 1;
+	name = "emergency shower"
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "NQ" = (
@@ -12168,12 +12154,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
-"Ok" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "Ol" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -12204,6 +12184,15 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"Oq" = (
+/obj/structure/table/glass,
+/obj/item/cartridge/medical,
+/obj/item/cartridge/medical,
+/obj/item/cartridge/medical,
+/obj/item/cartridge/chemistry,
+/obj/item/toy/figure/cmo,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "Os" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -12306,12 +12295,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/work)
-"OH" = (
-/obj/structure/industrial_lift{
-	id = "publicElevator"
-	},
-/turf/open/openspace,
-/area/medical/medbay/zone2)
 "OI" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -12627,17 +12610,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"Px" = (
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"Py" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Pz" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/asteroid/airless,
@@ -12684,6 +12656,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"PE" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "PF" = (
 /obj/machinery/camera{
 	c_tag = "Outer Psychology";
@@ -12734,6 +12711,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"PM" = (
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "PN" = (
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
@@ -12758,16 +12739,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"PR" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/neck/stethoscope,
-/obj/machinery/computer/security/telescreen/cmo{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
 "PS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
@@ -12783,6 +12754,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"PU" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "PV" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
@@ -12928,20 +12912,15 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "Qs" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
-"Qt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "Qu" = (
 /obj/structure/window{
 	dir = 8
@@ -13040,6 +13019,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"QI" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "QJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13060,12 +13046,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"QO" = (
-/obj/machinery/computer/crew,
-/obj/machinery/light_switch/directional/west,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "QP" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/south,
@@ -13184,6 +13164,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/space)
+"Ri" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Rj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/directional/north{
@@ -13231,6 +13215,10 @@
 "Rp" = (
 /turf/open/floor/iron/white,
 /area/security/prison/work)
+"Rr" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Rs" = (
 /obj/effect/spawner/randomarcade{
 	dir = 8
@@ -13250,12 +13238,9 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "Ru" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryblock";
-	name = "Surgery B Privacy Door"
-	},
-/turf/open/floor/plating,
+/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/glass/reinforced,
 /area/medical/medbay/zone2)
 "Rv" = (
 /obj/item/plunger,
@@ -13281,6 +13266,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"RB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
+"RD" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "RE" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -13345,6 +13344,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"RL" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "RM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -13536,9 +13542,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"Sj" = (
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
 "Sk" = (
 /obj/structure/railing{
 	dir = 4
@@ -13642,10 +13645,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"Sx" = (
-/obj/structure/closet/secure_closet/chief_medical,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Sy" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -13769,6 +13768,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"SY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "SZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -13844,10 +13847,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/research/abandoned)
-"Tn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "To" = (
 /obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/iron,
@@ -13940,16 +13939,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"TC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
 "TD" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -13960,10 +13949,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
-"TF" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "TG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -13977,6 +13962,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
+"TI" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "TK" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hos)
@@ -14009,10 +14000,12 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "TO" = (
-/obj/structure/sink{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = -8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
@@ -14174,15 +14167,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"Uv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/psychology)
 "Uw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -14376,6 +14360,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
+"Va" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "Vb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -14588,6 +14579,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"VA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "CMO Office"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "VB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -14628,16 +14627,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
-"VJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "VK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -14752,6 +14741,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"Wh" = (
+/obj/structure/industrial_lift{
+	id = "publicElevator"
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "Wj" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -14893,6 +14888,12 @@
 "WG" = (
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
+"WH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "WI" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -14949,6 +14950,11 @@
 /obj/item/stamp/denied,
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
+"WR" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "WS" = (
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
@@ -14975,10 +14981,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"WX" = (
-/obj/structure/noticeboard/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "WY" = (
 /obj/machinery/plate_press,
 /obj/structure/sign/poster/contraband/random{
@@ -15101,12 +15103,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/range)
-"Xn" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "Xo" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -15145,14 +15141,6 @@
 "Xv" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"Xw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "CMO Office"
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/zone2)
 "Xx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/closed/wall,
@@ -15391,6 +15379,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"Yj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Yk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -15417,6 +15411,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"Yn" = (
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Yo" = (
 /obj/structure/chair{
 	dir = 4
@@ -15447,6 +15445,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"Yu" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Yv" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -15462,10 +15464,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"Yw" = (
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Yx" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -15589,10 +15587,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
-"YQ" = (
-/obj/machinery/holopad,
-/turf/open/floor/glass/reinforced,
-/area/medical/medbay/zone2)
 "YR" = (
 /obj/machinery/atmospherics/pipe/multiz/dark/visible{
 	dir = 8
@@ -15601,14 +15595,6 @@
 /area/engineering/atmos/upper)
 "YS" = (
 /turf/open/openspace,
-/area/medical/medbay/zone2)
-"YU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "YV" = (
 /obj/machinery/flasher/directional/south{
@@ -15807,6 +15793,10 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"ZE" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "ZG" = (
 /obj/structure/bed,
 /obj/machinery/camera{
@@ -15837,10 +15827,12 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "ZK" = (
-/obj/structure/table,
-/obj/machinery/recharger,
+/obj/machinery/light/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/psychology)
 "ZL" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -15864,6 +15856,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
+"ZP" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ZQ" = (
 /obj/machinery/button/flasher{
 	id = "Cell 3";
@@ -15911,6 +15907,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"ZU" = (
+/obj/structure/cable,
+/obj/machinery/light/blacklight/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ZV" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -15939,13 +15940,12 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ZX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryblock";
-	name = "Surgery B Privacy Door"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ZY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -56155,14 +56155,14 @@ HW
 HW
 HW
 XV
-MU
-KI
-Yw
-Jz
-wg
-Ed
-KI
-Dh
+Nn
+hj
+mW
+yO
+iR
+sM
+hj
+yk
 XV
 MF
 MF
@@ -56412,14 +56412,14 @@ HW
 HW
 HW
 XV
-uk
+pk
 Vo
-sJ
-hN
+rm
+BF
 Es
-zC
+bA
 Vo
-zc
+cI
 XV
 MF
 MF
@@ -56669,21 +56669,21 @@ HW
 HW
 HW
 XV
-Kp
+GP
 Vo
-st
-mW
-mW
+sZ
+rN
+rN
 Vo
 Vo
-zK
+rq
 XV
 MF
 MF
 MF
 MF
 Jo
-Lz
+pY
 ZN
 ZN
 Qp
@@ -56926,14 +56926,14 @@ HW
 HW
 HW
 XV
-fL
-dM
-Jk
-jG
-jG
+eg
+Jx
+oD
+gC
+gC
 Vo
 Vo
-NP
+aQ
 XV
 MF
 MF
@@ -57177,7 +57177,7 @@ IB
 KC
 KC
 XA
-xV
+fn
 ES
 HW
 HW
@@ -57185,21 +57185,21 @@ HW
 XV
 XV
 XV
-mx
-Ru
-Ru
-Ru
-ZX
-ZX
+dc
+Lx
+Lx
+Lx
+zk
+zk
 PV
 PV
 PV
 PV
 MF
 Jo
-eX
+DU
 ZN
-jD
+iJ
 Qp
 Dx
 eQ
@@ -57440,21 +57440,21 @@ HW
 HW
 HW
 XV
-np
+lK
 Vo
-Jk
+oD
 Vo
 Vo
-Qs
-xj
-ZK
-ks
-uy
-Px
+JR
+Ho
+wu
+HT
+Yn
+zK
 PV
 MF
 Jo
-TF
+ul
 ZN
 vb
 Rg
@@ -57691,29 +57691,29 @@ Mh
 Mh
 Ss
 XG
-dc
+zx
 ES
 HW
 HW
 HW
 XV
-vU
+PU
 Vo
-Jk
+oD
 Vo
 Vo
 Vo
+Ho
 xj
-gk
-Ok
-Xn
+Yj
+Jm
 Jp
 PV
 MF
 Jo
 ZN
 ZN
-Uv
+Hp
 Qp
 dF
 Jo
@@ -57954,22 +57954,22 @@ HW
 HW
 HW
 XV
-My
-Tn
-cx
+TI
+Bj
+cy
 Vo
 Vo
 Vo
-xj
-tJ
-GP
+Ho
+bD
+Jz
 pC
 pC
 PV
 MF
 Jo
 vj
-zj
+WR
 gA
 ym
 AC
@@ -58211,23 +58211,23 @@ HW
 HW
 HW
 XV
-BL
+es
 Vo
-VJ
+kF
 Nd
 Nd
 Nd
 Cx
-By
-sa
-tp
-tp
+KP
+WH
+Lu
+Lu
 PV
 MF
 Jo
 Jo
 Jo
-vW
+El
 Jo
 Jo
 Jo
@@ -58468,26 +58468,26 @@ HW
 HW
 HW
 XV
-nu
-cl
-YU
-NG
+yj
+SY
+wS
+PM
 XV
 XV
 PV
-zH
-zH
+VA
+VA
 PV
-BU
+pG
 PV
 MF
 Jo
-ek
+LD
 gA
 St
 dW
 Nl
-wF
+My
 Bf
 Bb
 Bb
@@ -58725,26 +58725,26 @@ HW
 HW
 HW
 XV
-qR
+vJ
 Vo
-Jk
+oD
 Vo
-Xw
-QO
-qN
-so
-cW
+cd
+MM
+bE
+ou
+qA
 XV
 MF
 MF
 MF
 Jo
-Nn
-gm
+hG
+RB
 vz
 hL
 FZ
-kL
+ZK
 Bf
 Bb
 Bb
@@ -58976,33 +58976,33 @@ LQ
 Nd
 UK
 Vo
+iw
+XV
+HW
+HW
+HW
+XV
+jp
+Vo
 oD
-XV
-HW
-HW
-HW
-XV
-zO
 Vo
-Jk
-Vo
-Xw
-yx
-Sj
-LT
-PR
+cd
+zy
+aa
+Oq
+vP
 XV
 MF
-le
+Lj
 TZ
-TC
-eY
+fe
+mS
 ZN
 ZN
 ZN
 xL
 IN
-qw
+sn
 OJ
 Bb
 Bb
@@ -59240,17 +59240,17 @@ XV
 Vq
 XV
 XV
-gz
-Qt
-gz
-Xw
-jj
-GV
-nr
-qp
+qH
+tK
+qH
+cd
+wU
+ZE
+uk
+vt
 XV
 MF
-MK
+Qs
 MF
 Jo
 PF
@@ -59258,7 +59258,7 @@ sS
 aL
 aL
 aL
-uJ
+tx
 Bf
 Nv
 bN
@@ -59492,22 +59492,22 @@ ov
 Vo
 Vo
 Vo
-Jq
+RD
 XV
 Vo
 Vo
 XV
-hS
-Jk
+Ri
+oD
 Vo
-Xw
-Sx
-Sj
-YQ
-eP
+cd
+iV
+aa
+tp
+tC
 XV
 MF
-MK
+Qs
 Fx
 Jo
 Jo
@@ -59515,7 +59515,7 @@ sS
 aL
 aL
 aL
-uJ
+tx
 Bf
 ce
 Bb
@@ -59750,21 +59750,21 @@ zl
 zl
 VF
 VF
-ob
+vm
 zl
 zl
-ob
+vm
 zl
 UK
 Vo
-Xw
-KP
-Sj
-Sj
-mg
+cd
+aM
+aa
+aa
+Ru
 XV
 MF
-MK
+Qs
 cT
 CL
 Jo
@@ -59772,7 +59772,7 @@ hf
 ci
 ci
 ci
-ik
+ds
 Bf
 ce
 Bb
@@ -60011,17 +60011,17 @@ XV
 Vo
 Vo
 XV
-hU
-ll
+jE
+qN
 Vo
-Xw
+cd
 Vo
-jp
-Py
-oJ
+rQ
+ZX
+jz
 XV
 MF
-wc
+LR
 cT
 CL
 Jo
@@ -60265,20 +60265,20 @@ Vo
 YS
 YS
 XV
-iV
+kC
 XV
 XV
-yD
-ll
+eO
+qN
 Vo
-Xw
-Ll
-mQ
-xo
-kE
+cd
+Jl
+TO
+bK
+PE
 XV
 MF
-wc
+LR
 cT
 CL
 CL
@@ -60524,18 +60524,18 @@ YS
 XV
 MF
 XV
-JR
+hF
 Vo
-ll
-Jq
+qN
+RD
 XV
-Xw
-wf
-Xw
-Xw
+cd
+ek
+cd
+cd
 XV
 MF
-wc
+LR
 cT
 CL
 EX
@@ -60776,23 +60776,23 @@ PH
 xF
 Vo
 Vo
-yU
+dT
 XV
 XV
 MF
 XV
-Qs
+JR
 Vo
-ll
+qN
 Vo
-WX
+JB
 Vo
-ll
+qN
 Vo
-br
+NP
 XV
 MF
-wc
+LR
 cT
 CL
 EX
@@ -61031,25 +61031,25 @@ LF
 aK
 Vo
 Te
-Hs
-Hs
-jl
+vW
+vW
+fu
 XV
 MF
 MF
 XV
 XV
 XV
-jW
-uE
-uE
-uE
+ah
+no
+no
+no
 UK
 Vo
-br
+NP
 XV
 MF
-wc
+LR
 cT
 CL
 CL
@@ -61288,25 +61288,25 @@ ih
 aK
 Vo
 Vz
-vk
+ZU
 on
-JB
+oJ
 XV
 MF
 MF
 XV
-bK
-fR
-zn
+cl
+Va
+Ft
 Vo
 Vo
-Tn
-aT
+Bj
+dp
 Vo
-TO
+Mg
 XV
 MF
-wc
+LR
 cT
 CL
 EX
@@ -61552,18 +61552,18 @@ XV
 MF
 MF
 XV
-MD
-OH
-zn
+eJ
+Wh
+Ft
 Vo
 Vo
-cl
-gC
-za
-lR
+SY
+sF
+Jj
+Yu
 XV
 MF
-wc
+LR
 cT
 CL
 EX
@@ -61809,18 +61809,18 @@ MF
 MF
 MF
 XV
-rt
-lM
-MM
+RL
+QI
+FD
 Vo
 Vo
 Vo
-rX
-ll
-MT
+ZP
+qN
+Rr
 XV
 MF
-wc
+LR
 cT
 CL
 EX
@@ -62073,11 +62073,11 @@ XV
 XV
 XV
 XV
-bJ
+tM
 XV
 XV
 MF
-wc
+LR
 cT
 CL
 EX
@@ -62329,12 +62329,12 @@ MF
 MF
 MF
 XV
-Tn
-aT
+Bj
+dp
 Vo
 XV
 MF
-wc
+LR
 cT
 CL
 CL
@@ -62585,13 +62585,13 @@ TZ
 TZ
 TZ
 TZ
-aP
+fP
 zl
 tW
 zl
-dx
+lg
 Bn
-NA
+dX
 cT
 CL
 EX
@@ -62843,8 +62843,8 @@ MF
 MF
 MF
 XV
-cl
-oq
+SY
+wc
 Vo
 XV
 MF
@@ -64386,7 +64386,7 @@ Mu
 Mu
 Mu
 XV
-Ii
+ij
 Vo
 Vo
 Vo

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -1924,6 +1924,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/security/prison)
+"gI" = (
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "gK" = (
 /obj/structure/chair{
 	dir = 1
@@ -2287,10 +2291,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/space)
-"hS" = (
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "hT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3295,6 +3295,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/space)
+"le" = (
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "lf" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/tile{
@@ -3511,15 +3515,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
-"lN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "lO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5226,6 +5221,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"ru" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "rv" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -7464,10 +7468,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"yW" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "yY" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -8202,10 +8202,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
-"Bm" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -12197,6 +12193,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"NG" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "NH" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -13432,7 +13432,7 @@
 /turf/open/floor/iron/white,
 /area/security/prison/work)
 "Rr" = (
-/obj/structure/closet/crate/freezer/blood,
+/obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Rs" = (
@@ -60012,7 +60012,7 @@ fK
 aK
 Pb
 Co
-Bm
+NG
 Vo
 VF
 VF
@@ -60281,7 +60281,7 @@ on
 qN
 Vo
 cd
-yW
+gI
 rQ
 ZX
 jz
@@ -61567,7 +61567,7 @@ Vo
 Vo
 Vo
 Bj
-lN
+ru
 Vo
 Mg
 XV
@@ -64654,7 +64654,7 @@ ct
 xV
 Vo
 Vo
-hS
+le
 Vo
 Vo
 Vo

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -5,10 +5,6 @@
 "ab" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/visit)
-"ad" = (
-/obj/structure/curtain,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "ae" = (
 /obj/machinery/door/airlock/public{
 	id_tag = "Perma Bathroom 2";
@@ -234,10 +230,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"aU" = (
-/obj/structure/curtain,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "aV" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -375,6 +367,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
+"bp" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Bathroom Maintenance";
+	req_access_txt = "5"
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/fore)
 "bq" = (
 /obj/structure/cable,
 /obj/machinery/light/blacklight/directional/west,
@@ -516,6 +515,10 @@
 	icon_state = "wood-broken"
 	},
 /area/service/abandoned_gambling_den)
+"bS" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "bT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -571,15 +574,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/dorms)
-"cb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "cc" = (
 /obj/machinery/plate_press,
 /turf/open/floor/iron,
@@ -783,6 +777,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/space)
+"cM" = (
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "cO" = (
 /obj/structure/railing{
 	dir = 4
@@ -996,6 +996,11 @@
 "dw" = (
 /turf/open/floor/iron,
 /area/cargo/office)
+"dx" = (
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "dA" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -1324,6 +1329,10 @@
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/medical/medbay/zone2)
+"ev" = (
+/obj/structure/curtain,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "ew" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -1415,10 +1424,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"eP" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "eQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1440,9 +1445,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"eU" = (
-/turf/open/floor/plating,
-/area/medical/break_room)
 "eV" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -1523,10 +1525,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"fj" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "fl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1561,6 +1559,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"fs" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "fu" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 1
@@ -2225,6 +2229,15 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
+"hE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "hF" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
@@ -2312,16 +2325,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/space)
-"hS" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "hT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2817,25 +2820,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"jA" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "jB" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
@@ -3005,6 +2989,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"kd" = (
+/obj/structure/curtain,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "ke" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -3054,12 +3042,6 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/space)
-"ko" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "kq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -3427,6 +3409,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/garden)
+"ll" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "ln" = (
 /turf/closed/wall,
 /area/security/prison/work)
@@ -3807,6 +3793,10 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"mp" = (
+/obj/structure/mirror/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "mq" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/white,
@@ -3865,12 +3855,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"mD" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "mE" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/end{
@@ -3891,6 +3875,12 @@
 "mG" = (
 /turf/open/floor/glass,
 /area/service/hydroponics/upper)
+"mH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "mJ" = (
 /turf/closed/wall,
 /area/engineering/atmospherics_engine)
@@ -4799,6 +4789,20 @@
 /obj/structure/reagent_dispensers/virusfood/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"pR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Dormitory Maintenance";
+	req_one_access_txt = "5;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"pS" = (
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "pU" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -5147,6 +5151,16 @@
 /obj/item/storage/fancy/cigarettes/cigars,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"qR" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "qS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5301,12 +5315,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"rt" = (
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "rv" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -5842,14 +5850,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
-"td" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
-	},
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/medical/virology)
 "tf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -5957,9 +5957,6 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
-"tu" = (
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "tv" = (
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
@@ -5981,6 +5978,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"tA" = (
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "tB" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -6510,6 +6510,10 @@
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"vk" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "vl" = (
 /obj/structure/chair{
 	dir = 4
@@ -7224,6 +7228,17 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"xJ" = (
+/obj/structure/closet/l3closet/virology,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "xK" = (
 /obj/structure/curtain,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -7579,13 +7594,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
-"zc" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "zf" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
@@ -7651,6 +7659,12 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
+"zn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "zo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -7752,6 +7766,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"zC" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "zD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -7917,10 +7935,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"Af" = (
-/obj/machinery/atmospherics/components/tank/air,
-/turf/open/floor/plating,
-/area/medical/virology)
 "Ag" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7991,6 +8005,33 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"Ap" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "Ar" = (
 /obj/machinery/newscaster/directional/north,
 /obj/effect/spawner/lootdrop/prison_contraband,
@@ -8217,10 +8258,6 @@
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/medical/medbay/zone2)
-"AX" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "AY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -8305,11 +8342,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
-"Bm" = (
-/obj/machinery/light/directional/north,
-/obj/structure/closet/secure_closet/personal/patient,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8445,6 +8477,14 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
+"BU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/obj/machinery/space_heater,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/medical/virology)
 "BV" = (
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -9727,6 +9767,11 @@
 /obj/machinery/vending/sustenance,
 /turf/open/floor/iron,
 /area/security/prison)
+"FI" = (
+/obj/machinery/light_switch/directional/north,
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "FJ" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -9937,6 +9982,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"Gn" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Go" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -10026,8 +10075,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard)
 "GC" = (
-/obj/machinery/light_switch/directional/north,
-/obj/structure/closet/secure_closet/personal/patient,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "GE" = (
@@ -10724,6 +10772,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"IF" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "IG" = (
 /obj/structure/cable,
 /obj/machinery/vending/coffee,
@@ -10765,6 +10817,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"IO" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "IP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -10812,6 +10868,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"IU" = (
+/obj/machinery/newscaster/directional/east,
+/obj/structure/toilet,
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet1";
+	name = "Stall A Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "IW" = (
 /obj/structure/closet/wardrobe/yellow,
 /turf/open/floor/iron,
@@ -11237,10 +11304,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"Kn" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "Ko" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -11529,6 +11592,25 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"Lh" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -11546,6 +11628,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"Ll" = (
+/obj/machinery/light/directional/north,
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "Lm" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
@@ -11637,10 +11724,6 @@
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"LB" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "LC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -11981,17 +12064,6 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/iron/white,
 /area/service/theater)
-"MD" = (
-/obj/structure/closet/l3closet/virology,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "ME" = (
 /turf/open/floor/plating,
 /area/cargo/warehouse)
@@ -12080,10 +12152,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"MU" = (
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "MV" = (
 /obj/structure/sign/poster/official/space_cops{
 	pixel_y = 30
@@ -12339,6 +12407,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"NG" = (
+/turf/open/floor/plating,
+/area/medical/break_room)
 "NH" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -12406,12 +12477,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison/work)
-"NS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "NT" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
@@ -12505,11 +12570,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
-"Ok" = (
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "Ol" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -12983,6 +13043,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "PD" = (
@@ -13068,17 +13129,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
-"PL" = (
-/obj/machinery/newscaster/directional/east,
-/obj/structure/toilet,
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet1";
-	name = "Stall A Button";
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "PM" = (
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
@@ -13486,15 +13536,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
-"Rd" = (
-/obj/machinery/camera{
-	c_tag = "Medbay - Bathrooms";
-	dir = 8;
-	network = list("ss13","medbay")
-	},
-/obj/structure/mirror/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "Re" = (
 /obj/machinery/chem_heater/withbuffer,
 /obj/machinery/light/directional/south,
@@ -13573,33 +13614,6 @@
 "Rl" = (
 /turf/open/floor/carpet,
 /area/service/bar)
-"Rm" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "Rn" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -14115,13 +14129,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/work)
-"SG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Dormitory Maintenance";
-	req_one_access_txt = "5;12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "SI" = (
 /obj/structure/sink{
 	dir = 4;
@@ -14150,10 +14157,6 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
-"SO" = (
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "SP" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
@@ -14385,6 +14388,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"TC" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
+/area/medical/virology)
 "TD" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -14552,10 +14559,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/green,
 /area/space)
-"Uc" = (
-/obj/structure/mirror/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "Ud" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Fore";
@@ -14578,13 +14581,6 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"Uh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Bathroom Maintenance";
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/fore)
 "Ui" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/xenobiology)
@@ -14856,6 +14852,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"Vd" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "Ve" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -15278,16 +15278,21 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
-"Wq" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 6
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"Ws" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Wt" = (
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron,
@@ -16062,6 +16067,15 @@
 "YS" = (
 /turf/open/openspace,
 /area/medical/medbay/zone2)
+"YU" = (
+/obj/machinery/camera{
+	c_tag = "Medbay - Bathrooms";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/structure/mirror/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "YV" = (
 /obj/machinery/flasher/directional/south{
 	id = "Cell 6"
@@ -16114,10 +16128,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"Zd" = (
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "Ze" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/randomsnackvend,
@@ -56351,7 +56361,7 @@ HW
 HW
 HW
 fn
-SG
+pR
 Eg
 Eg
 Eg
@@ -56608,10 +56618,10 @@ HW
 HW
 HW
 fn
-tu
-SO
-ad
-rt
+tA
+ll
+ev
+cM
 Wh
 Nn
 hj
@@ -56859,14 +56869,14 @@ fp
 HW
 HW
 HW
-eU
+NG
 ES
-Uh
+bp
 ES
 ES
 fn
-eP
-tu
+bS
+tA
 fn
 fn
 Wh
@@ -57116,16 +57126,16 @@ fp
 HW
 HW
 HW
-eU
+NG
 ES
 NY
 ET
 KC
 fn
-Zd
-tu
-ad
-rt
+Vd
+tA
+ev
+cM
 Wh
 GP
 rN
@@ -57376,11 +57386,11 @@ ES
 ES
 ES
 NY
-NS
+zn
 XA
 fn
-Ok
-tu
+dx
+tA
 fn
 fn
 Wh
@@ -57630,16 +57640,16 @@ fp
 HW
 HW
 ES
-PL
+IU
 IB
 KC
-cb
+hE
 XA
 fn
-Ok
-tu
-tu
-Uc
+dx
+tA
+tA
+mp
 Wh
 Wh
 Wh
@@ -57889,14 +57899,14 @@ zx
 ES
 ES
 ES
-Kn
+zC
 JN
-Rd
+YU
 fn
-Ok
-tu
-AX
-Uc
+dx
+tA
+GC
+mp
 XV
 lK
 Vo
@@ -58152,8 +58162,8 @@ ES
 ES
 ES
 ES
-Wq
-tu
+vk
+tA
 XV
 PU
 Vo
@@ -58405,12 +58415,12 @@ ES
 ES
 KC
 Ss
-aU
-mD
-mD
+kd
+fs
+fs
 ES
-Bm
-tu
+Ll
+tA
 XV
 TI
 Bj
@@ -58658,7 +58668,7 @@ fp
 HW
 Ah
 ES
-LB
+IF
 IE
 fY
 Tk
@@ -58666,8 +58676,8 @@ ES
 US
 KC
 ES
-GC
-tu
+FI
+tA
 XV
 es
 Vo
@@ -58920,11 +58930,11 @@ ES
 ES
 RT
 ES
-zc
-zc
+pS
+pS
 ES
-Wq
-tu
+vk
+tA
 XV
 yj
 SY
@@ -59170,7 +59180,7 @@ Mu
 Mu
 ES
 gG
-fj
+IO
 rI
 wM
 ES
@@ -59431,10 +59441,10 @@ qL
 sw
 xS
 LQ
-ko
+mH
 UK
 Vo
-MU
+Gn
 qH
 xC
 Vo
@@ -60199,7 +60209,7 @@ ro
 ES
 pm
 yK
-hS
+qR
 VS
 aK
 Pb
@@ -60716,7 +60726,7 @@ fK
 SI
 Qb
 aK
-qN
+Ws
 on
 Vo
 Vo
@@ -60969,10 +60979,10 @@ kb
 Zp
 ZV
 CG
-jA
+Lh
 FX
 Nq
-Rm
+Ap
 PC
 iY
 Vo
@@ -61227,7 +61237,7 @@ vA
 tL
 Dn
 fK
-MD
+xJ
 Ip
 aK
 PH
@@ -62255,8 +62265,8 @@ kb
 lC
 Ea
 fK
-Af
-td
+TC
+BU
 aK
 MF
 Zm

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -153,9 +153,7 @@
 /turf/open/floor/iron/grimy,
 /area/space)
 "aA" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/obj/machinery/light/directional/west,
-/obj/machinery/bounty_board/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "aB" = (
@@ -178,6 +176,17 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"aF" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "aG" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -207,9 +216,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "aN" = (
-/obj/machinery/light/directional/east,
+/obj/machinery/light/directional/west,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/lobby)
 "aO" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -226,8 +236,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aS" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "aV" = (
@@ -379,6 +394,10 @@
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"br" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "bs" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/directional/south,
@@ -607,6 +626,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ch" = (
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "ci" = (
 /obj/structure/railing{
 	dir = 8
@@ -629,10 +654,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"cl" = (
+/turf/open/floor/plating,
+/area/engineering/atmos/upper)
 "cm" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "cn" = (
@@ -765,12 +794,19 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "cK" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics - HFR Main Room";
-	name = "atmospherics camera"
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_one_access_txt = "10; 24"
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space)
 "cL" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -840,6 +876,10 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"cY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "cZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance";
@@ -1055,6 +1095,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"dI" = (
+/obj/structure/closet/emcloset,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "dJ" = (
 /obj/structure/railing{
 	dir = 8
@@ -1087,6 +1134,12 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"dN" = (
+/obj/effect/turf_decal/arrows/white{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "dO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -1275,9 +1328,15 @@
 /turf/open/floor/iron,
 /area/security/prison/workout)
 "en" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/space)
 "ep" = (
 /turf/open/openspace,
 /area/service/bar/atrium)
@@ -1396,6 +1455,10 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/zone2)
+"eK" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "eL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1445,6 +1508,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"eU" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "eV" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -1469,6 +1536,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
+"eX" = (
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "eZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -1485,6 +1557,13 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"fc" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "fe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1941,6 +2020,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"gD" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "gE" = (
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -1979,9 +2062,9 @@
 /turf/open/openspace,
 /area/command/heads_quarters/rd)
 "gR" = (
-/obj/effect/loot_site_spawner,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "gS" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -1989,9 +2072,8 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "gV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "gW" = (
 /obj/structure/table,
@@ -2080,6 +2162,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"hh" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "hi" = (
 /obj/structure/table/glass,
 /obj/item/storage/toolbox/mechanical,
@@ -2421,6 +2509,10 @@
 /obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"ik" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "il" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -2454,9 +2546,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "iq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "ir" = (
@@ -2536,6 +2626,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"iE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "iF" = (
 /turf/open/floor/plating/airless,
 /area/hallway/primary/upper)
@@ -2880,8 +2976,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "jK" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/engineering/lobby)
 "jN" = (
 /obj/machinery/door/airlock/maintenance{
@@ -2938,6 +3033,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"jW" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "jX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -3309,6 +3410,12 @@
 	icon_state = "wood-broken6"
 	},
 /area/service/abandoned_gambling_den)
+"kY" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "kZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -3572,6 +3679,10 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
+"lN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engineering/lobby)
 "lO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3677,6 +3788,14 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
+"lZ" = (
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "ma" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -4289,7 +4408,8 @@
 /turf/closed/wall,
 /area/engineering/lobby)
 "oi" = (
-/obj/effect/turf_decal/bot,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "oj" = (
@@ -4315,7 +4435,9 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "om" = (
-/obj/machinery/vending/cigarette,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "on" = (
@@ -4450,14 +4572,11 @@
 /turf/open/floor/wood,
 /area/service/library/printer)
 "oR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating/airless,
 /area/engineering/lobby)
 "oS" = (
 /obj/machinery/door/poddoor/shutters{
@@ -4590,6 +4709,9 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"pn" = (
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "po" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -4879,6 +5001,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"qc" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "qd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4946,18 +5079,12 @@
 /turf/closed/wall/r_wall,
 /area/space)
 "qm" = (
-/obj/structure/rack,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/lobby)
 "qn" = (
 /obj/machinery/light/blacklight/directional/north,
 /obj/item/radio/intercom/directional/north{
@@ -5219,14 +5346,20 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "re" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "rg" = (
 /turf/open/floor/carpet/green,
 /area/space)
+"rh" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/item/soap/nanotrasen,
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "ri" = (
 /obj/machinery/door/airlock{
 	name = "Toilet G"
@@ -5354,9 +5487,9 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "rA" = (
-/obj/structure/closet/radiation,
+/obj/machinery/vending/coffee,
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/lobby)
 "rB" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -5538,13 +5671,8 @@
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "sd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
 /area/engineering/lobby)
 "se" = (
 /obj/machinery/camera{
@@ -5588,6 +5716,13 @@
 "sm" = (
 /obj/structure/table/wood,
 /obj/item/toy/mecha/ripley,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "sn" = (
@@ -5625,6 +5760,12 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"st" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "su" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/blue,
@@ -5685,6 +5826,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"sD" = (
+/obj/structure/rack,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "sE" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera{
@@ -5758,6 +5912,12 @@
 "sO" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
+"sP" = (
+/obj/structure/table,
+/obj/item/pipe_meter,
+/obj/item/pipe_meter,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "sQ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -5850,6 +6010,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
+"te" = (
+/obj/structure/closet/crate/internals,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "tf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -6076,6 +6240,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"tO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "tP" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -6100,10 +6270,9 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "tU" = (
-/obj/effect/turf_decal/arrows/red{
-	dir = 4;
-	pixel_x = -15
-	},
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "tW" = (
@@ -6226,10 +6395,7 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "uo" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Engineering";
-	name = "Engineering RC"
-	},
+/obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "up" = (
@@ -6765,6 +6931,13 @@
 /area/hallway/secondary/service)
 "we" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "wh" = (
@@ -6841,14 +7014,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"wr" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/iron,
-/area/engineering/lobby)
 "ws" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -6926,10 +7091,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"wH" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating,
-/area/space)
 "wI" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Permabrig Entrance";
@@ -6984,14 +7145,6 @@
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/medical/medbay/zone2)
-"wR" = (
-/obj/machinery/door/airlock/engineering{
-	name = "TEG Room";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
 "wS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -7045,12 +7198,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
-"xd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
 "xe" = (
 /obj/machinery/door/airlock/public{
 	id_tag = "Perma Bathroom 1";
@@ -7169,11 +7316,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xA" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
-	},
+/obj/effect/turf_decal/arrows/white,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "xB" = (
@@ -7220,13 +7363,9 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "xI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet/purple,
+/obj/structure/closet/toolcloset,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
 /area/engineering/lobby)
 "xJ" = (
 /obj/structure/closet/l3closet/virology,
@@ -7340,9 +7479,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "xY" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/turf/open/floor/plating/airless,
+/area/engineering/lobby)
 "xZ" = (
 /obj/structure/chair/stool{
 	pixel_y = 15
@@ -7350,9 +7492,8 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "ya" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "yb" = (
@@ -7497,6 +7638,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/cargo/warehouse)
+"yD" = (
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "yF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -7744,12 +7891,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "zA" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Engineering Lobby N";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
+/obj/machinery/rnd/production/protolathe/department/engineering,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "zB" = (
@@ -7771,14 +7913,13 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "zD" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "zE" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
+/obj/machinery/camera{
+	c_tag = "Atmospherics - HFR Main Room";
+	name = "atmospherics camera"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -7924,6 +8065,10 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/wood,
 /area/service/bar)
+"Ac" = (
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Ad" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -7976,9 +8121,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Al" = (
-/obj/effect/turf_decal/arrows/white,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/structure/fluff/broken_flooring,
+/turf/open/floor/plating/airless,
+/area/engineering/lobby)
 "Am" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -8258,12 +8403,19 @@
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/medical/medbay/zone2)
-"AY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
+"AV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"AY" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating/airless,
+/area/engineering/lobby)
 "AZ" = (
 /turf/open/floor/engine,
 /area/medical/chemistry)
@@ -8359,15 +8511,16 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "Br" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
-"Bs" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
+"Bt" = (
+/obj/structure/table,
+/obj/item/pipe,
+/obj/item/pipe,
+/obj/item/pipe,
+/obj/item/pipe,
+/obj/item/pipe,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "Bu" = (
@@ -8381,11 +8534,12 @@
 /turf/open/floor/plating,
 /area/security/prison/visit)
 "Bx" = (
-/obj/machinery/atmospherics/components/binary/circulator/cold{
-	dir = 4
+/obj/structure/sign/departments/engineering{
+	pixel_x = -30
 	},
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/effect/spawner/randomcolavend,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Bz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -8402,6 +8556,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"BC" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "BF" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8427,8 +8587,12 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "BK" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/east,
+/obj/machinery/modular_computer/console/preset/cargochat/engineering{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "BM" = (
@@ -8447,12 +8611,9 @@
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "BP" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/engineering/atmos/upper)
+/obj/structure/closet/toolcloset,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "BQ" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 5
@@ -8495,11 +8656,8 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "BX" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/toolbox/electrical,
-/obj/structure/sign/departments/engineering{
-	pixel_x = -30
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -8776,8 +8934,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "CR" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -8942,9 +9100,11 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "Dm" = (
-/obj/machinery/power/generator,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Dn" = (
 /obj/structure/cable,
 /obj/structure/closet/l3closet/virology,
@@ -9090,11 +9250,14 @@
 /turf/open/floor/iron/white,
 /area/maintenance/starboard/fore)
 "DM" = (
-/obj/effect/turf_decal/arrows/white{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Engine Locker Room";
+	dir = 8;
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/lobby)
 "DN" = (
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
@@ -9265,12 +9428,26 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"Er" = (
-/obj/machinery/atmospherics/components/binary/circulator{
-	dir = 8
-	},
+"Ep" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/area/engineering/atmos/upper)
+"Er" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/rglass,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/camera{
+	c_tag = "Engineering Lobby W";
+	dir = 4;
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Es" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -9343,14 +9520,13 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Ez" = (
-/obj/structure/table,
-/obj/item/pipe,
-/obj/item/pipe,
-/obj/item/pipe,
-/obj/item/pipe,
-/obj/item/pipe,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/carpet/purple,
+/area/engineering/lobby)
 "EA" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#990099";
@@ -9783,6 +9959,15 @@
 	},
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"FL" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/fifty,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "FM" = (
 /obj/structure/flora/grass/green,
 /turf/open/floor/grass,
@@ -9831,11 +10016,12 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "FS" = (
-/obj/structure/table,
-/obj/item/pipe_meter,
-/obj/item/pipe_meter,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/purple,
+/area/engineering/lobby)
 "FU" = (
 /obj/effect/landmark/start/prisoner,
 /obj/effect/turf_decal/siding/white{
@@ -9904,11 +10090,15 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "Ga" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/rglass,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/obj/machinery/computer/cargo/request{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "Gc" = (
@@ -9943,7 +10133,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/closet/crate/internals,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "Gj" = (
@@ -9987,15 +10176,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Go" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/space)
 "Gp" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -10113,6 +10296,12 @@
 "GK" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"GL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "GM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
@@ -10269,17 +10458,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Hf" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/machinery/door/airlock/engineering{
+	name = "TEG Room";
+	req_access_txt = "10"
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/plating,
+/area/space)
 "Hh" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "Hi" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -10296,7 +10484,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Hk" = (
-/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "Hl" = (
@@ -10462,8 +10652,9 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "HN" = (
-/obj/structure/table,
-/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "HO" = (
@@ -10699,6 +10890,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/zone2)
+"Is" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "It" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -10760,12 +10955,11 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "ID" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Testing Room";
-	req_access_txt = "24"
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "IE" = (
 /obj/machinery/door/airlock{
 	name = "Stall C"
@@ -10777,9 +10971,12 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "IG" = (
-/obj/structure/cable,
-/obj/machinery/vending/coffee,
-/obj/machinery/status_display/ai/directional/north,
+/obj/machinery/light/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Engineering";
+	name = "Engineering RC"
+	},
+/obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "II" = (
@@ -10809,6 +11006,7 @@
 /turf/open/floor/plating,
 /area/space)
 "IM" = (
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "IN" = (
@@ -11031,6 +11229,10 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"Ju" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "Jx" = (
 /obj/machinery/button/door/directional/east{
 	id = "surgeryblock";
@@ -11247,18 +11449,9 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "Kh" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Lobby SE";
-	dir = 8;
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/effect/loot_site_spawner,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "Ki" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -11304,6 +11497,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"Kn" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Ko" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -11377,11 +11574,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Kz" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/structure/curtain,
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "KA" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/purple,
@@ -11424,6 +11619,21 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"KG" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
+"KH" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_hacking,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/book/manual/wiki/engineering_guide,
+/turf/open/floor/iron,
+/area/engineering/lobby)
+"KJ" = (
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "KL" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -11454,10 +11664,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "KO" = (
-/obj/structure/cable,
-/obj/effect/spawner/randomcolavend,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/camera{
+	c_tag = "Engineering Lobby N";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "KP" = (
@@ -11904,9 +12116,11 @@
 /turf/open/floor/plating,
 /area/medical/break_room)
 "Md" = (
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/lobby)
 "Me" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron{
@@ -11987,13 +12201,9 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "Mt" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/lobby";
-	dir = 1;
-	name = "Engineering Lobby APC";
-	pixel_y = 24
-	},
+/obj/structure/closet/wardrobe/engineering_yellow,
+/obj/item/storage/bag/construction,
+/obj/item/storage/bag/construction,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "Mu" = (
@@ -12087,17 +12297,16 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "MJ" = (
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/wiki/engineering_construction,
-/obj/item/book/manual/wiki/engineering_hacking,
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Engineering Lobby NW";
-	dir = 4;
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
+/obj/structure/fluff/broken_flooring{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
 /area/engineering/lobby)
 "ML" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -12269,6 +12478,7 @@
 /area/medical/medbay/zone2)
 "Nk" = (
 /obj/item/radio/intercom/directional/east,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "Nl" = (
@@ -12320,6 +12530,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"Nu" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "Nv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -12331,9 +12545,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "Nw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Nx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance";
@@ -12417,10 +12636,27 @@
 /obj/item/radio/off,
 /turf/open/floor/iron,
 /area/security/office)
-"NK" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron,
+"NJ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/turf/open/space/basic,
 /area/engineering/atmos/upper)
+"NK" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Locker Room";
+	req_one_access_txt = "10;24"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "NL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -12480,6 +12716,13 @@
 "NT" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
+/area/space)
+"NU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "24"
+	},
+/turf/open/floor/iron,
 /area/space)
 "NV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -12690,10 +12933,14 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "OE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/turf/open/floor/carpet/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/engineering/lobby)
 "OF" = (
 /obj/structure/bed,
@@ -12854,6 +13101,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"Pe" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Pf" = (
 /obj/machinery/flasher/directional/south{
 	id = "Warden Permabrig Office";
@@ -12986,9 +13237,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Pt" = (
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "Pv" = (
@@ -13129,6 +13378,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"PL" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/machinery/camera{
+	c_tag = "Engineering Lobby E";
+	dir = 8;
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "PM" = (
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
@@ -13399,9 +13659,15 @@
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "QD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/engineering/lobby)
 "QE" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -13445,9 +13711,16 @@
 /turf/open/floor/iron/white,
 /area/maintenance/starboard/fore)
 "QJ" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/engineering/lobby)
 "QK" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -13523,11 +13796,17 @@
 /turf/open/floor/iron,
 /area/security/prison/workout)
 "QY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
+/obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engineering/atmospherics_engine)
+/obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/engineering/lobby)
 "Rb" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/upper)
@@ -13884,8 +14163,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "RW" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Testing Room";
+	req_access_txt = "24"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
@@ -13999,9 +14279,13 @@
 /turf/open/floor/glass/reinforced,
 /area/engineering/atmos/upper)
 "Sl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "Sm" = (
@@ -14146,6 +14430,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"SJ" = (
+/obj/structure/table,
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "SL" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/light/blacklight/directional/west,
@@ -14254,6 +14543,10 @@
 /obj/item/bedsheet/qm,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"Th" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/engineering/lobby)
 "Ti" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -14467,6 +14760,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "TQ" = (
@@ -14578,9 +14872,15 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Ug" = (
-/obj/effect/turf_decal/bot/right,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/area/engineering/lobby)
 "Ui" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/xenobiology)
@@ -14706,6 +15006,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"UI" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "UJ" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -14998,12 +15302,10 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "Vu" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/effect/turf_decal/arrows/red{
+	dir = 4;
+	pixel_x = -15
 	},
-/obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "Vv" = (
@@ -15062,6 +15364,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison/work)
+"VC" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/engineering/atmos/upper)
 "VD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -15150,10 +15456,14 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "VU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
+/obj/structure/noticeboard{
+	dir = 8;
+	pixel_x = 32
 	},
-/turf/open/floor/carpet/purple,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/iron,
 /area/engineering/lobby)
 "VV" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
@@ -15278,9 +15588,13 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"Wq" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Wr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/circulator/cold{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
@@ -15623,10 +15937,9 @@
 /turf/closed/wall,
 /area/holodeck/rec_center)
 "Xy" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/machinery/power/generator,
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "Xz" = (
 /obj/machinery/computer/slot_machine{
 	pixel_y = 2
@@ -15763,8 +16076,11 @@
 /turf/closed/wall,
 /area/medical/medbay/zone2)
 "XW" = (
-/turf/closed/wall,
-/area/engineering/atmos/upper)
+/obj/machinery/atmospherics/components/binary/circulator{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "XX" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/melee/flyswatter,
@@ -15784,6 +16100,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"XZ" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "Ya" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
@@ -16155,6 +16483,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"Zi" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engineering/atmospherics_engine)
 "Zj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16301,10 +16635,13 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "ZI" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/engineering/atmos/upper)
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -11
+	},
+/obj/structure/mirror/directional/west,
+/turf/open/floor/iron/white,
+/area/engineering/lobby)
 "ZJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -38428,7 +38765,7 @@ PG
 PG
 PG
 PG
-YB
+PG
 YB
 YB
 YB
@@ -38685,7 +39022,7 @@ PG
 PG
 PG
 PG
-YB
+PG
 YB
 YB
 YB
@@ -38934,17 +39271,17 @@ yV
 sV
 PG
 PG
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
+PG
+PG
+PG
+PG
+PG
+PG
+PG
+PG
+PG
+PG
+PG
 YB
 YB
 YB
@@ -39191,17 +39528,17 @@ nI
 sV
 PG
 PG
-ql
 PG
 PG
 PG
 PG
-YB
-YB
-YB
-YB
-YB
-ql
+PG
+PG
+PG
+PG
+PG
+PG
+PG
 YB
 YB
 YB
@@ -39448,19 +39785,21 @@ sV
 sV
 PG
 PG
-ql
 PG
 PG
 PG
 PG
+PG
+PG
+PG
+PG
+PG
+PG
+PG
 YB
 YB
 YB
-YB
-YB
-ql
-YB
-YB
+cl
 DG
 DG
 DG
@@ -39470,8 +39809,6 @@ DG
 DG
 DG
 DG
-DG
-Mu
 Mu
 Mu
 Mu
@@ -39705,30 +40042,30 @@ PG
 PG
 PG
 PG
-ql
 PG
 PG
-PG
-PG
+og
+og
+og
+og
+og
+og
+og
+og
+og
 YB
 YB
 YB
-YB
-YB
-ql
-YB
-YB
+cl
 DG
-gS
-gS
 gS
 gS
 gS
 fQ
 oE
 gS
+gS
 DG
-Mu
 DG
 DG
 DG
@@ -39962,21 +40299,22 @@ PG
 PG
 PG
 PG
-ql
 PG
-PG
-PG
-PG
+og
+og
+xI
+BP
+og
+ZI
+ZI
+ZI
+ZI
+og
 YB
 YB
 YB
-YB
-YB
-ql
-YB
-YB
+cl
 DG
-gS
 cs
 cs
 gS
@@ -39985,7 +40323,6 @@ gS
 gS
 gS
 DG
-Mu
 DG
 tY
 tY
@@ -40219,30 +40556,30 @@ PG
 PG
 PG
 PG
-ql
 PG
-PG
-PG
-PG
+og
+gR
+xY
+bG
+Kz
+pn
+Ju
+pn
+Is
+og
 YB
-YB
-YB
-YB
-YB
-ql
 YB
 YB
 DG
-gS
+DG
 cs
 gS
 gS
 gS
-gS
 cs
 gS
+gS
 DG
-Mu
 DG
 tY
 tY
@@ -40476,21 +40813,21 @@ PG
 PG
 PG
 PG
-ql
 PG
-PG
-PG
-PG
+og
+oR
+zD
+BX
+og
+og
+og
+Kz
+Kz
+og
 YB
-YB
-YB
-YB
-YB
-ql
 YB
 YB
 DG
-gS
 gS
 gS
 gS
@@ -40498,8 +40835,8 @@ gS
 gS
 cs
 gS
+gS
 DG
-Mu
 DG
 tY
 tY
@@ -40733,21 +41070,21 @@ PG
 PG
 PG
 PG
-ql
 PG
-PG
-PG
-PG
+og
+qm
+bG
+CR
+Md
+gD
+og
+hh
+jW
+og
 YB
-YB
-YB
-YB
-YB
-ql
 YB
 YB
 DG
-gS
 gS
 gS
 gS
@@ -40755,8 +41092,8 @@ gS
 fS
 Sk
 ju
+gS
 DG
-Mu
 DG
 DG
 DG
@@ -40990,17 +41327,18 @@ PG
 PG
 PG
 PG
-ql
 PG
-PG
-PG
-PG
+og
+re
+Al
+Dm
+MJ
+Wq
+og
+hh
+jW
+og
 YB
-YB
-YB
-YB
-YB
-ql
 YB
 YB
 DG
@@ -41008,12 +41346,11 @@ gS
 cs
 gS
 gS
-gS
 WD
 WD
 Gh
+gS
 DG
-Mu
 Mu
 Mu
 Mu
@@ -41247,17 +41584,18 @@ PG
 PG
 PG
 PG
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
-ql
+PG
+og
+gR
+AY
+DM
+Nw
+dI
+og
+hh
+rh
+og
+YB
 YB
 YB
 DG
@@ -41265,11 +41603,13 @@ gS
 cs
 gS
 gS
+dJ
+dJ
 gS
-dJ
-dJ
+gS
 DG
 DG
+DG
 sI
 sI
 sI
@@ -41277,9 +41617,6 @@ sI
 sI
 DG
 DG
-Mu
-Mu
-Mu
 Mu
 Mu
 Mu
@@ -41505,15 +41842,16 @@ PG
 PG
 PG
 PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-YB
+og
+og
+og
+og
+NK
+lN
+og
+og
+og
+og
 YB
 YB
 YB
@@ -41521,22 +41859,21 @@ DG
 gS
 cs
 gS
-gS
 cs
 gS
 gS
+gS
+gS
+te
 DG
-en
+ik
 gS
 gS
 gS
 gS
 gS
-en
+ik
 DG
-Mu
-Mu
-Mu
 Mu
 Mu
 Mu
@@ -41761,16 +42098,17 @@ PG
 PG
 PG
 PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-YB
+og
+og
+rA
+Bx
+Er
+Nw
+bG
+aF
+qc
+Pe
+og
 YB
 YB
 YB
@@ -41778,22 +42116,21 @@ DG
 gS
 gS
 gS
-gS
 cs
 gS
 gS
-sI
-gS
-gS
-gS
-gS
 gS
 gS
 gS
 sI
-Mu
-Mu
-Mu
+gS
+gS
+gS
+gS
+gS
+gS
+gS
+sI
 Mu
 Mu
 Mu
@@ -42014,19 +42351,20 @@ jY
 nX
 nQ
 nQ
-nQ
-nQ
-nQ
+ct
+PG
+ct
 og
 og
-og
-og
-og
-og
-og
-og
-og
-og
+aN
+bG
+bG
+bG
+OE
+tO
+tO
+iE
+XZ
 og
 og
 YB
@@ -42035,22 +42373,21 @@ DG
 gS
 gS
 gS
-gS
 cs
 gS
 gS
-sI
-gS
-gS
-gS
-DM
 gS
 gS
 gS
 sI
-Mu
-Mu
-Mu
+gS
+gS
+gS
+dN
+gS
+gS
+gS
+sI
 Mu
 Mu
 Mu
@@ -42269,21 +42606,22 @@ UX
 Au
 Au
 Au
+jY
 nQ
-GK
-GK
-GK
-GK
+PG
+PG
+PG
 og
 uo
-Xy
-BX
-MJ
-Go
-wr
-Ga
-aS
+bG
+bG
+bG
+bG
+Sl
+bG
+bG
 aA
+jK
 jK
 og
 YB
@@ -42291,23 +42629,22 @@ YB
 DG
 gS
 cs
-gS
 sN
 pK
 gS
 gS
-sI
 gS
-gS
-Ug
-Hf
-NK
 gS
 gS
 sI
-Mu
-Mu
-Mu
+gS
+gS
+gV
+ch
+KJ
+gS
+gS
+sI
 Mu
 Mu
 Mu
@@ -42526,45 +42863,45 @@ kA
 jY
 Au
 jY
+jY
 nQ
-GK
-GK
-GK
-GK
+PG
+PG
+PG
 og
 ya
-oR
+bG
+bG
+bG
+bG
 Sl
-Sl
-Sl
-Sl
-Sl
-Sl
-Sl
-Sl
+bG
+bG
+aA
+jK
+jK
 og
 YB
 YB
-DG
+NU
 gS
 cs
-gS
 gS
 oE
 gS
 gS
-ID
 gS
-Al
+gS
+gS
 RW
-Md
+gS
 xA
+yD
+KG
+lZ
 gS
 gS
 sI
-Mu
-Mu
-Mu
 Mu
 Mu
 Mu
@@ -42783,22 +43120,23 @@ kA
 jY
 Au
 jY
+jY
 nQ
-GK
-GK
-GK
-GK
+PG
+PG
+PG
 og
 zA
-sd
 pe
 pe
 pe
 pe
+QD
 pe
 pe
-pe
-bG
+Th
+fc
+og
 og
 YB
 YB
@@ -42806,23 +43144,22 @@ DG
 gS
 cs
 gS
-gS
 vH
 gS
 gS
+gS
+gS
+gS
 sI
-cK
-gS
-NK
 zE
-Ug
 gS
-gS
+KJ
+BC
 gV
-BP
-Mu
-Mu
-Mu
+gS
+gS
+Ep
+NJ
 Mu
 Mu
 Mu
@@ -43040,45 +43377,45 @@ kA
 jY
 Au
 jY
+jY
 nQ
 nQ
-GK
-nQ
-nQ
+PG
+PG
 og
 IG
-xI
+pe
 Br
 cm
-Td
-cm
+Ez
+QJ
 Td
 pe
-pe
+Th
 oi
 og
+YB
 YB
 YB
 DG
 gS
 gS
 gS
-gS
 cs
 gS
 gS
+gS
+gS
+gS
 sI
-Hh
-gS
-gS
 tU
 gS
 gS
 Vu
+gS
+gS
+FL
 sI
-Mu
-Mu
-Mu
 Mu
 Mu
 Mu
@@ -43299,12 +43636,12 @@ Au
 jY
 jY
 jY
-jY
 nQ
+PG
 PG
 og
 KO
-VU
+pe
 Zb
 Xg
 KA
@@ -43312,30 +43649,30 @@ sm
 KA
 uh
 pe
-oi
+Ac
 og
+YB
 YB
 YB
 DG
 gS
 gS
 gS
-gS
 cs
 gS
 gS
-sI
-rA
-gS
-qm
-gS
 gS
 gS
 gS
 sI
-Mu
-Mu
-Mu
+VC
+gS
+sD
+gS
+gS
+gS
+gS
+sI
 Mu
 Mu
 Mu
@@ -43556,43 +43893,43 @@ EQ
 Zz
 Zz
 jY
-jY
+nQ
 PG
 PG
 og
 Mt
-OE
+pe
 iq
 TP
-Pg
-TP
+FS
+QY
 Pg
 pe
 pe
-Pt
+bG
 og
 YB
 YB
+YB
 DG
 gS
 cs
 gS
-gS
 cs
 gS
 gS
+gS
+gS
+gS
 DG
-ZI
+eX
 gS
 gS
 gS
 gS
 gS
-aN
+eU
 DG
-Mu
-Mu
-Mu
 Mu
 Mu
 Mu
@@ -43813,8 +44150,8 @@ lb
 yZ
 yZ
 jY
-jY
 nQ
+PG
 PG
 og
 MX
@@ -43830,6 +44167,7 @@ Pt
 og
 YB
 YB
+YB
 DG
 gS
 cs
@@ -43838,8 +44176,10 @@ gS
 gS
 gS
 gS
+gS
 DG
 DG
+DG
 sI
 sI
 sI
@@ -43847,9 +44187,6 @@ sI
 sI
 DG
 DG
-Mu
-Mu
-Mu
 Mu
 Mu
 Mu
@@ -44070,8 +44407,8 @@ lb
 yZ
 yZ
 jY
-jY
 nQ
+PG
 PG
 og
 Ny
@@ -44079,12 +44416,13 @@ bG
 bG
 bG
 bG
+Sl
 bG
 bG
 bG
-bG
-Pt
+Kn
 og
+YB
 YB
 YB
 DG
@@ -44097,7 +44435,6 @@ gS
 gS
 gS
 DG
-Mu
 Mu
 Mu
 Mu
@@ -44327,25 +44664,25 @@ lb
 yZ
 yZ
 jY
-jY
 nQ
+PG
 PG
 og
 PJ
-bG
+aS
 om
+om
+om
+Ug
 bG
 bG
 bG
-CR
-BK
-Kh
 Nk
 og
 YB
 YB
+YB
 DG
-gS
 gS
 gS
 gS
@@ -44353,8 +44690,8 @@ gS
 gS
 cs
 gS
+gS
 DG
-Mu
 DG
 DG
 DG
@@ -44584,25 +44921,25 @@ dE
 rT
 rT
 jY
-jY
+nQ
 nQ
 PG
 og
 og
+Sl
+sd
+BK
+Ga
+VU
+KH
+PL
+UI
 og
 og
-og
-og
-og
-og
-og
-og
-og
-og
+YB
 YB
 YB
 DG
-gS
 gS
 gS
 gS
@@ -44610,8 +44947,8 @@ gS
 gS
 cs
 gS
+gS
 DG
-Mu
 DG
 tY
 tY
@@ -44845,30 +45182,30 @@ mE
 nQ
 PG
 PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-ct
+og
+cK
+og
+og
+og
+og
+og
+og
+og
+og
+YB
+YB
 YB
 YB
 DG
-gS
+DG
 cs
 gS
 gS
 gS
-gS
 cs
 gS
+gS
 DG
-Mu
 DG
 tY
 tY
@@ -45103,20 +45440,21 @@ nQ
 PG
 PG
 PG
+en
 PG
-ct
-ct
-ct
-ct
-ct
-ct
-ct
 PG
-ct
+PG
+PG
+PG
+PG
+PG
+PG
 YB
 YB
+YB
+YB
+cl
 DG
-gS
 cs
 cs
 gS
@@ -45125,7 +45463,6 @@ gS
 gS
 gS
 DG
-Mu
 DG
 tY
 tY
@@ -45361,28 +45698,28 @@ PG
 PG
 PG
 PG
-ct
 PG
-PG
-PG
-PG
-PG
-ct
-PG
-ct
+YB
+Go
+Go
 YB
 YB
+YB
+YB
+YB
+YB
+YB
+YB
+cl
 DG
-gS
-gS
 gS
 gS
 gS
 YR
 oE
 gS
+gS
 DG
-Mu
 DG
 DG
 DG
@@ -45618,17 +45955,19 @@ nQ
 nQ
 nQ
 PG
-ct
 PG
-PG
-PG
-PG
-PG
-ct
-PG
-ct
+mJ
+Hf
+Hf
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
 YB
 YB
+cl
 DG
 DG
 DG
@@ -45638,8 +45977,6 @@ DG
 DG
 DG
 DG
-XW
-Mu
 Mu
 Mu
 Mu
@@ -45875,26 +46212,26 @@ GK
 GK
 nQ
 PG
-ct
 PG
-PG
-PG
-PG
-PG
-ct
-PG
-ct
-YB
-YB
-ct
-YB
-YB
-YB
-YB
+mJ
+Hh
+Hh
+Bt
+sP
+SJ
+Hh
+Hh
+IM
 YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -46132,26 +46469,26 @@ GK
 GK
 nQ
 PG
-ct
-ct
 PG
-PG
-PG
-PG
-ct
-PG
-ct
-wH
-wH
-ct
-YB
-YB
-YB
-YB
+mJ
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+Hh
+IM
 YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -46390,25 +46727,25 @@ GK
 nQ
 PG
 PG
-ct
-PG
-PG
-PG
-PG
-ct
-PG
 mJ
-wR
-wR
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
+Hk
+Hh
+Hh
+Hh
+Zi
+Hh
+Hh
+IM
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -46647,25 +46984,25 @@ ms
 ms
 ms
 PG
-ct
-PG
-PG
-PG
-PG
-ct
-PG
 mJ
-IM
-IM
-Ez
-FS
 HN
+Wr
+cY
+st
+AV
+Hh
+Hh
 IM
-IM
-Nw
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -46904,25 +47241,25 @@ Qr
 Tp
 ms
 PG
-ct
-PG
-PG
-PG
-PG
-ct
-PG
 mJ
+Hh
+Xy
+Hh
+Hh
+Hh
+Hh
+Hh
 IM
-IM
-IM
-IM
-IM
-IM
-IM
-Nw
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -47161,25 +47498,25 @@ MC
 GQ
 ms
 PG
-ct
-PG
-PG
-PG
-PG
-ct
-PG
 mJ
-Bs
+ID
+XW
+cY
+br
+GL
+Hh
+Hh
 IM
-IM
-IM
-Kz
-IM
-IM
-Nw
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -47418,25 +47755,25 @@ Vw
 rV
 ms
 PG
-ct
-PG
-PG
-PG
-PG
-ct
-PG
 mJ
-xd
-Bx
-QD
-AY
-re
+Hk
+Hh
+Hh
+Hh
+kY
+Hh
+Hh
 IM
-IM
-Nw
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -47675,25 +48012,25 @@ bu
 fB
 ms
 PG
-ct
-PG
-PG
-PG
-PG
-ct
-PG
 mJ
-IM
-Dm
-IM
-IM
-IM
-IM
-IM
-Nw
+HN
+Hh
+Hh
+Hh
+Hh
+Hh
+eK
+mJ
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -47932,25 +48269,25 @@ yb
 hO
 ms
 PG
-ct
-PG
-PG
-PG
-PG
-ct
-PG
 mJ
-Wr
-Er
-QD
-Hk
-QY
-IM
-IM
-Nw
+Kh
+Hh
+Hh
+Hh
+Hh
+Hh
+Nu
+mJ
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -48189,25 +48526,25 @@ eV
 ak
 ms
 PG
-ct
-ct
-ct
-ct
-ct
-ct
-PG
 mJ
-Bs
-IM
-IM
-IM
-zD
-IM
-IM
-Nw
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+mJ
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -48453,18 +48790,18 @@ PG
 PG
 PG
 PG
-mJ
-xd
-IM
-IM
-IM
-IM
-IM
-xY
-mJ
+YB
+YB
+YB
 YB
 YB
 ct
+Mu
+Mu
+Mu
+Mu
+Mu
+Mu
 Mu
 Mu
 Mu
@@ -48710,17 +49047,17 @@ bd
 bd
 PG
 PG
-mJ
-gR
-IM
-IM
-IM
-IM
-IM
-QJ
-mJ
 YB
 YB
+YB
+YB
+YB
+ct
+ct
+ct
+ct
+ct
+ct
 ct
 Mu
 Mu
@@ -48967,15 +49304,15 @@ cv
 bd
 PG
 PG
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
-mJ
+YB
+YB
+YB
+YB
+YB
+YB
+YB
+YB
+YB
 YB
 YB
 ct

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -187,6 +187,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"aP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aR" = (
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/engine,
@@ -196,6 +206,14 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"aT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "aV" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -332,6 +350,13 @@
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"br" = (
+/obj/machinery/shower{
+	dir = 1;
+	name = "emergency shower"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "bs" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/directional/south,
@@ -408,6 +433,28 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"bJ" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Access";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"bK" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "bL" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -537,6 +584,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"cl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "cm" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -583,6 +634,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/hallway/primary/upper)
+"cx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "cz" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
@@ -723,6 +782,25 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"cW" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/stamp/cmo,
+/obj/item/stamp/denied,
+/obj/machinery/keycard_auth{
+	pixel_x = -5;
+	pixel_y = -25
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cmoprivacy";
+	name = "CMO Shutter Control";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access_txt = "40"
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "cZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance";
@@ -748,6 +826,19 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
 /area/space)
+"dc" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet2";
+	name = "Stall B Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "dd" = (
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
@@ -778,18 +869,14 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "dl" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/structure/urinal/directional/south,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
 	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet2";
-	name = "Stall B Button";
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/machinery/newscaster/directional/east,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/security/prison/toilet)
 "dm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -842,6 +929,16 @@
 "dw" = (
 /turf/open/floor/iron,
 /area/cargo/office)
+"dx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "dA" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -881,6 +978,7 @@
 	name = "Luxurious sofa"
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
 "dG" = (
@@ -927,6 +1025,15 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"dM" = (
+/obj/machinery/button/door/directional/east{
+	id = "surgeryblock";
+	name = "Privacy Button";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "dO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -961,6 +1068,9 @@
 "dW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/sign/departments/psychology{
+	pixel_x = -32
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
@@ -1043,6 +1153,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
+"ek" = (
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "el" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/white,
@@ -1166,6 +1282,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"eP" = (
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/camera{
+	c_tag = "CMO";
+	dir = 1;
+	name = "CMO Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "eQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1211,6 +1337,21 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
+"eX" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
+"eY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "eZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -1257,12 +1398,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"fk" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "fl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1288,17 +1423,8 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "fp" = (
-/obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Psychology";
-	name = "Psychology Camera";
-	network = list("ss13","medbay")
-	},
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+/turf/closed/wall/r_wall,
+/area/medical/break_room)
 "fq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -1399,6 +1525,12 @@
 "fK" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"fL" = (
+/obj/structure/closet/secure_closet/medical2,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "fM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1438,6 +1570,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"fR" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "fS" = (
 /obj/structure/railing{
 	dir = 4
@@ -1497,7 +1636,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "ga" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -1566,9 +1705,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"gk" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "gl" = (
 /turf/closed/wall,
 /area/service/library/private)
+"gm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "gn" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -1643,6 +1801,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"gz" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "gA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1660,14 +1822,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"gC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "gE" = (
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "gG" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "gH" = (
@@ -1874,6 +2043,7 @@
 	name = "Prison Camera";
 	network = list("ss13","prison")
 	},
+/obj/structure/urinal/directional/south,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "ht" = (
@@ -1980,6 +2150,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"hN" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "hO" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -2006,6 +2181,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/space)
+"hS" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "hT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2013,6 +2192,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/prison)
+"hU" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "hV" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/iron,
@@ -2086,6 +2269,12 @@
 	},
 /turf/open/floor/carpet/green,
 /area/space)
+"ik" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "il" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -2230,12 +2419,14 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "iN" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/camera{
+	c_tag = "Medbay Break Room";
+	name = "Medbay Break Room Camera";
+	network = list("ss13","medbay")
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "iP" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
@@ -2259,6 +2450,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
+"iV" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "iW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2282,7 +2480,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "iZ" = (
 /obj/structure/bed,
 /obj/item/radio/intercom/directional/north,
@@ -2332,10 +2530,23 @@
 /obj/item/toy/plush/supermatter,
 /turf/open/floor/iron,
 /area/security/prison)
+"jj" = (
+/obj/machinery/modular_computer/console/preset/id,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "jk" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"jl" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "jm" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
@@ -2350,6 +2561,14 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"jp" = (
+/obj/item/toy/cattoy,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "jr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -2430,6 +2649,22 @@
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/space)
+"jD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
+"jG" = (
+/obj/structure/table/glass,
+/obj/item/scalpel,
+/obj/item/retractor,
+/obj/effect/turf_decal/siding/blue{
+	color = "#73c2fb";
+	name = "medical blue"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -2517,6 +2752,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"jW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "jX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -2592,11 +2838,9 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "kj" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "kk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -2650,6 +2894,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"ks" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	dir = 4;
+	name = "Security Medbay monitor";
+	network = list("medbay")
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "kt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -2732,6 +2985,11 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"kE" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "kG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2773,6 +3031,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"kL" = (
+/obj/machinery/light/directional/south,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "kM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2917,6 +3182,16 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/space)
+"le" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "lf" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/tile{
@@ -2955,6 +3230,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/garden)
+"ll" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ln" = (
 /turf/closed/wall,
 /area/security/prison/work)
@@ -3110,6 +3395,13 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
+"lM" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "lO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3142,6 +3434,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"lR" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "lS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -3253,11 +3549,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"md" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "me" = (
 /obj/structure/cable,
 /obj/structure/railing/corner,
@@ -3270,6 +3561,11 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"mg" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "mh" = (
 /obj/structure/table/glass,
 /obj/item/stack/ducts/fifty,
@@ -3354,6 +3650,21 @@
 "mw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
+/area/medical/medbay/zone2)
+"mx" = (
+/obj/machinery/door/airlock/medical{
+	name = "Surgery B";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "my" = (
 /obj/structure/bed,
@@ -3459,6 +3770,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"mQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "mT" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Emergency Room";
@@ -3480,6 +3801,12 @@
 "mV" = (
 /turf/open/floor/iron/dark,
 /area/space)
+"mW" = (
+/obj/structure/table/glass,
+/obj/item/hemostat,
+/obj/item/cautery,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "mX" = (
 /obj/machinery/power/emitter,
 /obj/machinery/light/directional/north,
@@ -3585,13 +3912,26 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
+"np" = (
+/obj/structure/table,
+/obj/item/gun/syringe,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/clothing/neck/stethoscope,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "nq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
+"nr" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "ns" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/black,
@@ -3606,6 +3946,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"nu" = (
+/obj/structure/closet/secure_closet/medical3,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "nv" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
@@ -3773,6 +4117,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/medical/virology)
+"ob" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Virology Access";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "od" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -3822,7 +4177,7 @@
 "on" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "oo" = (
 /obj/structure/urinal/directional/north,
 /turf/open/floor/iron/white,
@@ -3831,6 +4186,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/service/library/printer)
+"oq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "os" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -3873,6 +4236,10 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"oD" = (
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "oE" = (
 /obj/structure/ladder,
 /turf/open/floor/iron,
@@ -3890,6 +4257,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"oJ" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "oK" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Laundry"
@@ -4061,11 +4433,9 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "pm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "po" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -4157,14 +4527,8 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "pC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/openspace,
+/area/security/checkpoint/medical)
 "pD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -4435,6 +4799,13 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"qp" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "qq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -4491,11 +4862,23 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/security/office)
-"qx" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop,
+"qw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/maintenance/starboard)
+"qx" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_access_txt = "5"
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "qz" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -4555,16 +4938,29 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "qL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
+"qN" = (
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Chief Medical Officer's Desk";
+	departmentType = 5;
+	name = "Chief Medical Officer"
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "qQ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/trophy,
 /obj/item/storage/fancy/cigarettes/cigars,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"qR" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "qS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -4703,6 +5099,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"rt" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "rv" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -4805,18 +5208,13 @@
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "rH" = (
-/obj/structure/filingcabinet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "rI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/structure/chair,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "rJ" = (
 /obj/structure/table,
 /obj/item/dest_tagger,
@@ -4899,6 +5297,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"rX" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "rY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -4907,6 +5309,12 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/space)
+"sa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "sb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -4918,7 +5326,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/iron,
-/area/holodeck/rec_center)
+/area/maintenance/fore)
 "sd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -4966,6 +5374,14 @@
 /obj/item/toy/mecha/ripley,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"so" = (
+/obj/machinery/light/directional/west,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "sq" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
@@ -4991,6 +5407,15 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"st" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "su" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/carpet/blue,
@@ -5010,9 +5435,13 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "sw" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "sx" = (
 /turf/open/floor/iron/white,
 /area/science/breakroom)
@@ -5073,6 +5502,15 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+"sJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "sN" = (
 /obj/machinery/atmospherics/pipe/multiz/cyan/visible/layer4{
 	dir = 1
@@ -5144,16 +5582,9 @@
 /turf/open/floor/circuit/telecomms,
 /area/maintenance/department/science/xenobiology)
 "ta" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet1";
-	name = "Stall A Button";
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "tb" = (
@@ -5241,6 +5672,12 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"tp" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "tq" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -5307,6 +5744,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"tJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "tL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -5330,11 +5773,9 @@
 /turf/open/floor/plating,
 /area/service/hydroponics/upper)
 "tR" = (
-/obj/machinery/door/airlock{
-	name = "Stall C"
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "tS" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/purple,
@@ -5352,15 +5793,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "tW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "tX" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry S";
@@ -5458,6 +5895,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"uk" = (
+/obj/structure/table/optable,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "um" = (
 /obj/structure/bed/dogbed/cayenne{
 	name = "Lia's bed"
@@ -5551,6 +5993,7 @@
 	req_access_txt = "69;33"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ux" = (
@@ -5560,6 +6003,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"uy" = (
+/obj/machinery/light/dim/directional/west,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "uA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard/fifty,
@@ -5579,6 +6026,12 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"uE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "uF" = (
 /obj/structure/railing{
 	dir = 8
@@ -5599,6 +6052,12 @@
 /obj/machinery/recharger,
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
+"uJ" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "uK" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/carpet/green,
@@ -5711,10 +6170,13 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "vb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/carpet/purple,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
 /area/medical/psychology)
 "vc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -5744,10 +6206,14 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "vj" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
+/obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"vk" = (
+/obj/structure/cable,
+/obj/machinery/light/blacklight/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "vl" = (
 /obj/structure/chair{
 	dir = 4
@@ -5928,10 +6394,37 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/service/bar)
+"vU" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "vV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/holodeck/rec_center)
+"vW" = (
+/obj/machinery/door/airlock/medical{
+	name = "Psychology";
+	req_access_txt = "70"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "vX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Emergency Room"
@@ -5956,6 +6449,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"wc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -5964,6 +6466,31 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"wf" = (
+/obj/machinery/door/airlock/command{
+	name = "Chief Medical Officer's Office";
+	req_access_txt = "40"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"wg" = (
+/obj/machinery/camera{
+	c_tag = "Surgery B";
+	dir = 4;
+	name = "Surgery B Camera";
+	network = list("ss13","medbay")
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "wh" = (
 /obj/machinery/camera{
 	c_tag = "Security Office - Table";
@@ -6079,11 +6606,15 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "wA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "wB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6124,6 +6655,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"wF" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "wH" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -6150,21 +6687,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "wL" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
-"wM" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Psychology Maintenance";
-	req_access_txt = "70"
+	name = "Medical Bathroom Maintenance";
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/space)
+"wM" = (
+/obj/structure/table,
+/obj/item/toy/mecha/odysseus,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "wO" = (
 /obj/structure/railing,
 /turf/open/floor/wood,
@@ -6266,6 +6801,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"xj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "xk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -6303,6 +6842,12 @@
 /obj/machinery/mechpad,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"xo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "xp" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/mech_bay_recharge_floor,
@@ -6389,7 +6934,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "xG" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -6474,9 +7019,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "xS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "xT" = (
@@ -6490,6 +7034,19 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
+"xV" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet1";
+	name = "Stall A Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "xW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6558,12 +7115,13 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "yh" = (
-/obj/machinery/firealarm/directional/west,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "ym" = (
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/carpet/purple,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
 /area/medical/psychology)
 "yn" = (
 /obj/machinery/camera{
@@ -6620,6 +7178,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"yx" = (
+/obj/machinery/computer/med_data,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "yz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -6646,6 +7208,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/cargo/warehouse)
+"yD" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "yF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -6709,6 +7276,13 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"yU" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "yV" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -30
@@ -6722,6 +7296,16 @@
 "yZ" = (
 /turf/open/openspace,
 /area/hallway/secondary/service)
+"za" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -6732,18 +7316,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"zc" = (
+/obj/structure/table/optable,
+/obj/item/toy/figure/md,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zf" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/psychologist,
-/obj/machinery/button/door/directional/north{
-	id = "psychology";
-	name = "Privacy Button";
-	pixel_x = 5;
-	pixel_y = 35;
-	req_access_txt = "70"
-	},
+/obj/structure/table/wood,
+/obj/machinery/light/directional/north,
+/obj/item/toy/figure/psychologist,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "zg" = (
@@ -6783,16 +7365,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"zj" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "zl" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zm" = (
 /obj/structure/chair{
 	dir = 1
@@ -6801,6 +7384,18 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
+"zn" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "zo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -6895,6 +7490,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"zC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -6911,6 +7512,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"zH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "CMO Office"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "zI" = (
 /obj/machinery/camera{
 	c_tag = "Prison - Court E";
@@ -6933,6 +7542,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"zK" = (
+/obj/structure/table/glass,
+/obj/item/surgical_drapes,
+/obj/item/book/manual/wiki/surgery,
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zL" = (
 /obj/machinery/biogenerator,
 /obj/machinery/light/directional/east,
@@ -6950,6 +7566,11 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"zO" = (
+/obj/structure/closet/secure_closet/medical3,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zP" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -7069,7 +7690,9 @@
 	},
 /area/medical/medbay/zone2)
 "Ah" = (
-/obj/machinery/recharge_station,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "Ai" = (
@@ -7428,12 +8051,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Bn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "Bo" = (
@@ -7474,6 +8094,13 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
+"By" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Bz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -7514,6 +8141,18 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"BL" = (
+/obj/structure/table,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/item/storage/belt/medical,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "BM" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
@@ -7560,6 +8199,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
+"BU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Security Post Maint";
+	req_access_txt = "63;12"
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/starboard/fore)
 "BV" = (
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -7676,15 +8322,15 @@
 	},
 /area/cargo/warehouse)
 "Co" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "Cp" = (
 /obj/structure/chair/office,
 /obj/structure/sign/poster/contraband/random{
@@ -7694,8 +8340,9 @@
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
 "Cq" = (
+/obj/machinery/airalarm/directional/west,
 /obj/machinery/disposal/bin,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/iron/white,
 /area/medical/psychology)
 "Cr" = (
 /obj/structure/table,
@@ -7746,6 +8393,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"Cx" = (
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Medbay";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Cz" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
@@ -7977,6 +8634,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
+"Dh" = (
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Di" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8096,9 +8759,9 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "Dz" = (
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/table,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "DB" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/soda_cans/canned_laughter,
@@ -8245,6 +8908,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"Ed" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Ee" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -8447,9 +9114,9 @@
 	},
 /area/holodeck/rec_center)
 "EI" = (
-/obj/structure/closet/secure_closet/psychology,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "EK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -8513,11 +9180,9 @@
 /turf/closed/wall,
 /area/medical/break_room)
 "ET" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
+/obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "EU" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -8819,8 +9484,11 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "FP" = (
-/turf/closed/wall,
-/area/maintenance/fore)
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "FQ" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Warden Perma Office";
@@ -8899,10 +9567,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "FZ" = (
-/obj/machinery/light/directional/south,
-/obj/structure/chair{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
 	},
@@ -9131,6 +9795,9 @@
 /obj/item/construction/plumbing,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"GP" = (
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "GQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -9167,6 +9834,10 @@
 /obj/structure/urinal/directional/north,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"GV" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "GW" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -9185,12 +9856,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Access";
+	req_access_txt = "5"
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Hb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -9299,6 +9971,11 @@
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
+"Hs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Ht" = (
 /obj/structure/frame/machine{
 	color = "#B392CB"
@@ -9578,6 +10255,17 @@
 /obj/item/paper_bin,
 /turf/open/floor/wood,
 /area/service/library/printer)
+"Ii" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Ij" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -9690,23 +10378,19 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Iz" = (
-/obj/structure/urinal/directional/east,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "IB" = (
-/obj/machinery/door/airlock/medical{
-	name = "Psychology";
-	req_access_txt = "70"
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "IC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -9726,12 +10410,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "IE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Bathroom Maintenance";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/iron/white,
 /area/medical/break_room)
 "IG" = (
 /obj/structure/cable,
@@ -9740,11 +10420,11 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "II" = (
-/obj/structure/table/wood,
-/obj/machinery/light/directional/north,
-/obj/item/toy/figure/psychologist,
+/obj/structure/mirror/directional/north,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "IJ" = (
 /obj/item/target,
 /obj/item/target,
@@ -9772,10 +10452,6 @@
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "IN" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -9916,6 +10592,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"Jk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Jn" = (
 /obj/machinery/button/door/directional/west{
 	id = "xenobio2";
@@ -9932,14 +10618,16 @@
 /turf/closed/wall,
 /area/medical/psychology)
 "Jp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"Jq" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Jr" = (
 /obj/structure/sign/painting/library_secure{
 	pixel_x = -32
@@ -9965,18 +10653,24 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"Jz" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "JA" = (
 /turf/open/floor/plating/airless,
 /area/commons/toilet)
+"JB" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "JC" = (
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
-"JE" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "JF" = (
 /obj/effect/spawner/lootdrop/prison_contraband,
 /obj/structure/closet/crate/hydroponics,
@@ -10015,7 +10709,7 @@
 /area/command/heads_quarters/hos)
 "JL" = (
 /obj/structure/table,
-/obj/item/toy/plush/batong,
+/obj/item/toy/plush/fly,
 /turf/open/floor/iron,
 /area/security/prison)
 "JM" = (
@@ -10026,6 +10720,10 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "JN" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "JO" = (
@@ -10061,6 +10759,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"JR" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "JT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -10212,6 +10914,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"Kp" = (
+/obj/structure/table/glass,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medigel/sterilizine,
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Kq" = (
 /obj/machinery/door/airlock{
 	id_tag = "Green Dorm";
@@ -10307,7 +11016,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "KC" = (
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "KD" = (
@@ -10327,6 +11035,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"KI" = (
+/obj/machinery/defibrillator_mount{
+	pixel_x = -28
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "KL" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
@@ -10363,6 +11077,10 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"KP" = (
+/obj/machinery/suit_storage_unit/cmo,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "KQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -10495,6 +11213,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"Ll" = (
+/obj/structure/bed/dogbed/runtime,
+/mob/living/simple_animal/pet/cat/runtime,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Lm" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
@@ -10572,10 +11295,18 @@
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"LA" = (
-/obj/machinery/light/blacklight/directional/east,
+"Lz" = (
+/obj/structure/table/wood,
+/obj/machinery/camera{
+	c_tag = "Psychology";
+	name = "Psychology Camera";
+	network = list("ss13","medbay")
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/psychology)
 "LC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -10611,7 +11342,8 @@
 /area/space)
 "LI" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/item/folder/blue,
+/obj/item/folder/white,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "LJ" = (
@@ -10653,9 +11385,32 @@
 /turf/open/floor/iron,
 /area/security/office)
 "LQ" = (
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/door/airlock/medical{
+	name = "Break Room";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"LT" = (
+/obj/structure/table/glass,
+/obj/item/cartridge/medical,
+/obj/item/cartridge/medical,
+/obj/item/cartridge/medical,
+/obj/item/cartridge/chemistry,
+/obj/item/toy/figure/cmo,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "LU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/spawner/structure/window/reinforced,
@@ -10718,9 +11473,9 @@
 	},
 /area/service/abandoned_gambling_den)
 "Mc" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/medical/psychology)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/break_room)
 "Md" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
@@ -10742,9 +11497,7 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "Mh" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "Mi" = (
@@ -10825,6 +11578,12 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"My" = (
+/obj/structure/table,
+/obj/item/storage/box/syringes,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Mz" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
@@ -10867,6 +11626,14 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"MD" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "ME" = (
 /turf/open/floor/plating,
 /area/cargo/warehouse)
@@ -10902,6 +11669,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"MK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "ML" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -10910,6 +11687,23 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"MM" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "MN" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Grenade testing"
@@ -10949,6 +11743,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"MT" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"MU" = (
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "MV" = (
 /obj/structure/sign/poster/official/space_cops{
 	pixel_y = 30
@@ -11003,9 +11805,10 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "Nd" = (
-/obj/machinery/light/blacklight/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "Ng" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -11052,15 +11855,26 @@
 /area/engineering/lobby)
 "Nl" = (
 /obj/machinery/newscaster/directional/west,
-/obj/structure/chair{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "Nm" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
+"Nn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "No" = (
 /obj/effect/spawner/randomarcade{
 	dir = 8
@@ -11134,6 +11948,16 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"NA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "NB" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -11185,6 +12009,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"NG" = (
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "NH" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -11225,6 +12053,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"NP" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "NQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -11264,9 +12096,7 @@
 /turf/open/floor/wood,
 /area/space)
 "NY" = (
-/obj/structure/mirror/directional/north,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
+/obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "NZ" = (
@@ -11338,6 +12168,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"Ok" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Ol" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -11470,6 +12306,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"OH" = (
+/obj/structure/industrial_lift{
+	id = "publicElevator"
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "OI" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -11579,7 +12421,6 @@
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
 "Pb" = (
-/obj/machinery/light/blacklight/directional/west,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -11588,7 +12429,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "Pc" = (
 /obj/structure/sink{
 	pixel_y = 25
@@ -11719,7 +12560,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "Pr" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -11786,6 +12627,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"Px" = (
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"Py" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Pz" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/floor/plating/asteroid/airless,
@@ -11806,7 +12658,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "PD" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -11839,13 +12691,13 @@
 	name = "Outside Psychology Camera";
 	network = list("ss13","medbay")
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "PG" = (
 /turf/open/floor/plating/airless,
 /area/space)
 "PH" = (
-/obj/machinery/light/blacklight/directional/east,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
@@ -11853,7 +12705,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "PI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -11906,19 +12758,34 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"PR" = (
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/neck/stethoscope,
+/obj/machinery/computer/security/telescreen/cmo{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "PS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "PT" = (
-/obj/structure/curtain,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "PV" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/closed/wall,
+/area/security/checkpoint/medical)
 "PW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -12060,6 +12927,21 @@
 /obj/item/toy/dummy,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"Qs" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"Qt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Qu" = (
 /obj/structure/window{
 	dir = 8
@@ -12178,6 +13060,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"QO" = (
+/obj/machinery/computer/crew,
+/obj/machinery/light_switch/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "QP" = (
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/south,
@@ -12187,19 +13075,9 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "QR" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Bathrooms";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "QS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -12294,6 +13172,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Rg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
@@ -12368,6 +13249,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"Ru" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "surgeryblock";
+	name = "Surgery B Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/zone2)
 "Rv" = (
 /obj/item/plunger,
 /turf/open/floor/iron/white,
@@ -12393,8 +13282,16 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "RE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/psychologist,
+/obj/machinery/button/door/directional/north{
+	id = "psychology";
+	name = "Privacy Button";
+	pixel_x = 5;
+	pixel_y = 35;
+	req_access_txt = "70"
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
@@ -12504,9 +13401,18 @@
 /turf/open/floor/iron/white,
 /area/commons/dorms)
 "RT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Bathrooms";
+	req_access_txt = "5"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "RU" = (
@@ -12630,6 +13536,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"Sj" = (
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "Sk" = (
 /obj/structure/railing{
 	dir = 4
@@ -12705,15 +13614,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "St" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
-	},
-/obj/structure/sign/departments/psychology{
-	pixel_x = -32
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
@@ -12737,6 +13642,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"Sx" = (
+/obj/structure/closet/secure_closet/chief_medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Sy" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -12890,19 +13799,15 @@
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
 "Te" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Tg" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/item/bedsheet/qm,
@@ -12920,11 +13825,15 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "Tk" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/folder/white,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "Tl" = (
 /turf/open/floor/wood,
 /area/space)
@@ -12935,6 +13844,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"Tn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "To" = (
 /obj/machinery/light/blacklight/directional/north,
 /turf/open/floor/iron,
@@ -13027,6 +13940,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"TC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/starboard/fore)
 "TD" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -13037,6 +13960,10 @@
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
+"TF" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "TG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -13081,6 +14008,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"TO" = (
+/obj/structure/sink{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = -8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "TP" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -13239,6 +14174,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"Uv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/psychology)
 "Uw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -13321,15 +14265,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "UK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "UL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -13374,10 +14314,7 @@
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "US" = (
-/obj/machinery/door/airlock{
-	id_tag = "medtoilet1";
-	name = "Stall A"
-	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "UT" = (
@@ -13578,7 +14515,7 @@
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
-/area/holodeck/rec_center)
+/area/maintenance/fore)
 "Vr" = (
 /obj/structure/chair{
 	dir = 8
@@ -13641,12 +14578,16 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "Vz" = (
-/obj/machinery/door/airlock{
-	id_tag = "medtoilet2";
-	name = "Stall B"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "VB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -13663,12 +14604,14 @@
 /turf/open/floor/iron/white,
 /area/security/prison/work)
 "VF" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/maintenance/fore)
+/area/medical/medbay/zone2)
 "VG" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13685,6 +14628,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"VJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "VK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -14019,9 +14972,13 @@
 /turf/closed/wall/r_wall,
 /area/security/prison/work)
 "WW" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"WX" = (
+/obj/structure/noticeboard/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "WY" = (
 /obj/machinery/plate_press,
 /obj/structure/sign/poster/contraband/random{
@@ -14126,20 +15083,30 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Xj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "Xk" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/range)
+"Xn" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "Xo" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -14178,6 +15145,14 @@
 "Xv" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"Xw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "CMO Office"
+	},
+/turf/open/floor/plating,
+/area/medical/medbay/zone2)
 "Xx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/closed/wall,
@@ -14194,11 +15169,12 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "XA" = (
-/obj/structure/chair{
-	pixel_y = -2
+/obj/machinery/door/airlock{
+	id_tag = "medtoilet1";
+	name = "Stall A"
 	},
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "XB" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -14236,7 +15212,11 @@
 /turf/open/floor/glass/reinforced,
 /area/space)
 "XG" = (
-/turf/open/openspace,
+/obj/machinery/door/airlock{
+	id_tag = "medtoilet2";
+	name = "Stall B"
+	},
+/turf/open/floor/iron/white,
 /area/medical/break_room)
 "XH" = (
 /obj/structure/rack,
@@ -14482,6 +15462,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"Yw" = (
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Yx" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -14605,6 +15589,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"YQ" = (
+/obj/machinery/holopad,
+/turf/open/floor/glass/reinforced,
+/area/medical/medbay/zone2)
 "YR" = (
 /obj/machinery/atmospherics/pipe/multiz/dark/visible{
 	dir = 8
@@ -14613,6 +15601,14 @@
 /area/engineering/atmos/upper)
 "YS" = (
 /turf/open/openspace,
+/area/medical/medbay/zone2)
+"YU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "YV" = (
 /obj/machinery/flasher/directional/south{
@@ -14733,12 +15729,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "Zp" = (
-/obj/machinery/light/directional/north,
-/obj/structure/chair{
-	pixel_y = -2
+/obj/machinery/door/airlock{
+	name = "Stall C"
 	},
 /turf/open/floor/iron/white,
-/area/medical/psychology)
+/area/medical/break_room)
 "Zq" = (
 /obj/machinery/computer/slot_machine,
 /obj/structure/sign/poster/contraband/random{
@@ -14841,6 +15836,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"ZK" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "ZL" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -14938,6 +15938,14 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"ZX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "surgeryblock";
+	name = "Surgery B Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "ZY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -44320,7 +45328,7 @@ Wa
 XM
 Iz
 Iz
-Iz
+dl
 XO
 tv
 aG
@@ -53847,11 +54855,11 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+ct
+ct
+ct
+ct
+ct
 Eg
 Eg
 Eg
@@ -54104,14 +55112,14 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-FP
+ct
+YB
+YB
+YB
+YB
+YB
+YB
+HW
 HW
 HW
 HW
@@ -54361,14 +55369,14 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-FP
+ct
+YB
+YB
+YB
+YB
+YB
+YB
+HW
 HW
 HW
 HW
@@ -54618,14 +55626,14 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-FP
+ct
+YB
+YB
+YB
+YB
+YB
+YB
+HW
 HW
 HW
 HW
@@ -54875,30 +55883,30 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-FP
+ct
+YB
+YB
+YB
+ES
+ES
+ES
+ES
+ES
 HW
 HW
-HW
 Eg
 Eg
 Eg
 Eg
 Eg
 Eg
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
+XV
+XV
+XV
+XV
+XV
+XV
+XV
 MF
 MF
 MF
@@ -55132,34 +56140,34 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+ct
+YB
+YB
+YB
+ES
 FP
-HW
-HW
-HW
-HW
-HW
-HW
 FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+FP
+ES
+HW
+HW
+HW
+HW
+HW
+XV
+MU
+KI
+Yw
+Jz
+wg
+Ed
+KI
+Dh
+XV
+MF
+MF
+MF
 Fx
-MF
-MF
-MF
-Jo
 Jo
 Jo
 Jo
@@ -55389,35 +56397,35 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-FP
+ct
+YB
+YB
+YB
+ES
+EI
+KC
+KC
+ES
 HW
 HW
 HW
 HW
 HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+XV
+uk
+Vo
+sJ
+hN
+Es
+zC
+Vo
+zc
+XV
+MF
 MF
 MF
 MF
 Jo
-Tk
 LI
 yh
 WW
@@ -55646,38 +56654,38 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-FP
+ct
+YB
+YB
+YB
+ES
+ET
+KC
+KC
+ES
 HW
 HW
 HW
 HW
 HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+XV
+Kp
+Vo
+st
+mW
+mW
+Vo
+Vo
+zK
+XV
+MF
 MF
 MF
 MF
 Jo
-fp
+Lz
 ZN
 ZN
-Qp
 Qp
 BO
 eQ
@@ -55903,12 +56911,13 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
+ct
+YB
+YB
+YB
 ES
+ES
+NY
 ES
 ES
 ES
@@ -55916,25 +56925,24 @@ ES
 HW
 HW
 HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+XV
+fL
+dM
+Jk
+jG
+jG
+Vo
+Vo
+NP
+XV
+MF
 MF
 MF
 MF
 Jo
-II
 zf
 RE
-Qp
+St
 Qp
 Dx
 eQ
@@ -56161,37 +57169,37 @@ ct
 ct
 ct
 ct
-ct
-ct
-ct
-ct
+YB
+YB
+YB
 ES
-JE
-JE
-JE
+IB
+KC
+KC
+XA
+xV
 ES
 HW
 HW
 HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
-MF
-MF
+XV
+XV
+XV
+mx
+Ru
+Ru
+Ru
+ZX
+ZX
+PV
+PV
+PV
+PV
 MF
 Jo
-qx
+eX
 ZN
-wA
-Qp
+jD
 Qp
 Dx
 eQ
@@ -56421,33 +57429,33 @@ PG
 PG
 PG
 PG
-YB
 ES
+IB
 KC
 JN
-JN
+ES
+ES
 ES
 HW
 HW
 HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
-MF
-MF
+XV
+np
+Vo
+Jk
+Vo
+Vo
+Qs
+xj
+ZK
+ks
+uy
+Px
+PV
 MF
 Jo
-rH
+TF
 ZN
-rI
 vb
 Rg
 Dx
@@ -56678,34 +57686,34 @@ nW
 nW
 nW
 HM
-YB
+wL
+Mh
+Mh
+Ss
+XG
+dc
 ES
-LA
-JN
-JN
-ES
 HW
 HW
 HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
-MF
+XV
+vU
+Vo
+Jk
+Vo
+Vo
+Vo
+xj
+gk
+Ok
+Xn
 Jp
-TZ
-wM
-pm
-pm
-qL
-Qp
+PV
+MF
+Jo
+ZN
+ZN
+Uv
 Qp
 dF
 Jo
@@ -56934,35 +57942,35 @@ YB
 YB
 YB
 YB
-HM
-YB
+PG
 ES
-ES
+IE
+Mh
 PT
 ES
 ES
 ES
-ES
 HW
 HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
-MF
+HW
+XV
+My
+Tn
+cx
+Vo
+Vo
+Vo
+xj
+tJ
+GP
+pC
 pC
 PV
+MF
 Jo
-EI
 vj
+zj
 gA
-Mc
 ym
 AC
 Jo
@@ -57191,39 +58199,39 @@ ct
 ct
 YB
 YB
-HM
-YB
+PG
 ES
+II
 Mh
-JN
-JN
+Tk
+Zp
 US
-ta
 ES
 HW
 HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
-MF
-pC
+HW
+XV
+BL
+Vo
+VJ
+Nd
+Nd
+Nd
+Cx
+By
+sa
+tp
+tp
 PV
+MF
 Jo
 Jo
 Jo
-IB
+vW
 Jo
 Jo
 Jo
-Jo
-Bb
+Bf
 Bb
 Bb
 Bb
@@ -57445,42 +58453,42 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-nW
-YB
 ES
-Mh
+ES
+qx
+ES
+ES
+ES
+ES
 RT
-xS
 ES
 ES
 ES
 HW
 HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
-MF
-pC
+HW
+XV
+nu
+cl
+YU
+NG
+XV
+XV
 PV
+zH
+zH
+PV
+BU
+PV
+MF
 Jo
-XA
-ZN
+ek
 gA
 St
 dW
 Nl
-Jo
-Bb
+wF
+Bf
 Bb
 Bb
 Bb
@@ -57702,42 +58710,42 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-nW
-nW
-IE
-on
-Ss
-JN
-Vz
-dl
 ES
+gG
+KC
+rI
+wM
+ES
+Vo
+ov
+Vo
+Vo
+XV
 HW
 HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+HW
+XV
+qR
+Vo
+Jk
+Vo
+Xw
+QO
+qN
+so
+cW
+XV
 MF
-pC
-PV
+MF
+MF
 Jo
-Zp
-ZN
-xL
+Nn
+gm
 vz
 hL
 FZ
-Jo
-Bb
+kL
+Bf
 Bb
 Bb
 Bb
@@ -57959,42 +58967,42 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
 ES
+iN
+qL
+sw
+xS
+LQ
 Nd
 UK
-gG
-ES
-ES
-ES
+Vo
+oD
+XV
 HW
 HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+HW
+XV
+zO
+Vo
+Jk
+Vo
+Xw
+yx
+Sj
+LT
+PR
+XV
 MF
-pC
-PV
-iN
-ZN
-ZN
+le
+TZ
+TC
+eY
 ZN
 ZN
 ZN
 xL
 IN
-bN
+qw
 OJ
 Bb
 Bb
@@ -58216,42 +59224,42 @@ Mu
 Mu
 Mu
 Mu
-ql
-ql
-ql
-ql
-ql
 ES
-NY
-Xj
-LQ
-tR
+kj
+rH
+ta
 Ah
-ES
-HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+Mc
+Vo
+ov
+Vo
+tR
+XV
+XV
+XV
+Vq
+XV
+XV
+gz
+Qt
+gz
+Xw
+jj
+GV
+nr
+qp
+XV
 MF
-pC
-PV
+MK
+MF
 Jo
-Dz
 PF
 sS
 aL
 aL
-kj
-Jo
-Bb
+aL
+uJ
+Bf
 Nv
 bN
 bN
@@ -58473,42 +59481,42 @@ Mu
 Mu
 Mu
 Mu
-Mu
-Mu
-Mu
-Mu
-Mu
 ES
+KC
+KC
+wA
+Dz
 ES
 QR
-ES
-ES
-ES
-ES
-HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+ov
+Vo
+Vo
+Vo
+Jq
+XV
+Vo
+Vo
+XV
+hS
+Jk
+Vo
+Xw
+Sx
+Sj
+YQ
+eP
+XV
 MF
-pC
-PV
-Jo
+MK
+Fx
 Jo
 Jo
 sS
 aL
 aL
-kj
-Jo
-Bb
+aL
+uJ
+Bf
 ce
 Bb
 Bb
@@ -58730,42 +59738,42 @@ Mu
 Mu
 nZ
 ro
-Mu
-Mu
+fp
+pm
 fK
 fK
 fK
 aK
 Pb
 Co
-fk
-fk
+zl
+zl
 VF
-HW
-HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+VF
+ob
+zl
+zl
+ob
+zl
+UK
+Vo
+Xw
+KP
+Sj
+Sj
+mg
+XV
 MF
-pC
-PV
+MK
 cT
 CL
 Jo
 hf
 ci
 ci
-ET
-Jo
-Bb
+ci
+ik
+Bf
 ce
 Bb
 Bb
@@ -58995,25 +60003,25 @@ HS
 aK
 Pq
 nq
-XG
-XG
-ES
-HW
-HW
-HW
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+Vo
+Vo
+YS
+YS
+XV
+Vo
+Vo
+XV
+hU
+ll
+Vo
+Xw
+Vo
+jp
+Py
+oJ
+XV
 MF
-pC
-MF
+wc
 cT
 CL
 Jo
@@ -59021,8 +60029,8 @@ eQ
 eQ
 eQ
 eQ
-Jo
-Bb
+eQ
+Bf
 ce
 Bb
 Bb
@@ -59252,25 +60260,25 @@ Qb
 ZV
 fY
 on
-XG
-XG
-ES
-FP
-FP
-FP
-FP
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+Vo
+Vo
+YS
+YS
+XV
+iV
+XV
+XV
+yD
+ll
+Vo
+Xw
+Ll
+mQ
+xo
+kE
+XV
 MF
-pC
-MF
+wc
 cT
 CL
 CL
@@ -59278,7 +60286,7 @@ CL
 CL
 CL
 CL
-Bf
+CL
 Bf
 ce
 Bb
@@ -59509,25 +60517,25 @@ Nq
 aK
 PC
 iY
-XG
-XG
-ES
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+Vo
+Vo
+YS
+YS
+XV
 MF
-pC
+XV
+JR
+Vo
+ll
+Jq
+XV
+Xw
+wf
+Xw
+Xw
+XV
 MF
+wc
 cT
 CL
 EX
@@ -59766,25 +60774,25 @@ Ip
 aK
 PH
 xF
-wL
-wL
-ES
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+Vo
+Vo
+yU
+XV
+XV
 MF
-pC
+XV
+Qs
+Vo
+ll
+Vo
+WX
+Vo
+ll
+Vo
+br
+XV
 MF
+wc
 cT
 CL
 EX
@@ -60021,27 +61029,27 @@ fK
 GA
 LF
 aK
-ES
+Vo
 Te
-ES
-ES
-ES
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+Hs
+Hs
+jl
+XV
 MF
-pC
 MF
+XV
+XV
+XV
+jW
+uE
+uE
+uE
+UK
+Vo
+br
+XV
+MF
+wc
 cT
 CL
 CL
@@ -60278,27 +61286,27 @@ fK
 GI
 ih
 aK
+Vo
+Vz
+vk
+on
+JB
+XV
 MF
-Zm
 MF
-Fx
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+XV
+bK
+fR
+zn
+Vo
+Vo
+Tn
+aT
+Vo
+TO
+XV
 MF
-pC
-MF
+wc
 cT
 CL
 EX
@@ -60535,27 +61543,27 @@ fK
 Hz
 Zu
 aK
+XV
+Xj
+XV
+XV
+XV
+XV
 MF
-Zm
 MF
-Fx
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
+XV
+MD
+OH
+zn
+Vo
+Vo
+cl
+gC
+za
+lR
+XV
 MF
-pC
-MF
+wc
 cT
 CL
 EX
@@ -60795,24 +61803,24 @@ aK
 MF
 Zm
 MF
-Fx
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Mu
-Fx
 MF
-pC
 MF
+MF
+MF
+MF
+XV
+rt
+lM
+MM
+Vo
+Vo
+Vo
+rX
+ll
+MT
+XV
+MF
+wc
 cT
 CL
 EX
@@ -61046,30 +62054,30 @@ AO
 Nm
 aK
 fK
-MF
-MF
-MF
+Mu
+Mu
+Fx
 MF
 Zm
 MF
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
-Fx
 MF
-pC
 MF
+MF
+MF
+MF
+XV
+XV
+XV
+XV
+XV
+XV
+XV
+XV
+bJ
+XV
+XV
+MF
+wc
 cT
 CL
 EX
@@ -61303,9 +62311,9 @@ BI
 xg
 yK
 fK
-MF
-MF
-MF
+Mu
+Mu
+Fx
 MF
 Zm
 MF
@@ -61320,13 +62328,13 @@ MF
 MF
 MF
 MF
+XV
+Tn
+aT
+Vo
+XV
 MF
-Fx
-MF
-MF
-MF
-pC
-MF
+wc
 cT
 CL
 CL
@@ -61560,9 +62568,9 @@ Cj
 lC
 Fm
 fK
-MF
-MF
-MF
+Mu
+Mu
+Fx
 MF
 Tz
 TZ
@@ -61577,13 +62585,13 @@ TZ
 TZ
 TZ
 TZ
-TZ
+aP
 zl
 tW
-md
-md
+zl
+dx
 Bn
-MF
+NA
 cT
 CL
 EX
@@ -61817,30 +62825,30 @@ VS
 lC
 FF
 fK
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
-MF
+Mu
+Mu
 Fx
-Zm
-PV
-PV
-PV
-PV
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+MF
+XV
+cl
+oq
+Vo
+XV
+MF
+MF
 cT
 CL
 CL
@@ -62074,8 +63082,8 @@ mc
 mc
 fK
 fK
-sw
-sw
+Mu
+Mu
 Fx
 Fx
 Fx
@@ -62091,7 +63099,7 @@ Fx
 Fx
 Fx
 Fx
-Fx
+XV
 XV
 GZ
 XV
@@ -63378,7 +64386,7 @@ Mu
 Mu
 Mu
 XV
-ov
+Ii
 Vo
 Vo
 Vo

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -5,6 +5,10 @@
 "ab" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/visit)
+"ad" = (
+/obj/structure/curtain,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "ae" = (
 /obj/machinery/door/airlock/public{
 	id_tag = "Perma Bathroom 2";
@@ -230,6 +234,10 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"aU" = (
+/obj/structure/curtain,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "aV" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
@@ -563,6 +571,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"cb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "cc" = (
 /obj/machinery/plate_press,
 /turf/open/floor/iron,
@@ -1398,6 +1415,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"eP" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "eQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1419,6 +1440,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"eU" = (
+/turf/open/floor/plating,
+/area/medical/break_room)
 "eV" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -1484,20 +1508,25 @@
 "fg" = (
 /obj/structure/table,
 /obj/item/storage/box/monkeycubes,
-/turf/open/floor/iron/white,
+/turf/open/floor/grass,
 /area/medical/virology)
 "fh" = (
 /obj/machinery/camera{
 	c_tag = "Virology - Monkey Pen";
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron/white,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
 /area/medical/virology)
 "fi" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"fj" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "fl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -1516,18 +1545,8 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "fn" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet1";
-	name = "Stall A Button";
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/turf/closed/wall,
+/area/medical/patients_rooms)
 "fo" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1536,10 +1555,8 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "fp" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/turf/closed/wall,
+/area/maintenance/fore)
 "fq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -1741,13 +1758,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "fY" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Medbay - Bathrooms";
-	dir = 8;
-	network = list("ss13","medbay")
-	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "ga" = (
@@ -2300,6 +2312,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/space)
+"hS" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "hT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2380,7 +2402,10 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "ih" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4;
+	name = "Virology air supply valve"
+	},
 /turf/open/floor/plating,
 /area/medical/virology)
 "ii" = (
@@ -2619,10 +2644,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "iW" = (
+/mob/living/carbon/human/species/monkey,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/grass,
 /area/medical/virology)
 "iX" = (
 /obj/structure/window{
@@ -2791,6 +2817,25 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"jA" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "jB" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/wood,
@@ -2811,9 +2856,8 @@
 /area/medical/medbay/zone2)
 "jE" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/turf/closed/wall,
+/area/medical/break_room)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -3010,6 +3054,12 @@
 /obj/item/clothing/under/misc/burial,
 /turf/open/floor/iron/dark,
 /area/space)
+"ko" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "kq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -3494,14 +3544,11 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/grass,
 /area/medical/virology)
 "lE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/white,
+/turf/open/floor/grass,
 /area/medical/virology)
 "lF" = (
 /obj/structure/table,
@@ -3818,6 +3865,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"mD" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "mE" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/end{
@@ -4222,6 +4275,7 @@
 "nY" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
+/obj/item/storage/secure/safe/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nZ" = (
@@ -4988,8 +5042,9 @@
 	name = "Medbay Maintenance";
 	req_access_txt = "5"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/maintenance/fore)
 "qz" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -5073,6 +5128,7 @@
 /area/security/prison)
 "qL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "qN" = (
@@ -5245,6 +5301,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"rt" = (
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "rv" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -5504,8 +5566,8 @@
 /obj/structure/sign/departments/restroom{
 	pixel_x = -30
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/turf/closed/wall,
+/area/medical/break_room)
 "sk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -5535,7 +5597,6 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "sr" = (
-/obj/structure/cable,
 /obj/machinery/door_buttons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
 	idInterior = "virology_airlock_interior";
@@ -5545,8 +5606,9 @@
 	pixel_y = -4;
 	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/sink{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ss" = (
@@ -5579,6 +5641,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "sx" = (
@@ -5761,9 +5824,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "tb" = (
@@ -5782,6 +5842,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
+"td" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/obj/machinery/space_heater,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/medical/virology)
 "tf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -5889,6 +5957,9 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"tu" = (
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "tv" = (
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
@@ -6492,10 +6563,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/starboard)
-"vx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "vy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -6815,16 +6882,6 @@
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"wA" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "wB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -6891,13 +6948,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "wL" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medical Bathroom Maintenance";
-	req_access_txt = "12"
+/obj/machinery/newscaster/directional/east,
+/obj/structure/toilet,
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet2";
+	name = "Stall B Button";
+	pixel_y = -7;
+	req_access_txt = "2"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/space)
+/area/medical/break_room)
 "wM" = (
 /obj/structure/table,
 /obj/item/toy/mecha/odysseus,
@@ -7229,6 +7289,7 @@
 "xS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "xT" = (
@@ -7518,6 +7579,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"zc" = (
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "zf" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
@@ -7647,18 +7715,8 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "zx" = (
-/obj/structure/toilet{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/west{
-	id = "medtoilet2";
-	name = "Stall B Button";
-	pixel_y = -7;
-	req_access_txt = "2"
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/turf/open/floor/plating/airless,
+/area/maintenance/fore)
 "zy" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/iron/white,
@@ -7859,6 +7917,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"Af" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
+/area/medical/virology)
 "Ag" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7871,11 +7933,9 @@
 	},
 /area/medical/medbay/zone2)
 "Ah" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "Ai" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -8157,6 +8217,10 @@
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
 /area/medical/medbay/zone2)
+"AX" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "AY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -8241,6 +8305,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"Bm" = (
+/obj/machinery/light/directional/north,
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "Bn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -8590,12 +8659,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "CC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/west{
 	id = "Virology";
 	name = "Virology Shutters";
@@ -8614,11 +8677,9 @@
 /area/space)
 "CG" = (
 /obj/structure/cable,
-/obj/structure/sink{
-	dir = 1
-	},
 /obj/machinery/light/directional/south,
-/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "CH" = (
@@ -8847,6 +8908,7 @@
 "Dn" = (
 /obj/structure/cable,
 /obj/structure/closet/l3closet/virology,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "Do" = (
@@ -8928,7 +8990,9 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "Dz" = (
-/obj/structure/table,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "DB" = (
@@ -9376,16 +9440,13 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "ER" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/grass,
 /area/medical/virology)
 "ES" = (
 /turf/closed/wall,
 /area/medical/break_room)
 "ET" = (
-/obj/machinery/light/blacklight/directional/east,
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "EU" = (
@@ -9526,7 +9587,6 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/effect/spawner/lootdrop/donkpockets,
-/obj/item/storage/secure/safe/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Fo" = (
@@ -9638,12 +9698,12 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "FD" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_one_access_txt = "5;12"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Dormitories";
+	req_access_txt = "5"
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "FE" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -9679,21 +9739,8 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "FM" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/camera{
-	c_tag = "Virology - Entrance";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/obj/structure/flora/grass/green,
+/turf/open/floor/grass,
 /area/medical/virology)
 "FN" = (
 /obj/structure/sink{
@@ -9710,11 +9757,10 @@
 /turf/open/floor/plating/airless,
 /area/space)
 "FP" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/break_room)
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/medical/virology)
 "FQ" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "Warden Perma Office";
@@ -9775,14 +9821,24 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "FX" = (
-/obj/structure/closet/l3closet/virology,
+/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -25;
+	pixel_y = 25;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "FY" = (
@@ -9963,15 +10019,17 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "GA" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/grass,
 /area/medical/virology)
 "GB" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard)
+"GC" = (
+/obj/machinery/light_switch/directional/north,
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "GE" = (
 /obj/machinery/duct,
 /turf/open/floor/carpet,
@@ -9998,8 +10056,10 @@
 /turf/open/floor/wood,
 /area/space)
 "GI" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
 /area/medical/virology)
 "GK" = (
@@ -10276,7 +10336,8 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Hz" = (
-/obj/machinery/atmospherics/components/tank/air,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
 /area/medical/virology)
 "HA" = (
@@ -10401,14 +10462,8 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "HS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -30
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/grass,
 /area/medical/virology)
 "HT" = (
 /obj/structure/table,
@@ -10579,10 +10634,10 @@
 /turf/open/openspace,
 /area/service/bar)
 "Ip" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Emergency Oxygen Supply"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -10639,8 +10694,9 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "IB" = (
-/obj/structure/sink{
-	pixel_y = 20
+/obj/machinery/door/airlock{
+	id_tag = "medtoilet1";
+	name = "Stall A"
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
@@ -10663,7 +10719,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "IE" = (
-/obj/structure/mirror/directional/north,
+/obj/machinery/door/airlock{
+	name = "Stall C"
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "IG" = (
@@ -10987,8 +11045,10 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "JN" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -11177,6 +11237,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"Kn" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "Ko" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -11573,6 +11637,10 @@
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"LB" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "LC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -11586,11 +11654,13 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "LF" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/on{
-	dir = 4;
-	name = "Virology air supply valve"
+/obj/machinery/door/airlock/maintenance{
+	name = "Emergency Oxygen Supply"
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "LG" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -11673,6 +11743,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "LR" = (
@@ -11778,7 +11849,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Mh" = (
-/obj/structure/cable,
+/obj/machinery/door/airlock{
+	id_tag = "medtoilet2";
+	name = "Stall B"
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "Mi" = (
@@ -11907,6 +11981,17 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"MD" = (
+/obj/structure/closet/l3closet/virology,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "ME" = (
 /turf/open/floor/plating,
 /area/cargo/warehouse)
@@ -11995,6 +12080,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"MU" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "MV" = (
 /obj/structure/sign/poster/official/space_cops{
 	pixel_y = 30
@@ -12143,11 +12232,11 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Nq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -12317,6 +12406,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"NS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "NT" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
@@ -12336,7 +12431,9 @@
 /turf/open/floor/wood,
 /area/space)
 "NY" = (
-/obj/structure/curtain,
+/obj/structure/sink{
+	pixel_y = 25
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "NZ" = (
@@ -12408,6 +12505,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
+"Ok" = (
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "Ol" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -12795,6 +12897,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Pr" = (
@@ -12876,12 +12979,10 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "PC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "PD" = (
@@ -12967,6 +13068,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"PL" = (
+/obj/machinery/newscaster/directional/east,
+/obj/structure/toilet,
+/obj/machinery/button/door/directional/west{
+	id = "medtoilet1";
+	name = "Stall A Button";
+	pixel_y = -7;
+	req_access_txt = "2"
+	},
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "PM" = (
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
@@ -13000,17 +13112,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"PT" = (
-/obj/machinery/airalarm/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/break_room)
 "PU" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/hud/health,
@@ -13067,12 +13168,13 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Qb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -30
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "Qd" = (
@@ -13321,9 +13423,9 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "QR" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/medical/virology)
 "QS" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -13384,6 +13486,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
+"Rd" = (
+/obj/machinery/camera{
+	c_tag = "Medbay - Bathrooms";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/structure/mirror/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
 "Re" = (
 /obj/machinery/chem_heater/withbuffer,
 /obj/machinery/light/directional/south,
@@ -13462,6 +13573,33 @@
 "Rl" = (
 /turf/open/floor/carpet,
 /area/service/bar)
+"Rm" = (
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_exterior";
+	name = "Virology Exterior Airlock";
+	req_access_txt = "39"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_exterior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_x = -24;
+	req_access_txt = "39"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "Rn" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -13912,10 +14050,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "Ss" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "St" = (
@@ -13945,23 +14085,8 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "Sy" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/white,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
 /area/medical/virology)
 "Sz" = (
 /obj/structure/bed,
@@ -13990,24 +14115,27 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"SG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Dormitory Maintenance";
+	req_one_access_txt = "5;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "SI" = (
-/obj/structure/cable,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -25;
-	pixel_y = 25;
-	req_access_txt = "39"
+/obj/machinery/camera{
+	c_tag = "Virology - Entrance";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -14022,6 +14150,10 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"SO" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "SP" = (
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
@@ -14131,11 +14263,11 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "Tk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -14420,6 +14552,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/green,
 /area/space)
+"Uc" = (
+/obj/structure/mirror/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "Ud" = (
 /obj/machinery/camera{
 	c_tag = "Holodeck - Fore";
@@ -14442,6 +14578,13 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"Uh" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Medical Bathroom Maintenance";
+	req_access_txt = "5"
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/fore)
 "Ui" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/xenobiology)
@@ -14625,7 +14768,7 @@
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "US" = (
-/obj/machinery/recharge_station,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "UT" = (
@@ -15135,6 +15278,10 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"Wq" = (
+/obj/structure/closet/secure_closet/personal/patient,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 6
@@ -15482,10 +15629,7 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "XA" = (
-/obj/machinery/door/airlock{
-	id_tag = "medtoilet1";
-	name = "Stall A"
-	},
+/obj/structure/mirror/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "XB" = (
@@ -15525,12 +15669,14 @@
 /turf/open/floor/glass/reinforced,
 /area/space)
 "XG" = (
-/obj/machinery/door/airlock{
-	id_tag = "medtoilet2";
-	name = "Stall B"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "XH" = (
 /obj/structure/rack,
 /obj/item/circuitboard/aicore,
@@ -15968,6 +16114,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"Zd" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "Ze" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/randomsnackvend,
@@ -16035,11 +16185,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "Zp" = (
-/obj/machinery/door/airlock{
-	name = "Stall C"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/virology)
 "Zq" = (
 /obj/machinery/computer/slot_machine,
 /obj/structure/sign/poster/contraband/random{
@@ -16068,11 +16221,7 @@
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
 "Zu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
-	},
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
 /turf/open/floor/plating,
 /area/medical/virology)
 "Zv" = (
@@ -16240,30 +16389,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ZV" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_exterior";
-	name = "Virology Exterior Airlock";
-	req_access_txt = "39"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -24;
-	req_access_txt = "39"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ZX" = (
@@ -55182,11 +55313,11 @@ Mu
 Mu
 Mu
 Mu
-ct
-ct
-ct
-ct
-ct
+Mu
+Mu
+Mu
+Mu
+fp
 Eg
 Eg
 Eg
@@ -55439,13 +55570,13 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
-YB
-YB
+Mu
+Mu
+fp
+fp
+fp
+HW
+HW
 HW
 HW
 HW
@@ -55696,13 +55827,13 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
-YB
-YB
+Mu
+fp
+fp
+HW
+HW
+HW
+HW
 HW
 HW
 HW
@@ -55953,13 +56084,13 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-YB
-YB
-YB
+Mu
+fp
+HW
+HW
+HW
+HW
+HW
 HW
 HW
 HW
@@ -56210,17 +56341,17 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-ES
-ES
-ES
-ES
-ES
+Mu
+fp
 HW
 HW
+HW
+HW
+HW
+HW
+HW
+fn
+SG
 Eg
 Eg
 Eg
@@ -56467,20 +56598,20 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
-ES
-FP
-FP
-FP
-ES
+fp
+fp
 HW
 HW
 HW
 HW
 HW
+HW
+HW
+fn
+tu
+SO
+ad
+rt
 Wh
 Nn
 hj
@@ -56724,20 +56855,20 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
+fp
+HW
+HW
+HW
+eU
 ES
-KC
-KC
-KC
+Uh
 ES
-HW
-HW
-HW
-HW
-HW
+ES
+fn
+eP
+tu
+fn
+fn
 Wh
 pk
 rN
@@ -56981,20 +57112,20 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
+fp
+HW
+HW
+HW
+eU
 ES
+NY
 ET
 KC
-ET
-ES
-HW
-HW
-HW
-HW
-HW
+fn
+Zd
+tu
+ad
+rt
 Wh
 GP
 rN
@@ -57238,20 +57369,20 @@ Mu
 Mu
 Mu
 Mu
-ct
-YB
-YB
-YB
+fp
+HW
+HW
+ES
 ES
 ES
 NY
-ES
-ES
-ES
-ES
-HW
-HW
-HW
+NS
+XA
+fn
+Ok
+tu
+fn
+fn
 Wh
 eg
 Jx
@@ -57488,27 +57619,27 @@ ct
 ct
 ct
 ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-YB
-YB
-YB
+fp
+fp
+fp
+fp
+fp
+fp
+fp
+fp
+HW
+HW
 ES
+PL
 IB
 KC
-KC
+cb
 XA
 fn
-ES
-HW
-HW
-HW
+Ok
+tu
+tu
+Uc
 Wh
 Wh
 Wh
@@ -57745,27 +57876,27 @@ PG
 PG
 PG
 PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
-PG
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
+zx
 ES
-IB
-KC
+ES
+ES
+Kn
 JN
-ES
-ES
-ES
-HW
-HW
-HW
+Rd
+fn
+Ok
+tu
+AX
+Uc
 XV
 lK
 Vo
@@ -58002,27 +58133,27 @@ nW
 nW
 nW
 nW
-nW
-nW
-nW
-nW
-nW
-nW
-nW
-nW
-nW
-nW
-HM
+Ah
+Ah
+Ah
+Ah
+Ah
+Ah
+Ah
+Ah
+Ah
+Ah
+ES
 wL
 Mh
-Mh
+KC
 Ss
-XG
-zx
 ES
-HW
-HW
-HW
+ES
+ES
+ES
+Wq
+tu
 XV
 PU
 Vo
@@ -58259,27 +58390,27 @@ YB
 YB
 YB
 YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-YB
-PG
+HW
+HW
+HW
+HW
+HW
+HW
+HW
+HW
+HW
+Ah
 ES
-IE
+ES
+ES
 KC
-PT
+Ss
+aU
+mD
+mD
 ES
-ES
-ES
-HW
-HW
-HW
+Bm
+tu
 XV
 TI
 Bj
@@ -58516,27 +58647,27 @@ ct
 ct
 ct
 ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-ct
-YB
-YB
-PG
+fp
+fp
+fp
+fp
+fp
+fp
+fp
+fp
+HW
+Ah
 ES
+LB
 IE
 fY
 Tk
-Zp
-US
 ES
-HW
-HW
-HW
+US
+KC
+ES
+GC
+tu
 XV
 es
 Vo
@@ -58789,11 +58920,11 @@ ES
 ES
 RT
 ES
+zc
+zc
 ES
-ES
-HW
-HW
-HW
+Wq
+tu
 XV
 yj
 SY
@@ -59039,7 +59170,7 @@ Mu
 Mu
 ES
 gG
-KC
+fj
 rI
 wM
 ES
@@ -59047,9 +59178,9 @@ Vo
 ov
 sj
 jE
-XV
-XV
-XV
+ES
+ES
+fn
 FD
 XV
 vJ
@@ -59300,10 +59431,10 @@ qL
 sw
 xS
 LQ
-Nd
+ko
 UK
 Vo
-Vo
+MU
 qH
 xC
 Vo
@@ -59555,7 +59686,7 @@ ES
 kj
 rH
 ta
-Ah
+KC
 Mc
 Vo
 iw
@@ -59810,11 +59941,11 @@ Mu
 Mu
 ES
 ed
-fp
-wA
+KC
 Dz
-ES
-QR
+Dz
+Mc
+Vo
 ov
 Vo
 Vo
@@ -60067,9 +60198,9 @@ nZ
 ro
 ES
 pm
-fK
-fK
-fK
+yK
+hS
+VS
 aK
 Pb
 Co
@@ -60325,8 +60456,8 @@ sW
 fK
 fK
 fK
-FM
-HS
+fK
+fK
 aK
 Pq
 nq
@@ -60578,14 +60709,14 @@ QN
 KF
 QN
 uT
-uT
+XG
 CC
 sr
-Sy
+fK
 SI
 Qb
-ZV
-dp
+aK
+qN
 on
 Vo
 Vo
@@ -60835,13 +60966,13 @@ Cm
 Nm
 lC
 kb
-kb
-kb
+Zp
+ZV
 CG
-fK
+jA
 FX
 Nq
-aK
+Rm
 PC
 iY
 Vo
@@ -61096,7 +61227,7 @@ vA
 tL
 Dn
 fK
-aK
+MD
 Ip
 aK
 PH
@@ -61353,7 +61484,7 @@ yv
 LY
 pQ
 fK
-GA
+aK
 LF
 aK
 Vo
@@ -62115,7 +62246,7 @@ Mu
 Mu
 fK
 fg
-sU
+GA
 lD
 Mz
 YK
@@ -62124,8 +62255,8 @@ kb
 lC
 Ea
 fK
-aK
-aK
+Af
+td
 aK
 MF
 Zm
@@ -62371,8 +62502,8 @@ Mu
 Mu
 Mu
 mc
-lC
-lC
+FM
+HS
 iW
 aK
 aK
@@ -62381,8 +62512,8 @@ AO
 Nm
 aK
 fK
-Mu
-Mu
+ct
+ct
 Fx
 MF
 Zm
@@ -62628,8 +62759,8 @@ Mu
 Mu
 Mu
 mc
-lC
-lC
+FP
+ER
 lE
 aK
 mP
@@ -62885,9 +63016,9 @@ Mu
 Mu
 Mu
 mc
-lC
-lC
-iW
+ER
+QR
+Sy
 Nm
 nb
 lC
@@ -63143,7 +63274,7 @@ Mu
 Mu
 fK
 fh
-vx
+ER
 ER
 aK
 nY

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -1889,6 +1889,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"gz" = (
+/obj/machinery/modular_computer/console/preset/cargochat/medical{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "gA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -1924,10 +1930,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
 /area/security/prison)
-"gI" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "gK" = (
 /obj/structure/chair{
 	dir = 1
@@ -3295,10 +3297,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/space)
-"le" = (
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "lf" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/turf_decal/tile{
@@ -3337,6 +3335,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "lj" = (
@@ -3547,6 +3546,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"lR" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "lS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -4204,6 +4207,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/medical/virology)
+"oa" = (
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "od" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -4290,6 +4297,15 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"ow" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ox" = (
@@ -5221,15 +5237,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"ru" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "rv" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -5592,6 +5599,12 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"sD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/medical/medbay/zone2)
 "sE" = (
 /obj/machinery/disposal/bin,
@@ -7381,6 +7394,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"yA" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "yB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -8337,6 +8356,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
+"BU" = (
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "BV" = (
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -10979,8 +11002,10 @@
 /turf/open/floor/iron,
 /area/security/prison/work)
 "JR" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
+/obj/machinery/computer/cargo/request{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/medical/medbay/zone2)
 "JT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -11133,6 +11158,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"Kp" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "Kq" = (
 /obj/machinery/door/airlock{
 	id_tag = "Green Dorm";
@@ -11415,6 +11448,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"Li" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -12193,10 +12230,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"NG" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "NH" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -57197,7 +57230,7 @@ Jx
 Nf
 gC
 mv
-Wp
+Li
 Wp
 aQ
 Wh
@@ -57710,7 +57743,7 @@ lK
 Vo
 oD
 Vo
-Vo
+yA
 JR
 Ho
 wu
@@ -57967,8 +58000,8 @@ PU
 Vo
 oD
 Vo
-Vo
-Vo
+yA
+gz
 Ho
 xj
 Yj
@@ -58224,8 +58257,8 @@ TI
 Bj
 cy
 Vo
-Vo
-Vo
+sD
+Kp
 Ho
 bD
 Jz
@@ -60012,7 +60045,7 @@ fK
 aK
 Pb
 Co
-NG
+lR
 Vo
 VF
 VF
@@ -60281,7 +60314,7 @@ on
 qN
 Vo
 cd
-gI
+oa
 rQ
 ZX
 jz
@@ -61567,7 +61600,7 @@ Vo
 Vo
 Vo
 Bj
-ru
+ow
 Vo
 Mg
 XV
@@ -64654,7 +64687,7 @@ ct
 xV
 Vo
 Vo
-le
+BU
 Vo
 Vo
 Vo

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -171,6 +171,12 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"aD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "aE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 5
@@ -808,6 +814,7 @@
 /area/science/robotics/mechbay)
 "cW" = (
 /obj/machinery/vending/drugs,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "cZ" = (
@@ -1357,6 +1364,10 @@
 	},
 /turf/open/floor/iron,
 /area/medical/medbay/zone2)
+"eK" = (
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "eL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1889,12 +1900,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"gz" = (
-/obj/machinery/modular_computer/console/preset/cargochat/medical{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "gA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -2027,6 +2032,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"hb" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "hc" = (
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
@@ -2798,6 +2809,10 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"jG" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/white,
+/area/maintenance/starboard/fore)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -3238,6 +3253,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"kV" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "kW" = (
 /obj/structure/railing{
 	dir = 6
@@ -3546,10 +3565,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
-"lR" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "lS" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -4207,10 +4222,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/medical/virology)
-"oa" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "od" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -4297,15 +4308,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
-"ow" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ox" = (
@@ -5600,12 +5602,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"sD" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "sE" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera{
@@ -5679,6 +5675,15 @@
 "sO" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
+"sP" = (
+/obj/structure/frame/machine{
+	color = "#B392CB"
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron{
+	initial_gas_mix = "n2=104;TEMP=293.15"
+	},
+/area/medical/medbay/zone2)
 "sQ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "mechbay";
@@ -7148,6 +7153,10 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"xJ" = (
+/obj/effect/landmark/start/chemist,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "xK" = (
 /obj/structure/curtain,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -7288,6 +7297,15 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"ye" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "yf" = (
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
@@ -7394,12 +7412,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"yA" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "yB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -8356,10 +8368,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
-"BU" = (
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "BV" = (
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -9122,6 +9130,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "Eo" = (
@@ -9980,6 +9989,13 @@
 "GK" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
+"GL" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "GM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
@@ -10206,6 +10222,14 @@
 /obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
+"Hs" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/hand_labeler,
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "Ht" = (
 /obj/structure/frame/machine{
 	color = "#B392CB"
@@ -10428,6 +10452,10 @@
 "HW" = (
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"HX" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "HY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -11158,14 +11186,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"Kp" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/hand_labeler,
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
 "Kq" = (
 /obj/machinery/door/airlock{
 	id_tag = "Green Dorm";
@@ -11448,10 +11468,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"Li" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "Lj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -14453,6 +14469,12 @@
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"Us" = (
+/obj/machinery/modular_computer/console/preset/cargochat/medical{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/medical/medbay/zone2)
 "Ut" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
@@ -57230,7 +57252,7 @@ Jx
 Nf
 gC
 mv
-Li
+kV
 Wp
 aQ
 Wh
@@ -57743,7 +57765,7 @@ lK
 Vo
 oD
 Vo
-yA
+aD
 JR
 Ho
 wu
@@ -58000,8 +58022,8 @@ PU
 Vo
 oD
 Vo
-yA
-gz
+aD
+Us
 Ho
 xj
 Yj
@@ -58257,8 +58279,8 @@ TI
 Bj
 cy
 Vo
-sD
-Kp
+hb
+Hs
 Ho
 bD
 Jz
@@ -58519,7 +58541,7 @@ Nd
 Cx
 KP
 WH
-Lu
+GL
 Lu
 PV
 MF
@@ -60045,7 +60067,7 @@ fK
 aK
 Pb
 Co
-lR
+HX
 Vo
 VF
 VF
@@ -60314,7 +60336,7 @@ on
 qN
 Vo
 cd
-oa
+eK
 rQ
 ZX
 jz
@@ -61078,7 +61100,7 @@ Vo
 dT
 dT
 Ft
-II
+jG
 XV
 cW
 Vo
@@ -61600,7 +61622,7 @@ Vo
 Vo
 Vo
 Bj
-ow
+ye
 Vo
 Mg
 XV
@@ -64687,7 +64709,7 @@ ct
 xV
 Vo
 Vo
-BU
+xJ
 Vo
 Vo
 Vo
@@ -64697,7 +64719,7 @@ Ir
 jt
 Nj
 Gu
-Ht
+sP
 Dw
 EX
 EX

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -30,7 +30,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ai" = (
@@ -206,9 +205,12 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "aQ" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/table/glass,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/hemostat,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "aR" = (
 /obj/item/toy/plush/slimeplushie,
 /turf/open/floor/engine,
@@ -403,7 +405,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "bB" = (
 /obj/machinery/button/door/directional/south{
 	id = "permafrontshutters";
@@ -594,13 +596,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"cl" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/openspace,
-/area/medical/medbay/zone2)
 "cm" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -725,10 +720,9 @@
 /area/security/prison/safe)
 "cI" = (
 /obj/structure/table/optable,
-/obj/item/toy/figure/md,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "cJ" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -749,6 +743,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/space)
+"cN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "cO" = (
 /obj/structure/railing{
 	dir = 4
@@ -839,8 +844,17 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "dd" = (
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
@@ -889,6 +903,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"do" = (
+/obj/structure/table/optable,
+/obj/item/toy/figure/md,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "dp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1053,7 +1072,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "dU" = (
@@ -1139,8 +1157,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "ed" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ee" = (
@@ -1156,11 +1173,14 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
 "eg" = (
-/obj/structure/closet/secure_closet/medical2,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/hemostat,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "eh" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -1186,6 +1206,15 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "el" = (
@@ -1290,6 +1319,24 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
+"eF" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"eG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "eH" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -1300,12 +1347,16 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "eJ" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
+/obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/machinery/light/floor,
-/turf/open/openspace,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/medical/medbay/zone2)
 "eL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1332,8 +1383,7 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "eO" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "eQ" = (
@@ -1403,7 +1453,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access_txt = "12"
+	req_one_access_txt = "5;12"
 	},
 /turf/open/floor/iron/white,
 /area/maintenance/starboard/fore)
@@ -1475,8 +1525,18 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "fp" = (
-/turf/closed/wall/r_wall,
-/area/medical/break_room)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "fq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -1619,16 +1679,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"fP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "fQ" = (
 /obj/machinery/atmospherics/pipe/multiz/orange/visible{
 	dir = 4
@@ -1688,11 +1738,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "fY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ga" = (
@@ -1858,20 +1905,17 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "gC" = (
-/obj/structure/table/glass,
-/obj/item/scalpel,
-/obj/item/retractor,
-/obj/effect/turf_decal/siding/blue{
-	color = "#73c2fb";
-	name = "medical blue"
+/obj/machinery/computer/operating{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "gE" = (
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "gG" = (
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "gH" = (
@@ -2020,7 +2064,7 @@
 	pixel_x = -28
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "hk" = (
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -2148,6 +2192,17 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
+"hE" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "hF" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
@@ -2209,6 +2264,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"hN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "hO" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -2316,14 +2381,7 @@
 /turf/open/floor/carpet/green,
 /area/space)
 "ij" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "il" = (
@@ -2395,7 +2453,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "iw" = (
-/obj/item/radio/intercom/directional/south,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "iy" = (
@@ -2504,8 +2562,12 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/table/glass,
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/scalpel,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "iS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -2618,7 +2680,7 @@
 /area/security/prison)
 "jp" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/machinery/status_display/ai/directional/east,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "jr" = (
@@ -2707,7 +2769,10 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "jE" = (
-/obj/machinery/newscaster/directional/north,
+/obj/structure/railing{
+	dir = 1;
+	layer = 3.1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "jH" = (
@@ -3003,11 +3068,8 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "kC" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
+/obj/machinery/bounty_board/directional/south,
+/turf/open/floor/iron/white,
 /area/maintenance/starboard/fore)
 "kD" = (
 /obj/structure/table/reinforced,
@@ -3228,11 +3290,11 @@
 "lg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access_txt = "12"
+	req_one_access_txt = "5;12"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lh" = (
@@ -3528,6 +3590,17 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
+"lZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ma" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -3799,8 +3872,12 @@
 /area/space)
 "mW" = (
 /obj/machinery/light_switch/directional/west,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "mX" = (
 /obj/machinery/power/emitter,
 /obj/machinery/light/directional/north,
@@ -4409,7 +4486,7 @@
 /obj/structure/table/optable,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "pl" = (
 /obj/structure/railing,
 /turf/open/floor/iron/white,
@@ -4757,6 +4834,12 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"qk" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "ql" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -4919,7 +5002,10 @@
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
 "qH" = (
-/obj/machinery/door/firedoor,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "qI" = (
@@ -5081,7 +5167,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "ro" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -5097,10 +5183,10 @@
 "rq" = (
 /obj/structure/table/glass,
 /obj/item/surgical_drapes,
-/obj/item/book/manual/wiki/surgery,
 /obj/machinery/vending/wallmed/directional/south,
+/obj/item/cautery,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "rr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -5250,11 +5336,8 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "rN" = (
-/obj/structure/table/glass,
-/obj/item/hemostat,
-/obj/item/cautery,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "rO" = (
 /turf/open/openspace,
 /area/science/xenobiology)
@@ -5523,8 +5606,12 @@
 /area/engineering/atmos/upper)
 "sM" = (
 /obj/machinery/airalarm/directional/west,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "sN" = (
 /obj/machinery/atmospherics/pipe/multiz/cyan/visible/layer4{
 	dir = 1
@@ -5603,7 +5690,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "ta" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -5782,14 +5869,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "tK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "tL" = (
@@ -5815,6 +5897,15 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "tN" = (
@@ -5830,9 +5921,12 @@
 /turf/open/floor/plating,
 /area/service/hydroponics/upper)
 "tR" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_one_access_txt = "5;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tS" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/purple,
@@ -6059,12 +6153,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ux" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/maintenance/starboard/fore)
 "uA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard/fifty,
@@ -6255,6 +6345,12 @@
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"vk" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "vl" = (
 /obj/structure/chair{
 	dir = 4
@@ -6263,14 +6359,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "vm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Virology Access";
-	req_access_txt = "5"
+/obj/structure/railing/corner{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "vo" = (
@@ -6313,6 +6404,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/starboard)
+"vw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -6722,7 +6817,6 @@
 "wM" = (
 /obj/structure/table,
 /obj/item/toy/mecha/odysseus,
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "wO" = (
@@ -6945,16 +7039,9 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "xC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/light/blacklight/directional/north,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/maintenance/starboard/fore)
 "xE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -7144,6 +7231,7 @@
 /area/medical/psychology)
 "yj" = (
 /obj/structure/closet/secure_closet/medical3,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "yk" = (
@@ -7151,7 +7239,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "ym" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
@@ -7277,13 +7365,12 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "yO" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/table/glass,
+/obj/item/cautery,
+/obj/item/surgical_drapes,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "yP" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry W";
@@ -7533,18 +7620,12 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "zJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 9
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/sign/departments/chemistry{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/turf/open/openspace,
+/area/maintenance/starboard/fore)
 "zK" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
@@ -7861,11 +7942,13 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "AM" = (
+/obj/structure/industrial_lift,
 /obj/structure/railing{
-	layer = 3.1
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/obj/machinery/light/floor,
+/turf/open/openspace,
+/area/maintenance/starboard/fore)
 "AN" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -8113,7 +8196,7 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "BG" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
@@ -8301,11 +8384,11 @@
 /area/cargo/warehouse)
 "Co" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
@@ -8946,6 +9029,19 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"Ep" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/sign/departments/chemistry{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Er" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 8
@@ -9339,17 +9435,12 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Ft" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
+/turf/open/openspace,
+/area/maintenance/starboard/fore)
 "Fv" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -9417,22 +9508,8 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "FD" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/zone2)
+/turf/closed/wall,
+/area/medical/surgery/room_b)
 "FE" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -9816,8 +9893,9 @@
 /obj/item/surgical_drapes,
 /obj/item/reagent_containers/medigel/sterilizine,
 /obj/machinery/vending/wallmed/directional/north,
+/obj/item/cautery,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "GQ" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -9877,6 +9955,15 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Access";
 	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
@@ -10624,6 +10711,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"Jk" = (
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Jl" = (
 /obj/structure/bed/dogbed/runtime,
 /mob/living/simple_animal/pet/cat/runtime,
@@ -10685,8 +10776,9 @@
 	req_access_txt = "5"
 	},
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "Jy" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/white,
@@ -11331,7 +11423,7 @@
 	name = "Surgery B Privacy Door"
 	},
 /turf/open/floor/plating,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "Ly" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/blacklight/directional/south,
@@ -11436,6 +11528,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "LR" = (
@@ -11871,7 +11964,7 @@
 "Nn" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/surgery/room_b)
 "No" = (
 /obj/effect/spawner/randomarcade{
 	dir = 8
@@ -13020,11 +13113,23 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "QI" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 6
+/obj/machinery/door/airlock/medical/glass{
+	name = "Virology Access";
+	req_access_txt = "5"
 	},
-/turf/open/openspace,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "QJ" = (
 /obj/structure/closet/emcloset,
@@ -13165,8 +13270,11 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "Ri" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace,
 /area/medical/medbay/zone2)
 "Rj" = (
 /obj/structure/table/reinforced,
@@ -13345,11 +13453,21 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "RL" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 5
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
 	},
-/turf/open/openspace,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/medical/medbay/zone2)
 "RM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -13419,6 +13537,15 @@
 	},
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "RU" = (
@@ -13803,10 +13930,10 @@
 /area/engineering/lobby)
 "Te" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -14232,6 +14359,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"UF" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "UG" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/orange,
@@ -14243,10 +14374,10 @@
 /turf/open/floor/iron,
 /area/security/prison/workout)
 "UJ" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/industrial_lift{
+	id = "publicElevator"
 	},
-/turf/open/floor/iron/white,
+/turf/open/openspace,
 /area/medical/medbay/zone2)
 "UK" = (
 /obj/structure/cable,
@@ -14363,7 +14494,7 @@
 "Va" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
-	dir = 10
+	dir = 6
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
@@ -14603,12 +14734,9 @@
 /turf/open/floor/iron/white,
 /area/security/prison/work)
 "VF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "VG" = (
@@ -14742,10 +14870,8 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Wh" = (
-/obj/structure/industrial_lift{
-	id = "publicElevator"
-	},
-/turf/open/openspace,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Wj" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -15094,7 +15220,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_access_txt = "12"
+	req_one_access_txt = "5;12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -15337,13 +15463,8 @@
 /turf/open/floor/plating,
 /area/security/prison/upper)
 "Yf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/structure/railing/corner,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Yg" = (
@@ -15357,14 +15478,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "Yh" = (
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/railing{
+	layer = 3.1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Yi" = (
@@ -15595,6 +15711,16 @@
 /area/engineering/atmos/upper)
 "YS" = (
 /turf/open/openspace,
+/area/medical/medbay/zone2)
+"YU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "YV" = (
 /obj/machinery/flasher/directional/south{
@@ -15909,7 +16035,7 @@
 /area/science/xenobiology)
 "ZU" = (
 /obj/structure/cable,
-/obj/machinery/light/blacklight/directional/east,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ZV" = (
@@ -55900,13 +56026,13 @@ Eg
 Eg
 Eg
 Eg
-XV
-XV
-XV
-XV
-XV
-XV
-XV
+FD
+FD
+FD
+FD
+FD
+FD
+FD
 MF
 MF
 MF
@@ -56154,7 +56280,7 @@ HW
 HW
 HW
 HW
-XV
+FD
 Nn
 hj
 mW
@@ -56163,7 +56289,7 @@ iR
 sM
 hj
 yk
-XV
+FD
 MF
 MF
 MF
@@ -56411,16 +56537,16 @@ HW
 HW
 HW
 HW
-XV
+FD
 pk
-Vo
+rN
 rm
 BF
-Es
+vw
 bA
-Vo
+rN
 cI
-XV
+FD
 MF
 MF
 MF
@@ -56668,16 +56794,16 @@ HW
 HW
 HW
 HW
-XV
+FD
 GP
-Vo
+rN
 sZ
 rN
 rN
-Vo
-Vo
+rN
+rN
 rq
-XV
+FD
 MF
 MF
 MF
@@ -56925,16 +57051,16 @@ ES
 HW
 HW
 HW
-XV
+FD
 eg
 Jx
-oD
+hN
 gC
-gC
-Vo
-Vo
+do
+UF
+UF
 aQ
-XV
+FD
 MF
 MF
 MF
@@ -57182,9 +57308,9 @@ ES
 HW
 HW
 HW
-XV
-XV
-XV
+FD
+FD
+FD
 dc
 Lx
 Lx
@@ -58719,11 +58845,11 @@ ES
 Vo
 ov
 Vo
-Vo
+fY
 XV
-HW
-HW
-HW
+XV
+XV
+tR
 XV
 vJ
 Vo
@@ -58976,11 +59102,11 @@ LQ
 Nd
 UK
 Vo
+Vo
+ij
 iw
-XV
-HW
-HW
-HW
+Vo
+Vo
 XV
 jp
 Vo
@@ -59231,18 +59357,18 @@ ta
 Ah
 Mc
 Vo
-ov
-Vo
-tR
-XV
-XV
-XV
-Vq
-XV
-XV
-qH
+fp
+vW
+vW
+vW
+vW
+vW
+vW
+QI
+vW
+vW
 tK
-qH
+Vo
 cd
 wU
 ZE
@@ -59492,12 +59618,12 @@ ov
 Vo
 Vo
 Vo
-RD
-XV
 Vo
 Vo
+Vo
 XV
-Ri
+Wh
+Vo
 oD
 Vo
 cd
@@ -59738,7 +59864,7 @@ Mu
 Mu
 nZ
 ro
-fp
+ES
 pm
 fK
 fK
@@ -59746,16 +59872,16 @@ fK
 aK
 Pb
 Co
-zl
-zl
+Vo
+Vo
 VF
 VF
 vm
-zl
-zl
-vm
-zl
-UK
+ux
+XV
+Vo
+Vo
+qN
 Vo
 cd
 aM
@@ -60007,11 +60133,11 @@ Vo
 Vo
 YS
 YS
-XV
-Vo
-Vo
-XV
 jE
+xC
+XV
+qk
+on
 qN
 Vo
 cd
@@ -60258,19 +60384,19 @@ Sy
 SI
 Qb
 ZV
-fY
+dp
 on
 Vo
 Vo
 YS
 YS
-XV
+jE
 kC
 XV
 XV
 eO
-qN
-Vo
+eG
+eO
 cd
 Jl
 TO
@@ -60521,8 +60647,8 @@ Vo
 Vo
 YS
 YS
-XV
-MF
+jE
+ux
 XV
 hF
 Vo
@@ -60777,11 +60903,11 @@ xF
 Vo
 Vo
 dT
+dT
+qH
+ux
 XV
-XV
-MF
-XV
-JR
+Jk
 Vo
 qN
 Vo
@@ -61032,14 +61158,14 @@ aK
 Vo
 Te
 vW
-vW
+no
 fu
+RD
+Fx
+Fx
 XV
-MF
-MF
 XV
-XV
-XV
+Vo
 ah
 no
 no
@@ -61286,18 +61412,18 @@ fK
 GI
 ih
 aK
-Vo
+ed
 Vz
 ZU
 on
 oJ
-XV
-MF
-MF
-XV
-cl
-Va
-Ft
+Vo
+Fx
+zJ
+Ri
+eJ
+Vo
+Vo
 Vo
 Vo
 Bj
@@ -61549,12 +61675,12 @@ XV
 XV
 XV
 XV
-MF
-MF
-XV
+Fx
+AM
+UJ
 eJ
-Wh
-Ft
+Vo
+Vo
 Vo
 Vo
 SY
@@ -61806,12 +61932,12 @@ MF
 MF
 MF
 MF
-MF
-MF
-XV
+Fx
+Ft
+Va
 RL
-QI
-FD
+Vo
+Vo
 Vo
 Vo
 Vo
@@ -62063,8 +62189,8 @@ MF
 MF
 MF
 MF
-MF
-MF
+Fx
+Fx
 XV
 XV
 XV
@@ -62585,7 +62711,7 @@ TZ
 TZ
 TZ
 TZ
-fP
+lg
 zl
 tW
 zl
@@ -63356,14 +63482,14 @@ Mu
 Mu
 Mu
 Mu
-Mu
-XV
+ct
+YU
 Yf
-ed
 oH
 oH
 oH
-ux
+eF
+Es
 HI
 mw
 mw
@@ -63613,14 +63739,14 @@ Mu
 Mu
 Mu
 Mu
-Mu
-XV
+ct
 ov
-AM
+Yh
 YS
 YS
 YS
-UJ
+vk
+Vo
 Wy
 AJ
 mm
@@ -63870,14 +63996,14 @@ Mu
 Mu
 Mu
 Mu
-Mu
-XV
+ct
+hE
 Yh
-AM
 YS
 YS
 YS
-UJ
+vk
+Vo
 gX
 qq
 mm
@@ -64127,9 +64253,9 @@ Mu
 Mu
 Mu
 Mu
-Mu
-XV
-xC
+ct
+cN
+Vo
 Vo
 Vo
 Vo
@@ -64384,9 +64510,9 @@ Mu
 Mu
 Mu
 Mu
-Mu
-XV
-ij
+ct
+lZ
+Vo
 Vo
 Vo
 Vo
@@ -64641,9 +64767,9 @@ Mu
 Mu
 Mu
 Mu
-Mu
-XV
-zJ
+ct
+Ep
+Es
 Es
 Es
 Es
@@ -64898,7 +65024,7 @@ Mu
 Mu
 Mu
 Mu
-Mu
+ql
 dG
 uw
 IT

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -160,6 +160,10 @@
 /area/engineering/lobby)
 "aB" = (
 /obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/camera{
+	c_tag = "Virology - Isolation A";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aC" = (
@@ -182,6 +186,12 @@
 /obj/item/soap/homemade,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"aI" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "aJ" = (
 /obj/structure/toilet,
 /turf/open/floor/iron/white,
@@ -743,17 +753,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/space)
-"cN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/light/blacklight/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "cO" = (
 /obj/structure/railing{
 	dir = 4
@@ -806,6 +805,10 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
+"cW" = (
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "cZ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Permabrig Maintenance";
@@ -863,6 +866,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
+"df" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "dg" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -878,8 +885,7 @@
 "dk" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/camera{
-	c_tag = "Virology Isolation A";
-	name = "Virology Camera";
+	c_tag = "Virology - Isolation B";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -903,11 +909,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"do" = (
-/obj/structure/table/optable,
-/obj/item/toy/figure/md,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "dp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -1157,9 +1158,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "ed" = (
-/obj/machinery/light/blacklight/directional/east,
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/break_room)
 "ee" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window{
@@ -1193,6 +1198,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/office)
+"ej" = (
+/obj/machinery/camera{
+	c_tag = "Medbay - Chemistry Lab N";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "ek" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Medical Officer's Office";
@@ -1257,6 +1269,10 @@
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera{
+	c_tag = "Medbay - Storage B";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "et" = (
@@ -1319,24 +1335,6 @@
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
-"eF" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
-"eG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "eH" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -1476,8 +1474,7 @@
 /area/medical/virology)
 "fh" = (
 /obj/machinery/camera{
-	c_tag = "Virology Monkey Pen";
-	name = "Virology Camera";
+	c_tag = "Virology - Monkey Pen";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -1525,18 +1522,10 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "fp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/break_room)
 "fq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -1738,10 +1727,15 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "fY" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Medbay - Bathrooms";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/break_room)
 "ga" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -1786,6 +1780,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"gf" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "gg" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -2159,6 +2160,12 @@
 	},
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
+"hy" = (
+/obj/structure/industrial_lift{
+	id = "publicElevator"
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "hz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -2192,17 +2199,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
-"hE" = (
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "hF" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
@@ -2264,16 +2260,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"hN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "hO" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -2381,7 +2367,7 @@
 /turf/open/floor/carpet/green,
 /area/space)
 "ij" = (
-/obj/machinery/light/dim/directional/west,
+/obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "il" = (
@@ -2453,7 +2439,16 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "iw" = (
-/obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "iy" = (
@@ -2540,12 +2535,25 @@
 "iN" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera{
-	c_tag = "Medbay Break Room";
-	name = "Medbay Break Room Camera";
+	c_tag = "Medbay - Break Room";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"iO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Medbay - Chemistry Lab Entrance";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "iP" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
@@ -2556,7 +2564,7 @@
 /area/space)
 "iR" = (
 /obj/machinery/camera{
-	c_tag = "Surgery B";
+	c_tag = "Medbay - Surgery B";
 	dir = 4;
 	name = "Surgery B Camera";
 	network = list("ss13","medbay")
@@ -2768,11 +2776,19 @@
 /obj/item/beacon,
 /turf/open/floor/iron/dark,
 /area/space)
-"jE" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1
+"jD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"jE" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "jH" = (
@@ -2937,7 +2953,7 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "kj" = (
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "kk" = (
@@ -3308,6 +3324,12 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"li" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "lj" = (
 /obj/structure/window/reinforced/tinted{
 	pixel_y = -4
@@ -3526,8 +3548,7 @@
 /area/medical/virology)
 "lT" = (
 /obj/machinery/camera{
-	c_tag = "Virology";
-	name = "Virology Camera";
+	c_tag = "Virology - Center";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/airalarm/directional/north,
@@ -3573,7 +3594,7 @@
 /obj/machinery/requests_console/directional/south{
 	department = "Virology";
 	departmentType = 2;
-	name = "Virology RC"
+	name = "Virology Requests Console"
 	},
 /turf/open/floor/iron/dark,
 /area/medical/virology)
@@ -3590,17 +3611,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
-"lZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "ma" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -3731,6 +3741,11 @@
 "mu" = (
 /turf/open/openspace,
 /area/holodeck/rec_center)
+"mv" = (
+/obj/structure/table/optable,
+/obj/item/toy/figure/md,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "mw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -3833,8 +3848,7 @@
 "mP" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/machinery/camera{
-	c_tag = "Virology Break Room";
-	name = "Virology Camera";
+	c_tag = "Virology - Break Room";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -3871,10 +3885,14 @@
 /turf/open/floor/iron/dark,
 /area/space)
 "mW" = (
-/obj/machinery/light_switch/directional/west,
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -12
+	},
+/obj/machinery/requests_console/directional/west{
+	department = "Surgery";
+	departmentType = 1;
+	name = "Surgery Requests Console"
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
@@ -4740,14 +4758,13 @@
 /area/security/prison)
 "pY" = (
 /obj/structure/table/wood,
-/obj/machinery/camera{
-	c_tag = "Psychology";
-	name = "Psychology Camera";
-	network = list("ss13","medbay")
-	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/camera{
+	c_tag = "Medbay - Psychology";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "pZ" = (
@@ -4834,12 +4851,6 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/security/prison)
-"qk" = (
-/obj/machinery/newscaster/directional/north,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "ql" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -5002,10 +5013,7 @@
 /turf/open/floor/plating/airless,
 /area/holodeck/rec_center)
 "qH" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/status_display/ai/directional/east,
+/obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "qI" = (
@@ -5548,6 +5556,25 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"sB" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Virology Access";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "sE" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera{
@@ -5695,6 +5722,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "tb" = (
@@ -5720,6 +5750,10 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"th" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "ti" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -5837,9 +5871,8 @@
 "tC" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/camera{
-	c_tag = "CMO";
+	c_tag = "Medbay - CMO Office";
 	dir = 1;
-	name = "CMO Camera";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/glass/reinforced,
@@ -5868,6 +5901,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"tJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light/blacklight/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "tK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -5921,12 +5965,12 @@
 /turf/open/floor/plating,
 /area/service/hydroponics/upper)
 "tR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_one_access_txt = "5;12"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "tS" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/purple,
@@ -5951,9 +5995,8 @@
 /area/medical/medbay/zone2)
 "tX" = (
 /obj/machinery/camera{
-	c_tag = "Chemistry S";
+	c_tag = "Medbay - Chemistry Lab S";
 	dir = 1;
-	name = "Chemistry Camera";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -6153,8 +6196,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "ux" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "uA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard/fifty,
@@ -6345,12 +6391,6 @@
 /obj/structure/closet/secure_closet/psychology,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"vk" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "vl" = (
 /obj/structure/chair{
 	dir = 4
@@ -6404,10 +6444,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/maintenance/starboard)
-"vw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "vx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -7039,9 +7075,9 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "xC" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "xE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -7157,6 +7193,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
+"xV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "xW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -7620,14 +7667,19 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "zJ" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/turf/open/openspace,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "zK" = (
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/camera{
+	c_tag = "Medbay - Sec Post Upper";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "zL" = (
@@ -7942,13 +7994,11 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "AM" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/light/floor,
-/turf/open/openspace,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "AN" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -8831,6 +8881,19 @@
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
+"DE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/sign/departments/chemistry{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "DF" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -9029,19 +9092,6 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"Ep" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/sign/departments/chemistry{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Er" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 8
@@ -9197,9 +9247,12 @@
 	},
 /area/holodeck/rec_center)
 "EI" = (
-/obj/machinery/newscaster/directional/north,
+/obj/structure/railing{
+	dir = 1;
+	layer = 3.1
+	},
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/medical/medbay/zone2)
 "EK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -9372,6 +9425,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"Fj" = (
+/obj/machinery/camera{
+	c_tag = "Medbay - Chemistry Lab E";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "Fk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -9435,12 +9496,12 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "Ft" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 5
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/turf/open/openspace,
-/area/maintenance/starboard/fore)
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Fv" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -9508,8 +9569,12 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "FD" = (
-/turf/closed/wall,
-/area/medical/surgery/room_b)
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_one_access_txt = "5;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "FE" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -9553,8 +9618,7 @@
 	dir = 9
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Airlock";
-	name = "Virology Camera";
+	c_tag = "Virology - Entrance";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -9818,6 +9882,17 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"Gz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "GA" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -10529,11 +10604,8 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "II" = (
-/obj/structure/mirror/directional/north,
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/break_room)
+/area/maintenance/starboard/fore)
 "IJ" = (
 /obj/item/target,
 /obj/item/target,
@@ -10711,10 +10783,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"Jk" = (
-/obj/machinery/vending/drugs,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "Jl" = (
 /obj/structure/bed/dogbed/runtime,
 /mob/living/simple_animal/pet/cat/runtime,
@@ -10773,10 +10841,15 @@
 /obj/machinery/button/door/directional/east{
 	id = "surgeryblock";
 	name = "Privacy Button";
+	pixel_x = 27;
+	pixel_y = 3;
 	req_access_txt = "5"
 	},
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/medical2,
+/obj/machinery/light_switch/directional/east{
+	pixel_y = -6
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "Jy" = (
@@ -11909,6 +11982,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"Nf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "Ng" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -12497,7 +12580,6 @@
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
 "Pb" = (
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -12755,13 +12837,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "PF" = (
+/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera{
-	c_tag = "Outer Psychology";
+	c_tag = "Medbay - Psychology Entrance";
 	dir = 8;
-	name = "Outside Psychology Camera";
 	network = list("ss13","medbay")
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "PG" = (
@@ -12773,6 +12854,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Virology Entrance";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
@@ -12845,6 +12930,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "PU" = (
@@ -12858,6 +12944,11 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/machinery/light/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "PV" = (
@@ -12878,6 +12969,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space)
+"PZ" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Qa" = (
 /obj/machinery/flasher/directional/south{
 	id = "Cell 5"
@@ -13113,24 +13211,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "QI" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Virology Access";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/maintenance/starboard/fore)
 "QJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13272,10 +13355,10 @@
 "Ri" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
-	dir = 10
+	dir = 9
 	},
 /turf/open/openspace,
-/area/medical/medbay/zone2)
+/area/maintenance/starboard/fore)
 "Rj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/directional/north{
@@ -13352,6 +13435,11 @@
 /area/medical/medbay/zone2)
 "Rv" = (
 /obj/item/plunger,
+/obj/machinery/camera{
+	c_tag = "Medbay - Chemistry Lab W";
+	dir = 4;
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "Rw" = (
@@ -13602,6 +13690,11 @@
 /obj/structure/table/optable{
 	color = "#B392CB"
 	},
+/obj/machinery/camera{
+	c_tag = "Medbay - Plasmaman Medbay";
+	dir = 1;
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron{
 	initial_gas_mix = "n2=104;TEMP=293.15"
 	},
@@ -13744,6 +13837,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "St" = (
@@ -13999,6 +14093,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"Tr" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Ts" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/iron,
@@ -14272,6 +14377,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"Un" = (
+/obj/machinery/camera{
+	c_tag = "Medbay - Elevator Upper";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Uo" = (
 /turf/closed/wall/r_wall,
 /area/service/abandoned_gambling_den)
@@ -14359,10 +14471,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"UF" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "UG" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/orange,
@@ -14374,11 +14482,13 @@
 /turf/open/floor/iron,
 /area/security/prison/workout)
 "UJ" = (
-/obj/structure/industrial_lift{
-	id = "publicElevator"
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 1
 	},
+/obj/machinery/light/floor,
 /turf/open/openspace,
-/area/medical/medbay/zone2)
+/area/maintenance/starboard/fore)
 "UK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -14494,10 +14604,10 @@
 "Va" = (
 /obj/structure/industrial_lift,
 /obj/structure/railing{
-	dir = 6
+	dir = 5
 	},
 /turf/open/openspace,
-/area/medical/medbay/zone2)
+/area/maintenance/starboard/fore)
 "Vb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -14870,9 +14980,8 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "Wh" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/turf/closed/wall,
+/area/medical/surgery/room_b)
 "Wj" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -14936,6 +15045,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"Wp" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/medical/surgery/room_b)
 "Wr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 6
@@ -15529,6 +15642,11 @@
 /area/security/prison)
 "Yn" = (
 /obj/machinery/light/dim/directional/west,
+/obj/machinery/requests_console/directional/west{
+	department = "Security";
+	departmentType = 5;
+	name = "Security Post RD"
+	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "Yo" = (
@@ -15711,16 +15829,6 @@
 /area/engineering/atmos/upper)
 "YS" = (
 /turf/open/openspace,
-/area/medical/medbay/zone2)
-"YU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "YV" = (
 /obj/machinery/flasher/directional/south{
@@ -15906,6 +16014,13 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"ZA" = (
+/obj/structure/industrial_lift,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/openspace,
+/area/medical/medbay/zone2)
 "ZB" = (
 /turf/closed/wall,
 /area/service/bar/atrium)
@@ -56026,13 +56141,13 @@ Eg
 Eg
 Eg
 Eg
-FD
-FD
-FD
-FD
-FD
-FD
-FD
+Wh
+Wh
+Wh
+Wh
+Wh
+Wh
+Wh
 MF
 MF
 MF
@@ -56280,7 +56395,7 @@ HW
 HW
 HW
 HW
-FD
+Wh
 Nn
 hj
 mW
@@ -56289,7 +56404,7 @@ iR
 sM
 hj
 yk
-FD
+Wh
 MF
 MF
 MF
@@ -56528,7 +56643,7 @@ YB
 YB
 YB
 ES
-EI
+KC
 KC
 KC
 ES
@@ -56537,16 +56652,16 @@ HW
 HW
 HW
 HW
-FD
+Wh
 pk
 rN
 rm
 BF
-vw
+th
 bA
 rN
 cI
-FD
+Wh
 MF
 MF
 MF
@@ -56787,14 +56902,14 @@ YB
 ES
 ET
 KC
-KC
+ET
 ES
 HW
 HW
 HW
 HW
 HW
-FD
+Wh
 GP
 rN
 sZ
@@ -56803,7 +56918,7 @@ rN
 rN
 rN
 rq
-FD
+Wh
 MF
 MF
 MF
@@ -57051,16 +57166,16 @@ ES
 HW
 HW
 HW
-FD
+Wh
 eg
 Jx
-hN
+Nf
 gC
-do
-UF
-UF
+mv
+Wp
+Wp
 aQ
-FD
+Wh
 MF
 MF
 MF
@@ -57308,9 +57423,9 @@ ES
 HW
 HW
 HW
-FD
-FD
-FD
+Wh
+Wh
+Wh
 dc
 Lx
 Lx
@@ -58071,7 +58186,7 @@ YB
 PG
 ES
 IE
-Mh
+KC
 PT
 ES
 ES
@@ -58327,8 +58442,8 @@ YB
 YB
 PG
 ES
-II
-Mh
+IE
+fY
 Tk
 Zp
 US
@@ -58845,11 +58960,11 @@ ES
 Vo
 ov
 Vo
-fY
+jE
 XV
 XV
 XV
-tR
+FD
 XV
 vJ
 Vo
@@ -59103,8 +59218,8 @@ Nd
 UK
 Vo
 Vo
-ij
-iw
+qH
+xC
 Vo
 Vo
 XV
@@ -59357,14 +59472,14 @@ ta
 Ah
 Mc
 Vo
-fp
+iw
 vW
 vW
+tR
 vW
+zJ
 vW
-vW
-vW
-QI
+sB
 vW
 vW
 tK
@@ -59608,8 +59723,8 @@ Mu
 Mu
 Mu
 ES
-KC
-KC
+ed
+fp
 wA
 Dz
 ES
@@ -59617,12 +59732,12 @@ QR
 ov
 Vo
 Vo
+ux
 Vo
-Vo
-Vo
+AM
 Vo
 XV
-Wh
+df
 Vo
 oD
 Vo
@@ -59877,7 +59992,7 @@ Vo
 VF
 VF
 vm
-ux
+II
 XV
 Vo
 Vo
@@ -60133,10 +60248,10 @@ Vo
 Vo
 YS
 YS
-jE
-xC
+EI
+QI
 XV
-qk
+li
 on
 qN
 Vo
@@ -60390,12 +60505,12 @@ Vo
 Vo
 YS
 YS
-jE
+EI
 kC
 XV
 XV
 eO
-eG
+Gz
 eO
 cd
 Jl
@@ -60647,8 +60762,8 @@ Vo
 Vo
 YS
 YS
-jE
-ux
+EI
+II
 XV
 hF
 Vo
@@ -60904,10 +61019,10 @@ Vo
 Vo
 dT
 dT
-qH
-ux
+Ft
+II
 XV
-Jk
+cW
 Vo
 qN
 Vo
@@ -61158,14 +61273,14 @@ aK
 Vo
 Te
 vW
-no
+Nd
 fu
 RD
 Fx
 Fx
 XV
 XV
-Vo
+Un
 ah
 no
 no
@@ -61412,15 +61527,15 @@ fK
 GI
 ih
 aK
-ed
+ij
 Vz
 ZU
 on
 oJ
 Vo
 Fx
-zJ
 Ri
+gf
 eJ
 Vo
 Vo
@@ -61676,8 +61791,8 @@ XV
 XV
 XV
 Fx
-AM
 UJ
+hy
 eJ
 Vo
 Vo
@@ -61933,8 +62048,8 @@ MF
 MF
 MF
 Fx
-Ft
 Va
+ZA
 RL
 Vo
 Vo
@@ -63483,12 +63598,12 @@ Mu
 Mu
 Mu
 ct
-YU
+jD
 Yf
 oH
 oH
 oH
-eF
+PZ
 Es
 HI
 mw
@@ -63740,12 +63855,12 @@ Mu
 Mu
 Mu
 ct
-ov
+iO
 Yh
 YS
 YS
 YS
-vk
+aI
 Vo
 Wy
 AJ
@@ -63997,12 +64112,12 @@ Mu
 Mu
 Mu
 ct
-hE
+Tr
 Yh
 YS
 YS
 YS
-vk
+aI
 Vo
 gX
 qq
@@ -64254,7 +64369,7 @@ Mu
 Mu
 Mu
 ct
-cN
+tJ
 Vo
 Vo
 Vo
@@ -64511,7 +64626,7 @@ Mu
 Mu
 Mu
 ct
-lZ
+xV
 Vo
 Vo
 Vo
@@ -64768,7 +64883,7 @@ Mu
 Mu
 Mu
 ct
-Ep
+DE
 Es
 Es
 Es
@@ -66568,7 +66683,7 @@ Mu
 Mu
 Mu
 dG
-Hu
+ej
 Hu
 jv
 Hu
@@ -68890,7 +69005,7 @@ AZ
 AZ
 ip
 pI
-Hu
+Fj
 LW
 Hu
 Hu

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -946,6 +946,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"dh" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "dj" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
@@ -3251,7 +3255,7 @@
 "kC" = (
 /obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "kD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -4388,9 +4392,14 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nZ" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/medical/virology)
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron/white,
+/area/medical/break_room)
+"oa" = (
+/obj/vehicle/ridden/wheelchair/gold,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "od" = (
 /obj/structure/rack,
 /obj/item/wirecutters,
@@ -5287,7 +5296,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/break_room)
 "qS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5895,6 +5904,10 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+"sK" = (
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "sM" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/sink{
@@ -8050,6 +8063,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
+"zZ" = (
+/obj/structure/chair/comfy,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "Aa" = (
 /obj/structure/bed,
 /obj/machinery/camera{
@@ -9246,9 +9263,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "DL" = (
-/obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "DM" = (
 /obj/machinery/camera{
 	c_tag = "Engine Locker Room";
@@ -10980,8 +10998,11 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "II" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "IJ" = (
 /obj/item/target,
 /obj/item/target,
@@ -13073,6 +13094,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/chair/comfy,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Pc" = (
@@ -13209,6 +13231,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
+/obj/structure/chair/comfy,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "Pr" = (
@@ -13707,9 +13730,9 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "QI" = (
-/obj/machinery/light/directional/south,
+/obj/structure/table,
 /turf/open/floor/iron/white,
-/area/maintenance/starboard/fore)
+/area/medical/break_room)
 "QJ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -13867,7 +13890,7 @@
 	dir = 9
 	},
 /turf/open/openspace,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "Rj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/directional/north{
@@ -15017,7 +15040,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/openspace,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "UK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -15136,7 +15159,7 @@
 	dir = 5
 	},
 /turf/open/openspace,
-/area/maintenance/starboard/fore)
+/area/medical/medbay/zone2)
 "Vb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -60292,7 +60315,7 @@ KC
 Dz
 Dz
 Mc
-Vo
+zZ
 ov
 Vo
 Vo
@@ -60541,14 +60564,14 @@ Mu
 Mu
 Mu
 Mu
-nZ
+Am
 ro
 ES
 pm
-yK
+nZ
 qR
-VS
-aK
+QI
+ES
 Pb
 Co
 yU
@@ -60556,7 +60579,7 @@ Vo
 VF
 VF
 vm
-II
+Vo
 XV
 Vo
 Vo
@@ -60813,7 +60836,7 @@ Vo
 YS
 YS
 EI
-QI
+RD
 XV
 li
 on
@@ -61840,8 +61863,8 @@ vW
 Nd
 fu
 RD
-Fx
-Fx
+XV
+XV
 XV
 XV
 Un
@@ -62096,8 +62119,8 @@ Vz
 ZU
 on
 oJ
-Vo
-Fx
+dh
+XV
 Ri
 gf
 eJ
@@ -62354,7 +62377,7 @@ XV
 XV
 XV
 XV
-Fx
+XV
 UJ
 hy
 eJ
@@ -62611,15 +62634,15 @@ MF
 MF
 MF
 MF
-Fx
+XV
 Va
 ZA
 RL
 Vo
-Vo
-Vo
-Vo
-Vo
+sK
+sK
+oa
+sK
 ZP
 qN
 Rr
@@ -62859,8 +62882,8 @@ AO
 Nm
 aK
 fK
-ct
-ct
+aK
+aK
 Fx
 MF
 Zm
@@ -62868,8 +62891,8 @@ MF
 MF
 MF
 MF
-Fx
-Fx
+XV
+XV
 XV
 XV
 XV

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -13090,6 +13090,9 @@
 	name = "Morgue Maintenance";
 	req_one_access_txt = "6;5"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "aYR" = (
@@ -44758,6 +44761,13 @@
 	},
 /turf/open/floor/plating,
 /area/service/lawoffice)
+"xkv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Coldroom Maintenance";
+	req_access_txt = "45"
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/maintenance/department/medical)
 "xkJ" = (
 /obj/structure/railing{
 	dir = 8
@@ -87276,7 +87286,7 @@ aEd
 csU
 aRR
 aRR
-aRR
+xkv
 aRR
 aRR
 aXM

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -322,6 +322,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"abj" = (
+/obj/effect/mapping_helpers/dead_body_placer,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "abk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /obj/machinery/light/no_nightlight/directional/north,
@@ -39346,12 +39351,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"dpu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "dpR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
@@ -40367,10 +40366,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gDq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "gEA" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -40396,12 +40391,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gKF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "gRT" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -40711,6 +40700,10 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"hVz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "hVV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
@@ -41442,6 +41435,12 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
+"kCg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "kEr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/shower{
@@ -43745,11 +43744,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
-"sTS" = (
-/obj/effect/mapping_helpers/dead_body_placer,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "sWI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44496,6 +44490,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"vrF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "vrY" = (
 /obj/structure/table,
 /obj/item/paicard,
@@ -85699,7 +85699,7 @@ bfe
 bgi
 bhR
 mkE
-dpu
+kCg
 cLv
 cLv
 cLv
@@ -86469,11 +86469,11 @@ bgi
 beJ
 cLv
 eKn
-gDq
-gDq
-sTS
-gDq
-gKF
+hVz
+hVz
+abj
+hVz
+vrF
 cLv
 cLv
 bgi

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -8609,7 +8609,6 @@
 "aFT" = (
 /obj/item/bodypart/r_leg,
 /obj/structure/bed/roller,
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aFU" = (
@@ -9268,6 +9267,7 @@
 "aIn" = (
 /obj/item/storage/box/bodybags,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aIp" = (
@@ -9364,11 +9364,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aIR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -10070,15 +10068,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "aMm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -10305,8 +10296,6 @@
 /area/medical/cryo)
 "aNg" = (
 /obj/structure/table/glass,
-/obj/item/wrench/medical,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
 	},
@@ -10314,6 +10303,9 @@
 	c_tag = "Medbay - Cryogenics";
 	network = list("ss13","medbay")
 	},
+/obj/item/soap/nanotrasen,
+/obj/item/wrench/medical,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aNh" = (
@@ -10495,13 +10487,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aNJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aNK" = (
 /obj/structure/stairs/east,
 /turf/open/floor/iron,
@@ -10511,16 +10496,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/maintenance/central)
-"aNM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aNN" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_x = 30
@@ -10671,11 +10646,11 @@
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aOx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "aOy" = (
 /obj/item/stack/sheet/glass,
 /turf/open/space/basic,
@@ -10949,15 +10924,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aPt" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/maintenance/department/medical)
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "aPu" = (
 /obj/item/melee/flyswatter,
 /turf/open/floor/iron/dark,
@@ -11412,16 +11381,12 @@
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aRK" = (
-/obj/structure/window{
-	dir = 1
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/eastleft{
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "aRN" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -11465,17 +11430,8 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aRR" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay";
-	name = "Delivery Beacon - Medbay"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/maintenance/department/medical)
+/turf/closed/wall/r_wall,
+/area/medical/coldroom)
 "aSd" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -11498,6 +11454,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aSh" = (
@@ -12285,14 +12242,15 @@
 /turf/closed/wall,
 /area/medical/cryo)
 "aVb" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/medicine,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aVc" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/iron/white,
@@ -32222,14 +32180,14 @@
 /area/engineering/atmos/upper)
 "cyS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -39443,17 +39401,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/central)
-"dIi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "dIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -39814,13 +39761,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"fha" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "fhP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -39980,6 +39920,17 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/iron,
 /area/space)
+"fzK" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Freezer";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/coldroom)
 "fzM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40001,10 +39952,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"fBh" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "fCp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -40121,6 +40068,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"fYS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "fZf" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line,
@@ -40217,8 +40171,8 @@
 /area/medical/medbay/central)
 "gjU" = (
 /obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "gkU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -40589,11 +40543,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hxo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "hxF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hAk" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "hBi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -40668,6 +40636,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"hNw" = (
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "hPD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -40777,6 +40749,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"ipA" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "iqJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40869,6 +40845,17 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"iJU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iKA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41183,10 +41170,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
-"jKh" = (
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "jKi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -41267,10 +41250,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/space)
-"jSL" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "jUc" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -41346,6 +41325,17 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"kmE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "knY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -41692,17 +41682,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/commons/dorms)
-"lyT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "lAI" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41720,6 +41699,19 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
 /area/space)
+"lBz" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
+	},
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Medical Delivery";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "lET" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -41853,17 +41845,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
-"meB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mhQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41956,6 +41937,9 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"mrg" = (
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
 "mrE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -42180,6 +42164,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"ngC" = (
+/obj/effect/landmark/start/paramedic,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "nhM" = (
 /obj/machinery/piratepad/civilian,
 /turf/open/floor/iron,
@@ -42317,6 +42306,13 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"nvF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -42402,6 +42398,11 @@
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"nEN" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "nGc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -42498,6 +42499,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"obJ" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay";
+	name = "Delivery Beacon - Medbay"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/medical/medbay/central)
 "odr" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -42525,6 +42538,10 @@
 "oif" = (
 /obj/structure/table,
 /obj/item/storage/box/masks,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"oiA" = (
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "omh" = (
@@ -42744,6 +42761,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"pgm" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "pgs" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
@@ -42944,6 +42965,11 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/white,
 /area/security/brig)
+"qgp" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "qhc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -42983,6 +43009,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
+"qsH" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "quc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -43020,6 +43050,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qBT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43604,6 +43644,15 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"sNV" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/camera{
+	c_tag = "Medbay Cold Storage";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "sPg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
 	dir = 1
@@ -43664,6 +43713,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/space)
+"sYZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "tcQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -43734,6 +43789,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"tob" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "tsg" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43854,11 +43915,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/space)
-"tDX" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "tDZ" = (
 /obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron/dark,
@@ -43992,6 +44048,17 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"udb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "ueZ" = (
 /obj/structure/table,
 /obj/item/key/security,
@@ -44039,6 +44106,9 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"usC" = (
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "uuG" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/bot_red,
@@ -44072,6 +44142,17 @@
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/white,
 /area/science)
+"uxJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uys" = (
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
@@ -44137,12 +44218,12 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "uKb" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/rack,
+/obj/item/wrench/medical,
+/obj/effect/turf_decal/siding/white,
+/obj/item/food/popsicle/creamsicle_orange,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "uMD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44334,6 +44415,10 @@
 "vls" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vlP" = (
@@ -44378,6 +44463,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"vtt" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "vwM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -44571,6 +44660,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"wqr" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "wrR" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
@@ -44929,6 +45022,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"xBt" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
+"xCs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xDh" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -45023,7 +45128,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "yck" = (
-/obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -86052,7 +86156,7 @@ bgi
 bgi
 aYV
 aXH
-jSL
+qsH
 cLv
 blN
 bmY
@@ -86803,8 +86907,8 @@ aak
 aEd
 aRb
 bbl
-bbl
 bvL
+bbl
 bcJ
 aPW
 bcJ
@@ -86815,8 +86919,8 @@ bbl
 bvL
 bwJ
 lXd
-bdK
-beO
+obJ
+lBz
 aQT
 beO
 cAQ
@@ -87060,8 +87164,8 @@ aak
 aEd
 aIT
 aHx
-aHx
 csU
+aHx
 aHx
 aHx
 aHx
@@ -87317,11 +87421,11 @@ aEd
 ykc
 aFX
 aEd
-aHx
 csU
-aHx
-bdK
-bdK
+aRR
+aRR
+aRR
+aRR
 aRR
 aXM
 lOu
@@ -87574,11 +87678,11 @@ aEd
 dJu
 aIT
 aEd
-aEd
-aNJ
-aEd
-bdK
-aOz
+aIR
+aRR
+gjU
+wqr
+xBt
 aRK
 aXM
 fjL
@@ -87831,12 +87935,12 @@ aEd
 aFU
 aHx
 aEd
-aHx
 bla
-aHx
-bdK
-beO
-beO
+aRR
+uKb
+usC
+hxo
+aRK
 aXM
 iro
 vlP
@@ -87845,7 +87949,7 @@ omY
 gEA
 uOh
 lOx
-meB
+iJU
 beO
 cFF
 bfb
@@ -88088,12 +88192,12 @@ aEd
 aIT
 aIT
 aMe
-aHx
 bla
-aHx
-bdK
-beO
-beO
+aRR
+hAk
+usC
+tob
+qBT
 aXM
 qay
 hhz
@@ -88102,7 +88206,7 @@ omY
 uZi
 uOh
 lOx
-dIi
+uxJ
 beO
 cFF
 uNo
@@ -88345,12 +88449,12 @@ aEd
 aFV
 xjL
 aEd
-aHx
-aNM
+bla
+aRR
 aOx
 aPt
 aMl
-beO
+sYZ
 aXM
 vdZ
 yck
@@ -88602,12 +88706,12 @@ aEd
 ykc
 aEd
 aEd
-aHx
 bla
-aHx
-bdK
-aQT
-beO
+aRR
+sNV
+qgp
+hNw
+fYS
 aXM
 aXM
 aXM
@@ -88859,13 +88963,13 @@ aak
 aEd
 aLp
 aHx
-aHx
 bla
-bdK
-bdK
-aQT
-beO
-beO
+aRR
+aRR
+aRR
+aRR
+fzK
+mrg
 beO
 beO
 aQT
@@ -89116,12 +89220,12 @@ aak
 aEd
 aFY
 aHO
-aHx
 bla
+aHx
 bdK
 aPv
 cyS
-bnh
+xCs
 nsd
 bnh
 snX
@@ -89134,7 +89238,7 @@ pZH
 iyE
 iyE
 iKA
-fha
+nvF
 aZo
 xoz
 xoz
@@ -89373,8 +89477,8 @@ aEd
 aEd
 aEd
 aIe
-aHx
 bla
+aHx
 bdK
 aPv
 aQN
@@ -89382,7 +89486,7 @@ beO
 xzJ
 beO
 idt
-uKb
+beO
 aSD
 aSo
 dqs
@@ -89390,7 +89494,7 @@ mkE
 nGc
 aSo
 aSD
-aQT
+kmE
 beO
 aZn
 bky
@@ -89630,16 +89734,16 @@ aHx
 aHx
 aGr
 aHx
-aHx
 bla
+aHx
 bdK
 aPv
 aQN
 bta
 bta
-fBh
+oiA
 bta
-gjU
+bta
 aSD
 ivN
 ptC
@@ -89647,12 +89751,12 @@ eKn
 xZB
 ivN
 aSD
-aQT
+kmE
 beO
 bhD
 aZW
 uYP
-jKh
+pgm
 bky
 iMA
 bky
@@ -89887,8 +89991,8 @@ ahv
 ahv
 aEd
 aIe
-aHx
 bla
+aHx
 bdK
 bdK
 aMu
@@ -89896,15 +90000,15 @@ ejx
 vWW
 oif
 bta
-gjU
+bta
 aSo
 ivL
 rrF
 gvV
 xZB
-ptC
+vtt
 aSD
-aQT
+kmE
 beO
 bhD
 biU
@@ -89913,7 +90017,7 @@ blU
 bnj
 boE
 bky
-bky
+ipA
 bhF
 cpH
 buh
@@ -90144,8 +90248,8 @@ aJD
 ahv
 bdL
 aHx
-aHx
 bla
+aHx
 bdK
 cuR
 aQS
@@ -90158,7 +90262,7 @@ aSo
 tYg
 ptC
 eKn
-tDX
+nEN
 ptC
 dqs
 aQT
@@ -90170,7 +90274,7 @@ bkv
 cXI
 keH
 bky
-bky
+ipA
 bhF
 cpH
 btm
@@ -90401,8 +90505,8 @@ aJE
 ahv
 aTe
 aHx
-aHx
 bla
+aHx
 bdK
 aKz
 aQT
@@ -90414,7 +90518,7 @@ bta
 aSo
 pAu
 xZB
-lyT
+udb
 xZB
 xZB
 nGc
@@ -90427,7 +90531,7 @@ bbc
 bky
 keH
 bky
-jKh
+ngC
 bhF
 cpH
 btm
@@ -90658,8 +90762,8 @@ aFp
 ahv
 aHx
 aHx
-aHx
 bla
+aHx
 bdK
 bdK
 aQT
@@ -90673,9 +90777,9 @@ wQS
 tYa
 miW
 ptC
-ptC
+vtt
 aSD
-aQT
+kmE
 beO
 bhD
 aZX
@@ -90684,7 +90788,7 @@ bkv
 mrE
 ufV
 bky
-bky
+ipA
 bhF
 cpH
 btm
@@ -90914,9 +91018,9 @@ aIV
 bba
 aOD
 fCC
-aRE
-aRE
+fCC
 aNU
+aHx
 aHx
 bdK
 aQT
@@ -90932,7 +91036,7 @@ rzp
 ptC
 oJL
 aSD
-aQT
+kmE
 beO
 bhD
 xbW
@@ -91172,8 +91276,8 @@ aJG
 ahv
 aGJ
 aHx
-aHx
 aNV
+fCC
 fCC
 aMV
 aMm
@@ -91189,12 +91293,12 @@ nkR
 dqs
 aSo
 aSD
-aQT
+kmE
 beO
 bhW
 bjd
 bky
-jKh
+pgm
 bky
 bky
 bky
@@ -91429,8 +91533,8 @@ aJH
 ahv
 aHB
 aHx
-aIR
-bwJ
+csU
+aHx
 aHx
 bdK
 aMu
@@ -91960,7 +92064,7 @@ aWN
 aXE
 bte
 beO
-dIi
+uxJ
 beO
 bhL
 aZY

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -10681,8 +10681,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aOz" = (
-/turf/closed/wall,
-/area/space/nearstation)
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "aOA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -10918,7 +10919,7 @@
 "aPm" = (
 /obj/effect/spawner/bundle/costume/pirate,
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/maintenance/department/medical)
 "aPn" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -11191,7 +11192,16 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aQN" = (
-/obj/machinery/vending/drugs,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aQS" = (
@@ -13278,10 +13288,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"aZL" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aZO" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -16129,16 +16135,9 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bnh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bnj" = (
@@ -23730,6 +23729,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bOW" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "bPd" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
@@ -24078,6 +24081,14 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"bQV" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/camera{
+	c_tag = "Medbay - Elevator";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "bRa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
@@ -39216,6 +39227,16 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
+"cXV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "cXX" = (
 /obj/machinery/computer/cargo{
 	dir = 8
@@ -39312,14 +39333,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"diV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "djJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -39358,19 +39371,13 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"dqs" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "dqB" = (
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
-"duv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "duA" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -39390,11 +39397,6 @@
 /obj/machinery/bluespace_vendor/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"dAQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "dBV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39432,11 +39434,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"dFR" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "dGr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -39457,6 +39454,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"dLf" = (
+/obj/structure/table,
+/obj/item/cautery,
+/obj/item/retractor,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "dLC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -39507,16 +39510,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"dSR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "dUL" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -39584,13 +39577,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
-"eiT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "eiV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -39603,6 +39589,14 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
+"ejx" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "ejT" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "holding cell locker"
@@ -39673,11 +39667,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"etr" = (
-/obj/structure/table,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
 "etz" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
@@ -39712,14 +39701,6 @@
 "eEO" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"eFr" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/camera{
-	c_tag = "Medbay - Elevator";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "eFy" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
@@ -39743,19 +39724,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"eKn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "eLa" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eLt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "eNp" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
@@ -39763,18 +39744,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"eNA" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera{
-	c_tag = "Medbay - Treatment Center";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "eVD" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -39792,6 +39761,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"eZc" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "eZp" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
@@ -39809,12 +39782,34 @@
 /obj/structure/reflector/box,
 /turf/open/floor/engine,
 /area/engineering/main)
+"fdp" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"fdL" = (
+/obj/machinery/camera{
+	c_tag = "Medbay - Security Post";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "fdV" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/space)
+"fhP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "fiV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -39824,6 +39819,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"fjL" = (
+/obj/machinery/smartfridge/organ,
+/obj/machinery/camera{
+	c_tag = "Medbay - Surgery A";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "fjZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
@@ -39847,11 +39850,12 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"foM" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/computer/operating,
+"foV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/pharmacy)
 "fpK" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39956,10 +39960,27 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/iron,
 /area/space)
+"fzM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/requests_console/directional/east{
+	department = "Morgue";
+	departmentType = 1;
+	name = "Morgue Requests Console"
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "fAI" = (
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"fBg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fCp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -39997,19 +40018,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fGw" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"fKL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -40071,10 +40079,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"fSw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "fTJ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -40156,12 +40160,22 @@
 /obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"ghC" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+"gdP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"geH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "ghI" = (
 /obj/structure/railing{
 	dir = 4
@@ -40173,19 +40187,21 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"gjL" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
+"giJ" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"gjU" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"gkU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "gkY" = (
@@ -40199,15 +40215,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"gmK" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "gnv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
@@ -40302,6 +40309,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"gvV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "gxs" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -40313,10 +40327,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"gAF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "gCa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -40326,11 +40336,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gFN" = (
+"gEA" = (
 /obj/structure/table,
-/obj/item/storage/box/masks,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/item/circular_saw,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "gGz" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/dark,
@@ -40365,9 +40375,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/engineering/engine_smes)
-"gWy" = (
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "gXc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -40457,6 +40464,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hhz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "hjq" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron,
@@ -40482,6 +40493,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hmF" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "hob" = (
 /turf/closed/wall,
 /area/security/brig)
@@ -40530,10 +40555,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"hwV" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "hxc" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40549,16 +40570,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hzm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "hBi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -40582,6 +40593,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"hDB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "hEg" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -40594,16 +40609,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"hFE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "hGO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -40624,14 +40629,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hKJ" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/camera{
-	c_tag = "Medbay - Surgery A";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "hLt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -40656,18 +40653,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hQq" = (
-/obj/structure/table,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/obj/machinery/requests_console/directional/west{
-	department = "Surgery";
-	departmentType = 1;
-	name = "Surgery Requests Console"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "hTK" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -40681,28 +40666,10 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"hVO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hVV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engineering/main)
-"hXk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"hXp" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "hXT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -40734,6 +40701,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"idt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "igc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/neutral{
@@ -40785,6 +40758,39 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/service/library)
+"iro" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/optable,
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
+"iuS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"ivL" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"ivN" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"iyE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iyV" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/stack/sheet/mineral/sandbags{
@@ -40839,12 +40845,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"iKv" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
+"iKA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"iKK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"iMA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -40852,13 +40865,31 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/maintenance/department/medical)
-"iKK" = (
+/area/medical/medbay/lobby)
+"iNH" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40984,9 +41015,9 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"jlz" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+"jlS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "jmW" = (
@@ -41040,6 +41071,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"jti" = (
+/obj/structure/table,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medigel/sterilizine,
+/obj/machinery/button/door/directional/east{
+	id = "mainsurgery";
+	name = "Privacy Button";
+	req_access_txt = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "jtK" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -41072,12 +41114,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"jwr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "jwD" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -41092,11 +41128,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
-"jEM" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/surgery,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "jEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41219,30 +41250,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"jUK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"jVn" = (
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"jVs" = (
-/obj/machinery/camera{
-	c_tag = "Medbay - Security Post";
-	dir = 8;
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "jVy" = (
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
@@ -41277,6 +41284,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
+"keH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "keN" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -41301,16 +41314,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"khF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "knY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -41324,6 +41327,20 @@
 	},
 /turf/open/floor/plating,
 /area/commons/dorms)
+"kpF" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/department/medical)
 "kuC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -41341,6 +41358,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/space)
+"kwV" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "kyq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -41349,20 +41370,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"kBK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"kBL" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "kBU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/radio/intercom/directional/south,
@@ -41392,12 +41399,6 @@
 "kId" = (
 /turf/open/floor/plating,
 /area/commons/dorms)
-"kJu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "kJX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41443,6 +41444,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"kSq" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/storage)
 "kTu" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -41493,15 +41508,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"kYs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "kYQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -41515,6 +41521,21 @@
 "kZs" = (
 /turf/closed/wall,
 /area/security/interrogation)
+"kZP" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "lah" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -41531,11 +41552,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
-"ldh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "ldq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -41555,6 +41571,11 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
+"lht" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "ljM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -41612,6 +41633,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible/layer4,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"lsR" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Pharmacy";
+	name = "Medbay Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"ltt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ltN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41683,13 +41719,17 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"lSe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+"lOu" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
+"lOx" = (
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"lTj" = (
+"lQl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
@@ -41706,11 +41746,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"lVb" = (
-/obj/structure/cable,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "lVC" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -41731,10 +41766,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"lXd" = (
+/obj/structure/cable,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lXn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"maq" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "mar" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41765,6 +41810,24 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
+"mhQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"miW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "mjr" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -41778,6 +41841,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"mkE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "mkP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -41829,16 +41902,6 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"mra" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mrE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -41907,6 +41970,16 @@
 /obj/structure/stairs/south,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"mAr" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Morgue";
+	network = list("ss13","medbay")
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mAK" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41934,21 +42007,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"mIE" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"mJe" = (
-/obj/structure/table,
-/obj/item/surgicaldrill,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "mJP" = (
 /obj/structure/chair{
 	dir = 8
@@ -41965,6 +42023,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"mKE" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mLI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/blue{
@@ -41988,6 +42050,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mON" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "mOS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42000,6 +42067,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"mQS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "mUd" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42109,6 +42181,17 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"nkR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "nlF" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -42154,16 +42237,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"nrs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "nrA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -42171,6 +42244,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"nsd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "nvh" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -42188,11 +42269,6 @@
 /obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/space)
-"nxG" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "nzM" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -42272,6 +42348,11 @@
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"nGc" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "nHB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
@@ -42291,9 +42372,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
-"nKm" = (
-/turf/open/floor/plating/elevatorshaft,
-/area/medical/storage)
 "nLu" = (
 /obj/structure/closet/radiation,
 /obj/effect/spawner/lootdrop/gloves,
@@ -42352,12 +42430,6 @@
 "nZK" = (
 /turf/closed/wall/r_wall,
 /area/space)
-"nZU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "oaI" = (
 /obj/structure/chair{
 	name = "Bailiff"
@@ -42376,10 +42448,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ofJ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "ofP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -42400,6 +42468,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oif" = (
+/obj/structure/table,
+/obj/item/storage/box/masks,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "omh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -42409,6 +42482,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"omY" = (
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "onX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -42442,16 +42518,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"oqK" = (
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "osl" = (
 /turf/open/floor/white,
 /area/service/library)
-"ovM" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "owj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42465,16 +42540,6 @@
 	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"oxX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "oEh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -42483,12 +42548,6 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"oFK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "oHG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -42496,11 +42555,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"oHK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "oIk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -42518,6 +42572,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oJL" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "oJU" = (
 /obj/structure/chair{
 	dir = 1
@@ -42564,6 +42624,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"oRH" = (
+/obj/structure/table,
+/obj/item/surgicaldrill,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "oSk" = (
 /obj/structure/closet/secure_closet/evidence,
 /turf/open/floor/iron,
@@ -42577,29 +42642,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"oTC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+"oUF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"oUy" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
-"oVf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "mainsurgery";
-	name = "Surgery Privacy Door"
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
 "oVs" = (
 /obj/structure/table,
 /obj/item/toy/eightball,
@@ -42648,6 +42696,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"phC" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pjl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -42665,21 +42722,14 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"pnv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "psH" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"ptC" = (
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "pux" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/light/directional/north,
@@ -42717,19 +42767,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
+"pAu" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "pAS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
-"pBk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "pHZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42773,15 +42819,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"pOb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "pQK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -42792,22 +42829,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
-"pRz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"pRT" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "pWh" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -42817,12 +42838,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pWM" = (
-/obj/structure/table,
-/obj/item/scalpel,
-/obj/item/hemostat,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+"pXf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pXg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42830,6 +42851,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"pZH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pZN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -42844,6 +42875,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"qay" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "qdp" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -42874,10 +42910,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"qln" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "qlV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -42893,10 +42925,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"qpN" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qqq" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
@@ -42938,22 +42966,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"qBl" = (
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/reagent_containers/medigel/sterilizine,
-/obj/machinery/button/door/directional/east{
-	id = "mainsurgery";
-	name = "Privacy Button";
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
-"qCw" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -42970,20 +42982,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"qHn" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
 "qJs" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -43014,6 +43012,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"qNb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "qNB" = (
 /obj/structure/grille/broken,
 /obj/effect/loot_site_spawner,
@@ -43124,20 +43129,13 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"rbV" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
+"rbY" = (
+/obj/effect/landmark/start/shaft_miner,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/space)
+"rcU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -43145,29 +43143,13 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
-"rbY" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/space)
+/area/medical/pharmacy)
 "rdy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"reW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"rjK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "rkl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43207,6 +43189,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"rrF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "rsn" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/turf_decal/siding/wood,
@@ -43225,6 +43211,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"rzp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "rEd" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -43258,21 +43254,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"rIm" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+"rJx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "rLc" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -43338,20 +43325,20 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"rQV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "rRf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"rSH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "rSY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -43387,6 +43374,16 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"rTC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "rVW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -43402,6 +43399,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"rXs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "rYx" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
@@ -43423,15 +43430,6 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/space)
-"sbD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "sgD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -43464,6 +43462,14 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"snX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ssn" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -30
@@ -43501,16 +43507,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
-"sxC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "szw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43522,6 +43518,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"sBF" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "sBP" = (
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
@@ -43545,12 +43550,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"sJG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "sPg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
 	dir = 1
@@ -43578,14 +43577,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"sRj" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/structure/sign/departments/medbay/alt{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "sSa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
@@ -43619,17 +43610,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/space)
-"tbA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/requests_console/directional/east{
-	department = "Morgue";
-	departmentType = 1;
-	name = "Morgue Requests Console"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "tcQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -43640,12 +43620,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"teg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "teP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -43677,10 +43651,24 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/science)
+"tly" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "tmp" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"tmr" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "tnq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -43770,6 +43758,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"tym" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "tyZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -43831,12 +43825,6 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/iron,
 /area/space)
-"tHH" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "tHO" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -43864,10 +43852,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"tKM" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "tLp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -43876,12 +43860,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"tMd" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "tML" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/directional/east,
@@ -43897,18 +43875,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"tUw" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"tVv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "tXD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43919,6 +43885,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"tYa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"tYg" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera{
+	c_tag = "Medbay - Treatment Center";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tYN" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass{
@@ -43959,6 +43941,12 @@
 /obj/item/storage/lockbox/loyalty,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"ufV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "ugK" = (
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
@@ -43979,15 +43967,25 @@
 /obj/item/toy/figure/cargotech,
 /turf/open/floor/iron,
 /area/space)
-"umH" = (
-/obj/machinery/door/firedoor,
+"unA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "uql" = (
 /obj/structure/cable,
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"uuG" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "uvU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -43998,12 +43996,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"uwf" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table/optable,
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "uwq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -44032,12 +44024,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/space)
-"uAI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "uAJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -44048,10 +44034,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"uEb" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "uEA" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/directional/south,
@@ -44066,6 +44048,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uFA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "uGx" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
@@ -44075,10 +44067,21 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"uMe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+"uJj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
+"uKb" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uMD" = (
@@ -44087,6 +44090,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"uNo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "uNP" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -44099,9 +44112,13 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"uNQ" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
+"uOh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "mainsurgery";
+	name = "Surgery Privacy Door"
+	},
+/turf/open/floor/plating,
 /area/medical/surgery)
 "uPf" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -44126,11 +44143,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"uSU" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uTy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44145,16 +44157,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uUS" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Morgue";
-	network = list("ss13","medbay")
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uWr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -44169,10 +44171,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"uWF" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "uYO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
@@ -44182,6 +44180,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uYP" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/medical/medbay/lobby)
 "uZf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -44192,12 +44195,34 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uZi" = (
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/hemostat,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
+"vch" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "vds" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"vdZ" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "vej" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
@@ -44247,6 +44272,16 @@
 "vkV" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"vls" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"vlP" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "vnA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44284,13 +44319,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"vvG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vwM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -44313,25 +44341,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"vCb" = (
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "vCx" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"vEi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "vFP" = (
 /obj/machinery/light_switch/directional/west,
 /turf/closed/wall,
@@ -44369,6 +44383,18 @@
 /obj/effect/turf_decal/siding/wideplating/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vOL" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/obj/machinery/requests_console/directional/west{
+	department = "Surgery";
+	departmentType = 1;
+	name = "Surgery Requests Console"
+	},
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "vQG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44401,16 +44427,6 @@
 "vSj" = (
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
-"vSN" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"vUl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "vUt" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
@@ -44424,6 +44440,12 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"vWW" = (
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "vZP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -44441,13 +44463,6 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"wad" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "wbs" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -44482,17 +44497,21 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/space)
-"wrB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+"wqd" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "wrR" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
@@ -44522,12 +44541,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"wvB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "wys" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44572,16 +44585,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"wJx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "wKL" = (
 /obj/structure/table,
 /obj/item/toy/foamblade,
@@ -44595,14 +44598,6 @@
 /obj/machinery/bluespace_vendor/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"wKZ" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Pharmacy";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "wLO" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -44647,19 +44642,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"wQr" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
+"wQS" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"wRn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "wRL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -44696,20 +44686,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"xcs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"xeS" = (
-/obj/structure/table,
-/obj/item/cautery,
-/obj/item/retractor,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "xfK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44774,6 +44750,9 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xly" = (
+/turf/open/floor/plating/elevatorshaft,
+/area/medical/storage)
 "xmX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -44784,20 +44763,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"xop" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
+"xoz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "xoT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -44810,6 +44781,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"xqx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "xqE" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -44824,15 +44805,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xui" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "xur" = (
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
-"xvF" = (
+"xxQ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/medbay/central)
 "xyD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -44846,6 +44835,12 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/space)
+"xzJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xzX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44884,14 +44879,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"xDK" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
+"xFO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/medbay/central)
 "xGE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -44912,15 +44909,6 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"xJu" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "xKA" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -44952,6 +44940,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"xZB" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "yal" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -44971,6 +44963,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"yck" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "ycR" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
@@ -85726,14 +85723,14 @@ aaa
 aaa
 aaa
 aak
-aKh
-aOz
+aEd
+aEd
 aEd
 aQG
 aIT
 aHx
 aHx
-hwV
+kwV
 aYK
 aZO
 aZO
@@ -85983,7 +85980,7 @@ aak
 aak
 aak
 aak
-aOz
+aEd
 aPm
 aEd
 aWL
@@ -86246,9 +86243,9 @@ aEd
 bwG
 aIT
 bdK
-qpN
-aQN
-aZL
+mKE
+aOz
+giJ
 bgi
 beJ
 cLv
@@ -86504,10 +86501,10 @@ aRN
 aIT
 bdK
 beO
-kBK
-hXk
+iuS
+oUF
 bdp
-tbA
+fzM
 bgl
 aZa
 cWw
@@ -86758,7 +86755,7 @@ bbl
 bbl
 bvL
 bwJ
-lVb
+lXd
 bdK
 beO
 aQT
@@ -87013,11 +87010,11 @@ aHx
 aXM
 aXM
 aXM
-iKv
+kpF
 aXM
 aXM
 aXM
-uSU
+vls
 aQT
 beO
 cAQ
@@ -87268,22 +87265,22 @@ bdK
 bdK
 aRR
 aXM
-uNQ
-vCb
-nrs
-hQq
-jEM
-oVf
-uUS
-lTj
-uMe
+lOu
+oqK
+geH
+vOL
+maq
+uOh
+mAr
+lQl
+fBg
 cFF
 aYb
-kYs
+fhP
 aZb
-vUl
-jlz
-teg
+xui
+fdp
+tym
 bno
 bbq
 cyf
@@ -87522,21 +87519,21 @@ aEd
 aNJ
 aEd
 bdK
-aQN
+aOz
 aRK
 aXM
-hKJ
-reW
-xcs
-xvF
-xeS
-oVf
-tMd
+fjL
+hDB
+unA
+omY
+dLf
+uOh
+lOx
 aQT
 beO
 cFF
 aYi
-mIE
+vch
 bfj
 aZV
 bfj
@@ -87782,23 +87779,23 @@ bdK
 beO
 beO
 aXM
-uwf
-qCw
-nrs
-xvF
-oUy
-oVf
-tMd
+iro
+vlP
+geH
+omY
+gEA
+uOh
+lOx
 aQT
 beO
 cFF
 bfb
-hzm
-dAQ
+rXs
+jlS
 blL
 bae
 bno
-jVs
+fdL
 bbq
 bcu
 bcy
@@ -88039,18 +88036,18 @@ bdK
 beO
 beO
 aXM
-foM
-fSw
-xJu
-xvF
-pWM
-oVf
-tMd
+qay
+hhz
+sBF
+omY
+uZi
+uOh
+lOx
 aQT
 beO
 cFF
-pBk
-pRz
+uNo
+xqx
 aZc
 cNm
 baf
@@ -88296,15 +88293,15 @@ aPt
 aMl
 beO
 aXM
-hXp
-fGw
-nrs
-qBl
-mJe
-oVf
-tMd
-khF
-hVO
+vdZ
+yck
+geH
+jti
+oRH
+uOh
+lOx
+xFO
+gdP
 cAQ
 aYj
 cFF
@@ -88555,11 +88552,11 @@ beO
 aXM
 aXM
 aXM
-rbV
+iNH
 aXM
 aXM
 aXM
-gmK
+phC
 aQT
 beO
 beO
@@ -88813,7 +88810,7 @@ beO
 beO
 beO
 aQT
-umH
+bOW
 beO
 beO
 beO
@@ -89065,31 +89062,31 @@ bla
 bdK
 aPv
 cyS
-tVv
-fKL
-tVv
-rQV
-sxC
-vvG
-hXk
-hXk
-mra
-dSR
-ldh
-ldh
-oFK
-hXk
+bnh
+nsd
+bnh
+snX
+tly
+xxQ
+oUF
+oUF
+mhQ
+pZH
+iyE
+iyE
+iKA
+oUF
 aZo
-kJu
-kJu
-rjK
-rjK
-eLt
-rjK
+xoz
+xoz
+mQS
+mQS
+gkU
+mQS
 brv
-gjL
-rIm
-oHK
+kZP
+wqd
+mON
 bgv
 btm
 bww
@@ -89321,31 +89318,31 @@ aHx
 bla
 bdK
 aPv
-bnh
+aQN
 beO
-wvB
+xzJ
 beO
-lSe
-ovM
+idt
+uKb
 aSD
 aSo
-uWF
-pnv
-dFR
+dqs
+mkE
+nGc
 aSo
 aSD
 aQT
 beO
 aZn
 bky
-uEb
-uEb
-uEb
-wJx
-uEb
-uEb
+tmr
+tmr
+tmr
+uFA
+tmr
+tmr
 bdI
-xop
+hmF
 buR
 crm
 btm
@@ -89578,27 +89575,27 @@ aHx
 bla
 bdK
 aPv
-bnh
+aQN
 bta
 bta
 bta
 bta
-kBL
+gjU
 aSD
-tHH
-gWy
-pOb
-tKM
-tHH
+ivN
+ptC
+eKn
+xZB
+ivN
 aSD
 aQT
 beO
 bhD
 aZW
-etr
+uYP
 bky
 bky
-sbD
+iMA
 bky
 bky
 bsh
@@ -89836,23 +89833,23 @@ bla
 bdK
 bdK
 aMu
-sRj
-jVn
-gFN
+ejx
+vWW
+oif
 bta
-kBL
+gjU
 aSo
-wQr
-gAF
-wad
-tKM
-gWy
+ivL
+rrF
+gvV
+xZB
+ptC
 aSD
 aQT
 beO
 bhD
 biU
-etr
+uYP
 blU
 bnj
 boE
@@ -90096,15 +90093,15 @@ aQS
 bte
 bte
 bte
-eFr
+bQV
 bta
 aSo
-eNA
-gWy
-pOb
-tKM
-gWy
-uWF
+tYg
+ptC
+eKn
+xZB
+ptC
+dqs
 aQT
 beO
 aZQ
@@ -90112,7 +90109,7 @@ bky
 bag
 bkv
 cXI
-jwr
+keH
 bky
 bky
 bhF
@@ -90351,17 +90348,17 @@ bdK
 aKz
 aQT
 bte
-nKm
-nKm
+xly
+xly
 cbT
 bta
 aSo
-tUw
-tKM
-hFE
-tKM
-tKM
-dFR
+pAu
+xZB
+rzp
+xZB
+xZB
+nGc
 aQT
 beO
 bhD
@@ -90369,7 +90366,7 @@ biW
 baj
 bbc
 bky
-jwr
+keH
 bky
 bky
 bhF
@@ -90608,16 +90605,16 @@ bdK
 bdK
 aQT
 bte
-nKm
-nKm
+xly
+xly
 cbT
 bta
 aSo
-xDK
-qln
-diV
-gWy
-gWy
+wQS
+tYa
+miW
+ptC
+ptC
 aSD
 aQT
 beO
@@ -90626,7 +90623,7 @@ aZX
 bkv
 bkv
 mrE
-uAI
+ufV
 bky
 bky
 bhF
@@ -90865,16 +90862,16 @@ aHx
 bdK
 aQT
 bte
-nKm
-nKm
-qHn
+xly
+xly
+kSq
 bta
 aSD
-vSN
-gWy
-hFE
-gWy
-pRT
+uuG
+ptC
+rzp
+ptC
+oJL
 aSD
 aQT
 beO
@@ -91128,9 +91125,9 @@ bte
 bta
 aSD
 aSo
-uWF
-wrB
-uWF
+dqs
+nkR
+dqs
 aSo
 aSD
 aQT
@@ -91383,7 +91380,7 @@ beO
 beO
 beO
 beO
-umH
+bOW
 beO
 beO
 aQT
@@ -91640,15 +91637,15 @@ aSX
 aOA
 bZT
 bZT
-eiT
+ltt
 bZT
 bZT
 aWw
-ldh
+iyE
 aXK
-ldh
-sJG
-uMe
+iyE
+rJx
+fBg
 bhK
 bhK
 bkC
@@ -92160,9 +92157,9 @@ aZi
 aWP
 bbr
 bte
-wKZ
-khF
-hVO
+lsR
+xFO
+gdP
 bhM
 blX
 bkE
@@ -92418,16 +92415,16 @@ ape
 bbs
 bte
 beO
-oTC
-hXk
+cXV
+oUF
 biX
-duv
+uJj
 ucU
 ogF
 bnu
 boJ
 ucU
-nxG
+lht
 bhK
 btm
 btm
@@ -92674,16 +92671,16 @@ aUM
 aWR
 bbt
 bte
-ghC
-ghC
-ghC
+pXf
+pXf
+pXf
 bhK
-jUK
-nZU
-vEi
+rTC
+foV
+rSH
 bnv
-wRn
-ofJ
+qNb
+eZc
 brG
 bhK
 btx
@@ -92938,7 +92935,7 @@ bhK
 bac
 bal
 bbh
-oxX
+rcU
 bbu
 bcv
 bdv

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -1033,6 +1033,11 @@
 "afm" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
+"afp" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "afq" = (
 /obj/item/stock_parts/cell/potato{
 	name = "\improper Beepsky's emergency battery"
@@ -5081,12 +5086,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/command/bridge)
-"avk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "avn" = (
 /turf/open/floor/iron,
 /area/security/processing)
@@ -13253,6 +13252,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "aZp" = (
@@ -13385,6 +13385,7 @@
 /area/security/checkpoint/medical)
 "bag" = (
 /obj/structure/chair/office/light,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bah" = (
@@ -13504,7 +13505,6 @@
 /area/medical/abandoned)
 "bbc" = (
 /obj/structure/table,
-/obj/structure/cable,
 /obj/item/reagent_containers/food/drinks/britcup,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
@@ -13677,6 +13677,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"bca" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "bcf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -13975,6 +13979,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bdJ" = (
@@ -16893,6 +16898,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"bqq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "bqr" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/west,
@@ -21261,6 +21270,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"bEy" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "bEz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -26507,12 +26526,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
-"cde" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "cdk" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/yellow,
@@ -36472,6 +36485,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
+"cOZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "cPa" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -39261,6 +39278,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"cYY" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "cZG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -39282,16 +39305,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"dcM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "ddh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 6
@@ -39341,21 +39354,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"dkl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"dlq" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "dmw" = (
 /obj/structure/table,
 /obj/item/storage/box/shipping,
@@ -39384,20 +39382,6 @@
 "dqB" = (
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
-"dro" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"drv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "duA" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -39412,11 +39396,27 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"dvA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "dzf" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/bluespace_vendor/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"dBo" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "dBV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39440,16 +39440,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
-"dCp" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "dDa" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"dEF" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "dEZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -39486,11 +39484,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"dLF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "dMF" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -39544,11 +39537,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"dWj" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/computer/operating,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "dWI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 5
@@ -39592,10 +39580,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"ehr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "ehC" = (
 /obj/structure/rack,
 /obj/item/radio/off,
@@ -39647,6 +39631,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ena" = (
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "ene" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -39660,14 +39650,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"eqE" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "eqU" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/space/basic,
@@ -39720,14 +39702,16 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"eyC" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/camera{
-	c_tag = "Surgery A";
-	name = "Surgery Camera";
-	network = list("ss13","medbay")
+"eya" = (
+/obj/structure/table,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medigel/sterilizine,
+/obj/machinery/button/door/directional/east{
+	id = "mainsurgery";
+	name = "Privacy Button";
+	req_access_txt = "5"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/surgery)
 "eze" = (
 /turf/open/floor/iron,
@@ -39741,6 +39725,18 @@
 /obj/item/firing_pin/implant/mindshield,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"eDG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"eDM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "eEO" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -39748,6 +39744,10 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"eHg" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "eHp" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255
@@ -39767,21 +39767,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"eJa" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
+"eID" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/area/security/checkpoint/medical)
 "eLa" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -39793,6 +39782,25 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"eOZ" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"eSd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
+"eUR" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "eVD" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -39833,6 +39841,17 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"feJ" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"fhV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fiV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -39842,16 +39861,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"fjK" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "fjZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
@@ -39867,6 +39876,13 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"flE" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fmk" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -39875,15 +39891,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"foi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "fpK" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39935,6 +39942,12 @@
 	},
 /turf/open/floor/plating,
 /area/commons/dorms)
+"fru" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "frR" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -39958,14 +39971,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"fwL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "fwU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/directional/east,
@@ -39996,9 +40001,6 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/iron,
 /area/space)
-"fzh" = (
-/turf/open/floor/plating/elevatorshaft,
-/area/medical/storage)
 "fAI" = (
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
@@ -40019,6 +40021,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"fDA" = (
+/obj/structure/table,
+/obj/item/storage/box/masks,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "fEA" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -40040,10 +40047,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fJE" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+"fGX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -40082,6 +40095,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"fPL" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fQS" = (
 /obj/structure/window{
 	dir = 1
@@ -40123,11 +40140,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"fYy" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "fZf" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line,
@@ -40244,20 +40256,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/commons/dorms)
-"gof" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"gpk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "gqT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"gsn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gsC" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -40321,14 +40329,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"gyV" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/structure/sign/departments/medbay/alt{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "gzW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -40345,24 +40345,35 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gEO" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
-/obj/item/kirbyplants/random,
+"gEj" = (
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"gFZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "gGz" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
+"gIz" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/medical/medbay/lobby)
 "gJn" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"gKi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gKm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -40374,16 +40385,16 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gQU" = (
+"gQJ" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/pharmacy)
+/area/medical/surgery)
 "gRT" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -40420,12 +40431,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"gXC" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table/optable,
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "haR" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -40472,14 +40477,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"hfi" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Pharmacy";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hfS" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -40526,15 +40523,28 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hmq" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
+"hkY" = (
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/hemostat,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
+"hmc" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "hob" = (
 /turf/closed/wall,
 /area/security/brig)
+"hok" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hoD" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -40650,6 +40660,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hKu" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hLt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -40659,12 +40678,38 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hMs" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"hMt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "hME" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"hPl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "hPD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -40674,6 +40719,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hSb" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "hTK" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -40722,12 +40774,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"iee" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "igc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/neutral{
@@ -40755,12 +40801,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"iiP" = (
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "ijl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40771,34 +40811,54 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"imE" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "inh" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
+"inS" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
+"inT" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"inZ" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/storage)
 "iog" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"ioI" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "iqJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"iyo" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/west,
+"itn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/pharmacy)
 "iyV" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/stack/sheet/mineral/sandbags{
@@ -40818,6 +40878,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"izU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "iAk" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -40845,6 +40915,18 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron,
 /area/space)
+"iFv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
+"iFD" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "iGq" = (
 /obj/machinery/camera{
 	c_tag = "Minisat Exterior SE";
@@ -40859,6 +40941,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"iQX" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40897,11 +40983,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"iYr" = (
+/obj/structure/table,
+/obj/item/circular_saw,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "iYI" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"jad" = (
+/turf/open/floor/plating/elevatorshaft,
+/area/medical/storage)
 "jbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -40916,6 +41010,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"jcp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "jcz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -40971,16 +41075,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"jiQ" = (
-/obj/structure/table,
-/obj/item/scalpel,
-/obj/item/hemostat,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
-"jiU" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "jjw" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
@@ -40994,6 +41088,20 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"jlj" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
+"jmC" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "jmW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -41045,6 +41153,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"jsi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "jtK" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -41068,6 +41184,12 @@
 	},
 /turf/open/floor/carpet,
 /area/service/chapel/main)
+"juY" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/optable,
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "jvH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -41091,6 +41213,22 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
+"jAB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"jAL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "jEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41202,15 +41340,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/space)
-"jRf" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"jTz" = (
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "jUc" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -41280,16 +41409,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"kke" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "knY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -41354,6 +41473,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"kHU" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "kId" = (
 /turf/open/floor/plating,
 /area/commons/dorms)
@@ -41385,11 +41509,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
-"kQh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "kQJ" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -41407,11 +41526,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"kRJ" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "kTu" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -41503,6 +41617,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"lek" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "leP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/vacuum/external{
@@ -41579,6 +41699,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"lwV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "lAI" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41618,26 +41743,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"lHQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"lII" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "lIQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -41658,12 +41763,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"lPC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "lUI" = (
 /obj/structure/sign/directions/engineering{
 	pixel_x = -30
@@ -41695,6 +41794,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lXC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "mar" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41725,6 +41830,16 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
+"mhb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "mjr" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -41738,11 +41853,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"mkk" = (
-/obj/structure/table,
-/obj/item/storage/box/masks,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+"mkL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "mkP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -41786,12 +41902,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"mqI" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "mqW" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas,
@@ -41859,12 +41969,6 @@
 /obj/item/target/syndicate,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
-"mwL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mxv" = (
 /obj/structure/window,
 /obj/machinery/hydroponics/constructable,
@@ -41874,16 +41978,6 @@
 /obj/structure/stairs/south,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"myo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mAK" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41911,11 +42005,10 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"mII" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+"mIL" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "mJP" = (
 /obj/structure/chair{
 	dir = 8
@@ -41955,11 +42048,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"mOb" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "mOS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -41994,12 +42082,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/science/explab)
-"mVS" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "mVT" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42008,14 +42090,20 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"mXl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+"mZV" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "ncQ" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/duct,
@@ -42099,6 +42187,11 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"nnh" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "nnm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -42129,11 +42222,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics)
-"npX" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/surgery,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "nqe" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -42163,35 +42251,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nwB" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
 /obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/space)
-"nyw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "nzM" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -42263,22 +42328,12 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library)
-"nDg" = (
-/obj/structure/table,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
-"nDv" = (
+"nDc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/medbay/central)
 "nDG" = (
 /obj/structure/sink{
 	dir = 4;
@@ -42328,10 +42383,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"nNN" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "nOf" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase/lawyer,
@@ -42343,20 +42394,30 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
-"nQv" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
+"nSc" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "nSk" = (
 /obj/structure/chair{
 	dir = 1
@@ -42420,10 +42481,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"okg" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "omh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -42433,6 +42490,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"onj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "onX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -42469,10 +42534,6 @@
 "osl" = (
 /turf/open/floor/white,
 /area/service/library)
-"ouW" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "owj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42486,10 +42547,6 @@
 	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"owo" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "oEh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -42646,22 +42703,11 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"plL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "psH" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"ptO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "pux" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/light/directional/north,
@@ -42702,12 +42748,6 @@
 "pAS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
-"pGu" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "pHZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42761,6 +42801,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
+"pSS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "pWh" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -42777,12 +42826,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"pXZ" = (
-/obj/structure/table,
-/obj/item/cautery,
-/obj/item/retractor,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "pZN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -42797,7 +42840,7 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"qaM" = (
+"qbP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42805,6 +42848,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/treatment_center)
 "qdp" = (
@@ -42832,8 +42876,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"qhE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+"qhK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "qji" = (
@@ -42841,13 +42889,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"qkD" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qlV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -42859,23 +42900,45 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
-"qmD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qna" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"qoA" = (
+"qnr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/surgery)
+"qnO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "qqq" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
+"qrp" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"qrA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "quc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -42891,6 +42954,14 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"qvS" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "qwp" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics Internal Airlock";
@@ -42913,12 +42984,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"qyR" = (
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43000,6 +43065,16 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
+"qRU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qTJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -43081,16 +43156,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
-"rcT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
+"rct" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/operating,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/surgery)
 "rdy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -43126,6 +43196,21 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"roQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"rpX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "rqh" = (
 /obj/machinery/holopad,
 /obj/item/beacon,
@@ -43135,20 +43220,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"rri" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/department/medical)
 "rsn" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/turf_decal/siding/wood,
@@ -43190,10 +43261,6 @@
 /obj/item/clothing/gloves/cargo_gauntlet,
 /turf/open/floor/iron,
 /area/space)
-"rEq" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "rGv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43204,17 +43271,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"rKt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "rLc" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -43280,17 +43336,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"rOH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"rQT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+"rOL" = (
+/obj/structure/cable,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "rRf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
@@ -43339,12 +43389,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
-"rWJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "rWX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -43374,16 +43418,6 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/space)
-"sao" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "sgD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -43416,6 +43450,24 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"skd" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"skl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"snW" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "ssn" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -30
@@ -43436,6 +43488,32 @@
 "ste" = (
 /turf/open/space/basic,
 /area/commons/dorms)
+"svy" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Morgue";
+	name = "Medbay Camera";
+	network = list("ss13","medbay")
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"swf" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "swA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43458,16 +43536,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"sAR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "sBD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43478,15 +43546,6 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"sBX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "sHB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -43506,6 +43565,36 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"sKl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"sMp" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
+"sNH" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "sPg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
 	dir = 1
@@ -43533,24 +43622,17 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"sRT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "sSa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"sTb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
+"sSm" = (
+/obj/structure/table,
+/obj/item/surgicaldrill,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "sTr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -43573,35 +43655,16 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"sXo" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "sYV" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/space)
+"taA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "tcQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -43612,6 +43675,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"teJ" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Pharmacy";
+	name = "Medbay Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "teP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -43621,6 +43692,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"tfv" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "tiZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -43631,11 +43706,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
-"tjr" = (
-/obj/structure/table,
-/obj/item/surgicaldrill,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "tjt" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -43657,22 +43727,35 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"tnN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "tnQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"toF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+"tqA" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/maintenance/department/medical)
 "tsg" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43738,6 +43821,9 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"txK" = (
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tyl" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -43830,16 +43916,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"tJE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "tKH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -43862,12 +43938,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/space)
-"tPu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+"tMS" = (
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
+"tOY" = (
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "tRe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -43878,14 +43957,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"tWG" = (
+"tWy" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/medbay/central)
 "tXD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43948,6 +44026,16 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"ujK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "ujZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -43980,10 +44068,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"uwz" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uwK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -44003,10 +44087,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/space)
-"uAi" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "uAJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -44031,18 +44111,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uFQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "uGx" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"uHu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "uJd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44066,6 +44148,16 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"uNZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uPf" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
@@ -44136,10 +44228,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"vbm" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "vds" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -44163,16 +44251,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"vjw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+"viO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
-/area/medical/pharmacy)
+/area/medical/surgery)
 "vjO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -44205,12 +44287,6 @@
 "vkV" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"vmZ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vnA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44248,11 +44324,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"vvi" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "vwM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -44275,19 +44346,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"vAu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"vCm" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vCx" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
@@ -44317,16 +44375,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars)
-"vMe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "vNP" = (
 /obj/structure/rack,
 /obj/item/gun/grenadelauncher,
@@ -44340,12 +44388,6 @@
 /obj/effect/turf_decal/siding/wideplating/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"vOq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "vQG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44367,15 +44409,6 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"vQV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "vRn" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Cargo Bay";
@@ -44426,12 +44459,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wlt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "wlG" = (
 /obj/structure/reflector/single,
 /turf/open/floor/engine,
@@ -44486,6 +44513,21 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"wvU" = (
+/obj/structure/table,
+/obj/item/cautery,
+/obj/item/retractor,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
+"wyq" = (
+/obj/machinery/smartfridge/organ,
+/obj/machinery/camera{
+	c_tag = "Surgery A";
+	name = "Surgery Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "wys" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44517,14 +44559,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"wFP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "mainsurgery";
-	name = "Surgery Privacy Door"
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
 "wFX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44538,6 +44572,14 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"wJn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "mainsurgery";
+	name = "Surgery Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/medical/surgery)
 "wKL" = (
 /obj/structure/table,
 /obj/item/toy/foamblade,
@@ -44551,11 +44593,6 @@
 /obj/machinery/bluespace_vendor/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"wLr" = (
-/obj/structure/cable,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "wLO" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -44577,6 +44614,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wOu" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "wOw" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 30
@@ -44615,17 +44657,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wXA" = (
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/reagent_containers/medigel/sterilizine,
-/obj/machinery/button/door/directional/east{
-	id = "mainsurgery";
-	name = "Privacy Button";
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "wZO" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -44636,6 +44667,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"xba" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xbW" = (
 /obj/structure/table,
 /obj/machinery/light/directional/north,
@@ -44653,17 +44694,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"xfL" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Morgue";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "xgL" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -44681,6 +44711,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xiW" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "xjf" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/white,
@@ -44764,6 +44804,22 @@
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
+"xxy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"xxW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xyD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -44777,10 +44833,12 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/space)
-"xzL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+"xzk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/medbay/central)
 "xzX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44925,13 +44983,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"yik" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "yjV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44941,16 +44992,6 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/department/medical)
-"ylf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 
 (1,1,1) = {"
 aaa
@@ -85668,7 +85709,7 @@ aQG
 aIT
 aHx
 aHx
-fJE
+tfv
 aYK
 aZO
 aZO
@@ -86181,9 +86222,9 @@ aEd
 bwG
 aIT
 bdK
-uwz
+gEj
 aQN
-nNN
+inT
 bgi
 beJ
 cLv
@@ -86439,10 +86480,10 @@ aRN
 aIT
 bdK
 beO
-lHQ
-tPu
+xba
+nDc
 bdp
-rWJ
+mkL
 bgl
 aZa
 cWw
@@ -86693,7 +86734,7 @@ bbl
 bbl
 bvL
 bwJ
-wLr
+rOL
 bdK
 beO
 aQT
@@ -86948,11 +86989,11 @@ aHx
 aXM
 aXM
 aXM
-rri
+tqA
 aXM
 aXM
 aXM
-dlq
+feJ
 aQT
 beO
 cAQ
@@ -87203,22 +87244,22 @@ bdK
 bdK
 aRR
 aXM
-jiU
-iiP
-vMe
-nDg
-npX
-wFP
-xfL
-toF
-plL
+inS
+ena
+gQJ
+hSb
+wOu
+wJn
+svy
+uNZ
+skl
 cFF
 aYb
-foi
+roQ
 aZb
-ehr
-fYy
-avk
+eID
+kHU
+fru
 bno
 bbq
 cyf
@@ -87460,18 +87501,18 @@ bdK
 aQN
 aRK
 aXM
-eyC
-gof
-tWG
-jTz
-pXZ
-wFP
-dCp
+wyq
+viO
+qnr
+tMS
+wvU
+wJn
+eUR
 aQT
 beO
 cFF
 aYi
-fjK
+xiW
 bfj
 aZV
 bfj
@@ -87717,19 +87758,19 @@ bdK
 beO
 beO
 aXM
-gXC
-mOb
-vMe
-jTz
-mII
-wFP
-dCp
+juY
+jmC
+gQJ
+tMS
+iYr
+wJn
+eUR
 aQT
 beO
 cFF
 bfb
-rcT
-dLF
+fGX
+gFZ
 blL
 bae
 bno
@@ -87974,18 +88015,18 @@ bdK
 beO
 beO
 aXM
-dWj
-xzL
-nDv
-jTz
-jiQ
-wFP
-dCp
+rct
+bca
+jlj
+tMS
+hkY
+wJn
+eUR
 aQT
 beO
 cFF
-lII
-sAR
+ujK
+hMt
 aZc
 cNm
 baf
@@ -88231,15 +88272,15 @@ aPt
 aMl
 beO
 aXM
-mqI
-vvi
-vMe
-wXA
-tjr
-wFP
-dCp
-sao
-mwL
+dBo
+nnh
+gQJ
+eya
+sSm
+wJn
+eUR
+sKl
+gsn
 cAQ
 aYj
 cFF
@@ -88490,11 +88531,11 @@ beO
 aXM
 aXM
 aXM
-sXo
+nSc
 aXM
 aXM
 aXM
-gEO
+hKu
 aQT
 beO
 beO
@@ -88748,7 +88789,7 @@ beO
 beO
 beO
 aQT
-owo
+fPL
 beO
 beO
 beO
@@ -89000,31 +89041,31 @@ bla
 bdK
 aPv
 cyS
-wlt
-fwL
-wlt
-nyw
-myo
-vCm
-tPu
-tPu
-dkl
-ylf
-dro
-dro
-lPC
-dro
+eDM
+onj
+eDM
+jsi
+xxW
+hok
+nDc
+nDc
+qRU
+jcp
+taA
+taA
+fhV
+nDc
 aZo
-kQh
-kQh
-kQh
-kQh
-sBX
-kQh
+lXC
+lXC
+lwV
+lwV
+tnN
+lwV
 brv
-eJa
-nwB
-ptO
+swf
+sNH
+qnO
 bgv
 btm
 bww
@@ -89258,30 +89299,30 @@ bdK
 aPv
 bnh
 beO
-qmD
+gKi
 beO
-vAu
-qkD
+eDG
+flE
 aSD
 aSo
-vbm
-qaM
-sRT
+dEF
+bEy
+sMp
 aSo
 aSD
 aQT
 beO
 aZn
 bky
-bky
-bky
-bky
-vQV
-bky
-bky
+iQX
+iQX
+iQX
+uFQ
+iQX
+iQX
 bdI
-cpH
-btm
+mZV
+buR
 crm
 btm
 bwx
@@ -89518,22 +89559,22 @@ bta
 bta
 bta
 bta
-okg
+imE
 aSD
-iyo
-qoA
-drv
-rEq
-iyo
+eOZ
+txK
+pSS
+eHg
+eOZ
 aSD
 aQT
 beO
 bhD
 aZW
-bkv
+gIz
 bky
 bky
-vQV
+jAB
 bky
 bky
 bsh
@@ -89771,23 +89812,23 @@ bla
 bdK
 bdK
 aMu
-gyV
-qyR
-mkk
+qvS
+tOY
+fDA
 bta
-okg
+imE
 aSo
-pGu
-qhE
-rOH
-rEq
-qoA
+hmc
+cOZ
+jAL
+eHg
+txK
 aSD
 aQT
 beO
 bhD
 biU
-bkv
+gIz
 blU
 bnj
 boE
@@ -90031,15 +90072,15 @@ aQS
 bte
 bte
 bte
-uAi
+mIL
 bta
 aSo
-eqE
-qoA
-drv
-rEq
-qoA
-vbm
+qrp
+txK
+pSS
+eHg
+txK
+dEF
 aQT
 beO
 aZQ
@@ -90047,7 +90088,7 @@ bky
 bag
 bkv
 cXI
-cde
+lek
 bky
 bky
 bhF
@@ -90286,17 +90327,17 @@ bdK
 aKz
 aQT
 bte
-fzh
-fzh
+jad
+jad
 cbT
 bta
 aSo
-hmq
-rEq
-kke
-rEq
-rEq
-sRT
+cYY
+eHg
+hPl
+eHg
+eHg
+sMp
 aQT
 beO
 bhD
@@ -90304,7 +90345,7 @@ biW
 baj
 bbc
 bky
-cde
+lek
 bky
 bky
 bhF
@@ -90543,16 +90584,16 @@ bdK
 bdK
 aQT
 bte
-fzh
-fzh
+jad
+jad
 cbT
 bta
 aSo
-ioI
-rQT
-mXl
-qoA
-qoA
+skd
+bqq
+qhK
+txK
+txK
 aSD
 aQT
 beO
@@ -90561,7 +90602,7 @@ aZX
 bkv
 bkv
 mrE
-vOq
+xxy
 bky
 bky
 bhF
@@ -90800,16 +90841,16 @@ aHx
 bdK
 aQT
 bte
-fzh
-fzh
-nQv
+jad
+jad
+inZ
 bta
 aSD
-mVS
-qoA
-kke
-qoA
-jRf
+iFD
+txK
+hPl
+txK
+hMs
 aSD
 aQT
 beO
@@ -91063,9 +91104,9 @@ bte
 bta
 aSD
 aSo
-vbm
-rKt
-vbm
+dEF
+qbP
+dEF
 aSo
 aSD
 aQT
@@ -91318,7 +91359,7 @@ beO
 beO
 beO
 beO
-owo
+fPL
 beO
 beO
 aQT
@@ -91575,15 +91616,15 @@ aSX
 aOA
 bZT
 bZT
-yik
+tWy
 bZT
 bZT
 aWw
-dro
+taA
 aXK
-dro
-iee
-plL
+taA
+xzk
+skl
 bhK
 bhK
 bkC
@@ -92095,9 +92136,9 @@ aZi
 aWP
 bbr
 bte
-hfi
-sao
-mwL
+teJ
+sKl
+gsn
 bhM
 blX
 bkE
@@ -92353,16 +92394,16 @@ ape
 bbs
 bte
 beO
-tJE
-tPu
+qrA
+nDc
 biX
-dcM
+izU
 ucU
 ogF
 bnu
 boJ
 ucU
-kRJ
+afp
 bhK
 btm
 btm
@@ -92609,16 +92650,16 @@ aUM
 aWR
 bbt
 bte
-vmZ
-vmZ
-vmZ
+rpX
+rpX
+rpX
 bhK
-gQU
-gpk
-uHu
+mhb
+iFv
+itn
 bnv
-sTb
-ouW
+eSd
+snW
 brG
 bhK
 btx
@@ -92873,7 +92914,7 @@ bhK
 bac
 bal
 bbh
-vjw
+dvA
 bbu
 bcv
 bdv

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -39401,12 +39401,28 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/central)
+"dHd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "dIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"dJo" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "dJu" = (
 /obj/machinery/power/smes{
 	charge = 500000
@@ -39479,6 +39495,11 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"dVM" = (
+/obj/effect/landmark/start/paramedic,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "dWI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 5
@@ -39594,6 +39615,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"epy" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "eqU" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/space/basic,
@@ -39712,6 +39737,12 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"eWa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "eYF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -39890,6 +39921,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"ftl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "fwU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/directional/east,
@@ -39915,22 +39952,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"fyn" = (
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "fyz" = (
 /obj/structure/table,
 /obj/item/stack/rods/ten,
 /turf/open/floor/iron,
 /area/space)
-"fzK" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Freezer";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/coldroom)
 "fzM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40068,13 +40098,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"fYS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "fZf" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line,
@@ -40349,10 +40372,30 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"gSu" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
+	},
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Medical Delivery";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gTq" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/engineering/engine_smes)
+"gTR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "gXc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -40543,25 +40586,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"hxo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "hxF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hAk" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "hBi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -40636,10 +40665,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"hNw" = (
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "hPD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -40749,10 +40774,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"ipA" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "iqJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40818,6 +40839,12 @@
 /obj/item/toy/plush/nukeplushie,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"iCb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "iCe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -40845,17 +40872,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"iJU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "iKA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40901,6 +40917,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"iOn" = (
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40976,6 +40995,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"jei" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "jes" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -40997,6 +41024,17 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/space)
+"jhs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "jhG" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -41006,6 +41044,9 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"jiJ" = (
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
 "jiN" = (
 /obj/structure/chair{
 	dir = 8;
@@ -41246,6 +41287,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"jPm" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "jPq" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -41325,17 +41370,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"kmE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "knY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -41490,6 +41524,10 @@
 /obj/machinery/modular_computer/console/preset/cargochat/service,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"kVb" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "kWd" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
@@ -41699,19 +41737,10 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
 /area/space)
-"lBz" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -5
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+"lCr" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "lET" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -41810,6 +41839,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lXz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "maq" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
@@ -41937,9 +41977,6 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"mrg" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
 "mrE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -42008,6 +42045,10 @@
 /obj/structure/stairs/south,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"mzT" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "mAr" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Hall - Morgue";
@@ -42164,11 +42205,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
-"ngC" = (
-/obj/effect/landmark/start/paramedic,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "nhM" = (
 /obj/machinery/piratepad/civilian,
 /turf/open/floor/iron,
@@ -42306,13 +42342,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nvF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -42390,6 +42419,16 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library)
+"nDz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "nDG" = (
 /obj/structure/sink{
 	dir = 4;
@@ -42398,11 +42437,6 @@
 /obj/structure/mirror/directional/west,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"nEN" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "nGc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -42499,18 +42533,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"obJ" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay";
-	name = "Delivery Beacon - Medbay"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
 "odr" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -42538,10 +42560,6 @@
 "oif" = (
 /obj/structure/table,
 /obj/item/storage/box/masks,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"oiA" = (
-/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "omh" = (
@@ -42743,6 +42761,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/white,
 /area/science)
+"oZp" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "oZx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -42761,10 +42783,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"pgm" = (
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "pgs" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
@@ -42965,11 +42983,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/white,
 /area/security/brig)
-"qgp" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "qhc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -43009,10 +43022,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
-"qsH" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "quc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -43050,16 +43059,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"qBT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43644,15 +43643,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"sNV" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/camera{
-	c_tag = "Medbay Cold Storage";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "sPg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
 	dir = 1
@@ -43713,12 +43703,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/space)
-"sYZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "tcQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -43789,12 +43773,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"tob" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "tsg" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -44048,17 +44026,13 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"udb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+"ues" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/medbay/central)
 "ueZ" = (
 /obj/structure/table,
 /obj/item/key/security,
@@ -44106,9 +44080,6 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"usC" = (
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "uuG" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/bot_red,
@@ -44142,17 +44113,6 @@
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/white,
 /area/science)
-"uxJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uys" = (
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
@@ -44224,6 +44184,15 @@
 /obj/item/food/popsicle/creamsicle_orange,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
+"uMz" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/camera{
+	c_tag = "Medbay Cold Storage";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "uMD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44270,6 +44239,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uPk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uPA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/gloves,
@@ -44297,6 +44274,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"uTS" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay";
+	name = "Delivery Beacon - Medbay"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/medical/medbay/central)
 "uWr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -44463,10 +44452,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"vtt" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "vwM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -44494,6 +44479,17 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vDG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vFP" = (
 /obj/machinery/light_switch/directional/west,
 /turf/closed/wall,
@@ -44620,6 +44616,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"wil" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "wlG" = (
 /obj/structure/reflector/single,
 /turf/open/floor/engine,
@@ -44660,10 +44661,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"wqr" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "wrR" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
@@ -44838,6 +44835,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xfF" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "xfK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -45022,18 +45023,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"xBt" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
-"xCs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "xDh" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -45104,6 +45093,17 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"xZi" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Freezer";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/coldroom)
 "xZB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -86156,7 +86156,7 @@ bgi
 bgi
 aYV
 aXH
-qsH
+lCr
 cLv
 blN
 bmY
@@ -86919,8 +86919,8 @@ bbl
 bvL
 bwJ
 lXd
-obJ
-lBz
+uTS
+gSu
 aQT
 beO
 cAQ
@@ -87681,8 +87681,8 @@ aEd
 aIR
 aRR
 gjU
-wqr
-xBt
+jPm
+xfF
 aRK
 aXM
 fjL
@@ -87938,8 +87938,8 @@ aEd
 bla
 aRR
 uKb
-usC
-hxo
+iOn
+ftl
 aRK
 aXM
 iro
@@ -87949,7 +87949,7 @@ omY
 gEA
 uOh
 lOx
-iJU
+lXz
 beO
 cFF
 bfb
@@ -88194,10 +88194,10 @@ aIT
 aMe
 bla
 aRR
-hAk
-usC
-tob
-qBT
+jei
+iOn
+eWa
+nDz
 aXM
 qay
 hhz
@@ -88206,7 +88206,7 @@ omY
 uZi
 uOh
 lOx
-uxJ
+jhs
 beO
 cFF
 uNo
@@ -88454,7 +88454,7 @@ aRR
 aOx
 aPt
 aMl
-sYZ
+iCb
 aXM
 vdZ
 yck
@@ -88708,10 +88708,10 @@ aEd
 aEd
 bla
 aRR
-sNV
-qgp
-hNw
-fYS
+uMz
+dJo
+fyn
+gTR
 aXM
 aXM
 aXM
@@ -88968,8 +88968,8 @@ aRR
 aRR
 aRR
 aRR
-fzK
-mrg
+xZi
+jiJ
 beO
 beO
 aQT
@@ -89225,7 +89225,7 @@ aHx
 bdK
 aPv
 cyS
-xCs
+uPk
 nsd
 bnh
 snX
@@ -89238,7 +89238,7 @@ pZH
 iyE
 iyE
 iKA
-nvF
+ues
 aZo
 xoz
 xoz
@@ -89494,7 +89494,7 @@ mkE
 nGc
 aSo
 aSD
-kmE
+vDG
 beO
 aZn
 bky
@@ -89741,7 +89741,7 @@ aPv
 aQN
 bta
 bta
-oiA
+kVb
 bta
 bta
 aSD
@@ -89751,12 +89751,12 @@ eKn
 xZB
 ivN
 aSD
-kmE
+vDG
 beO
 bhD
 aZW
 uYP
-pgm
+oZp
 bky
 iMA
 bky
@@ -90006,9 +90006,9 @@ ivL
 rrF
 gvV
 xZB
-vtt
+epy
 aSD
-kmE
+vDG
 beO
 bhD
 biU
@@ -90017,7 +90017,7 @@ blU
 bnj
 boE
 bky
-ipA
+mzT
 bhF
 cpH
 buh
@@ -90262,7 +90262,7 @@ aSo
 tYg
 ptC
 eKn
-nEN
+wil
 ptC
 dqs
 aQT
@@ -90274,7 +90274,7 @@ bkv
 cXI
 keH
 bky
-ipA
+mzT
 bhF
 cpH
 btm
@@ -90518,7 +90518,7 @@ bta
 aSo
 pAu
 xZB
-udb
+dHd
 xZB
 xZB
 nGc
@@ -90531,7 +90531,7 @@ bbc
 bky
 keH
 bky
-ngC
+dVM
 bhF
 cpH
 btm
@@ -90777,9 +90777,9 @@ wQS
 tYa
 miW
 ptC
-vtt
+epy
 aSD
-kmE
+vDG
 beO
 bhD
 aZX
@@ -90788,7 +90788,7 @@ bkv
 mrE
 ufV
 bky
-ipA
+mzT
 bhF
 cpH
 btm
@@ -91036,7 +91036,7 @@ rzp
 ptC
 oJL
 aSD
-kmE
+vDG
 beO
 bhD
 xbW
@@ -91293,12 +91293,12 @@ nkR
 dqs
 aSo
 aSD
-kmE
+vDG
 beO
 bhW
 bjd
 bky
-pgm
+oZp
 bky
 bky
 bky
@@ -92064,7 +92064,7 @@ aWN
 aXE
 bte
 beO
-uxJ
+jhs
 beO
 bhL
 aZY

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -9386,8 +9386,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aIU" = (
-/obj/structure/fluff/broken_flooring,
-/turf/open/floor/plating,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
 /area/maintenance/central)
 "aIV" = (
 /obj/effect/decal/cleanable/blood/innards,
@@ -9422,11 +9422,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aJj" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/structure/fluff/broken_flooring,
+/turf/open/floor/plating,
 /area/maintenance/central)
 "aJl" = (
 /obj/structure/chair{
@@ -9479,10 +9476,17 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
 	},
-/obj/structure/cable,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aJz" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aJA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -9492,21 +9496,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aJA" = (
-/obj/structure/chair,
-/turf/open/floor/iron,
-/area/maintenance/central)
 "aJB" = (
 /obj/structure/chair,
-/obj/item/toy/plush/awakenedplushie,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aJC" = (
 /obj/structure/chair,
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/item/toy/plush/awakenedplushie,
+/turf/open/floor/iron,
 /area/maintenance/central)
 "aJD" = (
 /obj/effect/decal/cleanable/blood,
@@ -9533,9 +9530,11 @@
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aJI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/chair,
+/obj/structure/fluff/broken_flooring{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/maintenance/central)
 "aJJ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -9601,10 +9600,8 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "aKg" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 30
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aKh" = (
@@ -9671,9 +9668,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aKs" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 30
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aKt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -9708,15 +9708,13 @@
 /turf/open/floor/iron/white,
 /area/science)
 "aKz" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"aKA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aKA" = (
-/obj/structure/fluff/broken_flooring{
-	icon_state = "singular"
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aKB" = (
 /obj/structure/punching_bag,
 /turf/open/floor/iron,
@@ -9744,10 +9742,9 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "aKE" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/grille,
-/obj/structure/cable,
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aKM" = (
@@ -9893,6 +9890,7 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aLn" = (
+/obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/grille,
 /obj/structure/cable,
@@ -9953,7 +9951,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aLM" = (
 /obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner/east,
 /obj/structure/grille,
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -9965,12 +9962,10 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aLO" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4;
-	icon_state = "singular"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/grille,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aLP" = (
@@ -10055,38 +10050,37 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aMf" = (
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"aMg" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/central)
-"aMg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aMk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aMm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aMo" = (
@@ -10106,28 +10100,32 @@
 	},
 /area/maintenance/port/fore)
 "aMu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"aMv" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"aMv" = (
+"aMw" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
 /area/maintenance/central)
-"aMw" = (
+"aMy" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/grille,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"aMy" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/central)
 "aMz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/maintenance/central)
 "aMA" = (
@@ -10157,7 +10155,7 @@
 /area/security/courtroom)
 "aMG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/central)
@@ -10210,6 +10208,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
+"aMP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
@@ -10218,17 +10222,7 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/central)
-"aMP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/central)
 "aMQ" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -10239,17 +10233,22 @@
 /area/maintenance/central)
 "aMR" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
+"aMS" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/maintenance/central)
-"aMS" = (
-/obj/structure/cable,
-/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aMT" = (
@@ -10263,9 +10262,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMU" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
+/obj/structure/cable,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aMV" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -10294,10 +10294,14 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "aNb" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
+"aNc" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron/dark,
 /area/medical/cryo)
-"aNc" = (
+"aNg" = (
 /obj/structure/table/glass,
 /obj/item/wrench/medical,
 /obj/item/reagent_containers/spray/cleaner,
@@ -10311,10 +10315,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"aNg" = (
-/obj/structure/stairs/east,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "aNh" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -10502,9 +10502,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aNK" = (
-/obj/machinery/light/directional/west,
+/obj/structure/stairs/east,
 /turf/open/floor/iron,
-/area/maintenance/central)
+/area/commons/fitness/recreation)
 "aNL" = (
 /obj/item/melee/baseball_bat,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -10955,11 +10955,8 @@
 /turf/open/floor/iron/white,
 /area/maintenance/department/medical)
 "aPu" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -32
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/item/melee/flyswatter,
+/turf/open/floor/iron/dark,
 /area/maintenance/central)
 "aPv" = (
 /obj/structure/stairs/north,
@@ -10989,12 +10986,14 @@
 /turf/open/floor/iron/white,
 /area/science)
 "aPE" = (
-/obj/item/melee/flyswatter,
-/turf/open/floor/iron/dark,
-/area/maintenance/central)
-"aPG" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/closet/lasertag/red,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
+"aPG" = (
+/obj/structure/closet/athletic_mixed,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aPI" = (
@@ -11162,12 +11161,14 @@
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aQF" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
+	},
+/obj/structure/chair{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -11245,11 +11246,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aRc" = (
-/obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/landmark/start/hangover/closet,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/area/maintenance/central)
 "aRd" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/grille,
@@ -11631,9 +11630,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aSH" = (
-/obj/machinery/rnd/production/techfab/department/medical,
+/obj/structure/window{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/medbay/central)
 "aSI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -11645,11 +11646,9 @@
 /turf/closed/wall,
 /area/maintenance/starboard/fore)
 "aSJ" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/maintenance/central)
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aSP" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate{
@@ -11658,9 +11657,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aSQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aSS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -11872,15 +11874,42 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aTz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aTA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aTB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"aTC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aTD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aTF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "law1";
+	name = "Purple Office Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/service/lawoffice)
+"aTI" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/brute{
 	pixel_x = 3;
@@ -11903,84 +11932,38 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"aTC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/maintenance/central)
-"aTD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/central)
-"aTF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "law1";
-	name = "Purple Office Privacy Door"
-	},
-/turf/open/floor/plating,
-/area/service/lawoffice)
-"aTI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/maintenance/central)
 "aTJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/central)
-"aTK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/central)
-"aTL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aTM" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/northright{
-	dir = 8;
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/obj/structure/window/reinforced{
+/obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"aTK" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"aTL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"aTM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aTS" = (
-/obj/machinery/newscaster/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aTT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -12172,11 +12155,11 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aUz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/maintenance/central)
@@ -12235,32 +12218,46 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "aUK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aUL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/central)
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aUM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aUN" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northright{
+	dir = 8;
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron,
-/area/maintenance/central)
-"aUN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/central)
+/turf/open/floor/iron/dark,
+/area/medical/storage)
 "aUO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -12284,19 +12281,22 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aUW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aUY" = (
-/obj/structure/fluff/broken_flooring{
-	icon_state = "singular"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/central)
 "aVa" = (
 /turf/closed/wall,
@@ -12363,10 +12363,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aVo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/central)
 "aVp" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -12379,15 +12380,14 @@
 /turf/open/floor/plating,
 /area/science/explab)
 "aVq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aVs" = (
 /obj/structure/bookcase,
 /obj/machinery/light/directional/west,
@@ -12446,29 +12446,12 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aVz" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aVA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/open/floor/engine,
@@ -12531,26 +12514,23 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aVK" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aVN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aVN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aVO" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
 /turf/open/floor/iron,
+/area/maintenance/central)
+"aVO" = (
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/maintenance/central)
 "aVP" = (
 /obj/effect/landmark/start/depsec/medical,
@@ -12584,9 +12564,10 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "aVX" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
 /area/maintenance/central)
 "aWq" = (
 /obj/structure/cable,
@@ -12632,9 +12613,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aWw" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/iron,
-/area/maintenance/central)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "aWz" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -12697,28 +12684,49 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aWN" = (
-/obj/structure/table,
-/obj/item/megaphone,
-/turf/open/floor/iron,
-/area/maintenance/central)
-"aWP" = (
-/obj/structure/table,
-/obj/item/shard/plasma,
-/obj/item/stack/rods,
-/obj/item/kitchen/rollingpin,
-/obj/item/shard{
-	icon_state = "medium"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
 	},
-/turf/open/floor/iron,
-/area/maintenance/central)
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aWP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aWR" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron,
-/area/maintenance/central)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aWS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -12746,22 +12754,14 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "aXa" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -30
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aXc" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -12787,13 +12787,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aXh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/central)
 "aXi" = (
 /turf/closed/wall,
@@ -12806,20 +12803,17 @@
 /turf/open/floor/iron/white,
 /area/science)
 "aXl" = (
-/obj/structure/sign/departments/medbay/alt{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/light/directional/south,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aXm" = (
 /turf/closed/wall,
 /area/commons/dorms)
 "aXn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aXo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -12845,9 +12839,10 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "aXw" = (
-/obj/structure/stairs/north,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/obj/structure/table,
+/obj/item/megaphone,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aXx" = (
 /obj/machinery/sparker{
 	id = "testigniter";
@@ -12881,45 +12876,46 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aXC" = (
-/obj/structure/filingcabinet,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/table,
+/obj/item/shard/plasma,
+/obj/item/stack/rods,
+/obj/item/kitchen/rollingpin,
+/obj/item/shard{
+	icon_state = "medium"
 	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aXD" = (
 /obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aXE" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Medbay";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 1;
 	name = "Medical blue corner"
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/storage)
 "aXF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/central)
 "aXH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -12931,42 +12927,31 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "aXJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue Maintenance";
-	req_one_access_txt = "6;5"
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aXK" = (
-/obj/machinery/smartfridge/organ,
-/turf/closed/wall,
-/area/medical/morgue)
-"aXL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_one_access_txt = "5;12"
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = 32
 	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"aXL" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/starboard/fore)
 "aXM" = (
 /obj/item/stack/cable_coil/five,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aXN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
+/obj/structure/stairs/north,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "aXO" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers,
@@ -12989,28 +12974,33 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/structure/filingcabinet,
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "aYi" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/depsec/medical,
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "aYj" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "Security Medbay monitor";
-	network = list("medbay")
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Medbay";
+	req_access_txt = "63"
 	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "aYk" = (
@@ -13130,17 +13120,21 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "aYN" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/medical)
 "aYO" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance";
+	req_one_access_txt = "6;5"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/maintenance/starboard/fore)
 "aYR" = (
 /obj/structure/sign/poster/contraband/random{
@@ -13159,10 +13153,74 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aYV" = (
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
+/area/medical/morgue)
+"aYY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_one_access_txt = "5;12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"aYZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
+"aZa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
+"aZb" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"aZc" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	dir = 8;
+	name = "Security Medbay monitor";
+	network = list("medbay")
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"aZf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
-"aYY" = (
+"aZh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/storage)
+"aZi" = (
+/obj/structure/table,
+/obj/item/sensor_device,
+/obj/item/storage/box/rxglasses,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aZj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aZn" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
 	name = "Medbay";
@@ -13183,7 +13241,7 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"aYZ" = (
+"aZo" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
 	name = "Medbay";
@@ -13207,74 +13265,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"aZa" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Reception";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"aZb" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"aZc" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"aZf" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
-"aZh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/storage)
-"aZi" = (
-/obj/structure/table,
-/obj/item/sensor_device,
-/obj/item/storage/box/rxglasses,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aZj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aZn" = (
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Lobby NE";
-	name = "Medbay Lobby Camera";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"aZo" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/storage/box/syringes,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/assembly/signaler,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "aZp" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -13305,6 +13295,76 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aZQ" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Reception";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"aZS" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"aZU" = (
+/obj/machinery/door/morgue{
+	name = "Confession Booth (Chaplain)";
+	req_access_txt = "22"
+	},
+/turf/open/floor/carpet/green,
+/area/service/chapel/main)
+"aZV" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"aZW" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/medical/medbay/lobby)
+"aZX" = (
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Lobby NE";
+	name = "Medbay Lobby Camera";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"aZY" = (
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/storage/box/syringes,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/assembly/signaler,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
+"bab" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"bac" = (
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
 /obj/item/grenade/chem_grenade,
@@ -13321,31 +13381,35 @@
 /obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"aZS" = (
+"bae" = (
 /obj/effect/landmark/start/depsec/medical,
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
-"aZU" = (
-/obj/machinery/door/morgue{
-	name = "Confession Booth (Chaplain)";
-	req_access_txt = "22"
-	},
-/turf/open/floor/carpet/green,
-/area/service/chapel/main)
-"aZV" = (
+"baf" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
-"aZW" = (
+"bag" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"aZX" = (
+"bah" = (
+/obj/structure/closet/wardrobe/white,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"bai" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science)
+"baj" = (
 /obj/structure/cable,
 /obj/machinery/button/door/directional/east{
 	desc = "A door remote control switch for the medbay foyer.";
@@ -13357,7 +13421,7 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"aZY" = (
+"bal" = (
 /obj/structure/table/glass,
 /obj/item/assembly/timer,
 /obj/item/assembly/timer,
@@ -13373,74 +13437,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"bab" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"bac" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = -30
-	},
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"bae" = (
-/obj/machinery/computer/crew{
-	dir = 8
-	},
-/obj/machinery/requests_console/directional/west{
-	department = "Security";
-	departmentType = 5;
-	name = "Medical Security Post";
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"baf" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/item/reagent_containers/food/drinks/britcup,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
-"bag" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/effect/landmark/start/chemist,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"bah" = (
-/obj/structure/closet/wardrobe/white,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bai" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science)
-"baj" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 15
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"bal" = (
-/obj/structure/rack,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
 "bao" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin{
@@ -13464,11 +13460,12 @@
 /turf/open/floor/iron/dark,
 /area/medical/storage)
 "bap" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
+/obj/structure/sign/nanotrasen{
+	pixel_x = -30
+	},
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "baq" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
@@ -13492,14 +13489,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "baZ" = (
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/computer/crew{
+	dir = 8
 	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -30
+/obj/machinery/requests_console/directional/west{
+	department = "Security";
+	departmentType = 5;
+	name = "Medical Security Post";
+	pixel_x = 0;
+	pixel_y = -30
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "bba" = (
 /obj/structure/fluff/broken_flooring,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -13513,26 +13514,18 @@
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "bbc" = (
-/obj/structure/chair,
-/obj/structure/sign/departments/psychology{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table,
+/obj/structure/cable,
+/obj/item/reagent_containers/food/drinks/britcup,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "bbd" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Pharmacy Maintenance";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
+/obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
-/area/maintenance/department/medical)
+/area/medical/pharmacy)
 "bbf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -13554,31 +13547,33 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bbh" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
-"bbi" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
-"bbj" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/camera{
-	c_tag = "Pharmacy";
-	dir = 8;
-	name = "Pharmacy Camera";
-	network = list("ss13","medbay")
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 15
 	},
+/obj/machinery/firealarm/directional/east,
+/obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"bbk" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/storage/box/ids,
-/obj/machinery/firealarm/directional/north,
+"bbi" = (
+/obj/structure/rack,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron,
-/area/security/checkpoint/customs)
+/area/maintenance/starboard/fore)
+"bbj" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
+"bbk" = (
+/obj/structure/chair,
+/obj/structure/sign/departments/psychology{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bbl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -13586,17 +13581,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bbm" = (
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
-"bbn" = (
-/obj/machinery/light/blacklight/directional/east,
-/obj/machinery/firealarm/directional/east,
-/obj/structure/bodycontainer/morgue{
+/obj/machinery/door/airlock/maintenance{
+	name = "Pharmacy Maintenance";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
+/turf/open/floor/iron/white,
+/area/maintenance/department/medical)
+"bbn" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
 "bbo" = (
 /obj/structure/sign/directions/command{
 	dir = 4;
@@ -13606,11 +13607,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bbq" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "medcell";
-	name = "Medical Cell Locker"
-	},
-/turf/open/floor/iron/white,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "bbr" = (
 /obj/machinery/light_switch/directional/south,
@@ -13626,23 +13625,22 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bbu" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"bbw" = (
-/obj/structure/table/glass,
-/obj/item/hand_labeler,
-/obj/machinery/light/directional/east,
-/obj/machinery/button/door/directional/east{
-	id = "chemlock";
-	name = "Pharmacy Shutters";
-	req_one_access_txt = "5;69"
+/obj/machinery/disposal/bin,
+/obj/machinery/camera{
+	c_tag = "Pharmacy";
+	dir = 8;
+	name = "Pharmacy Camera";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"bbw" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/storage/box/ids,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs)
 "bbD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -13729,19 +13727,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bco" = (
-/obj/structure/chair{
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
+"bcp" = (
+/obj/machinery/light/blacklight/directional/east,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"bcp" = (
-/obj/item/kirbyplants/random,
-/obj/structure/sign/departments/chemistry/pharmacy{
-	pixel_x = 30
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "bcr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13749,41 +13745,44 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bcs" = (
-/obj/structure/chair/office/light{
+/obj/structure/closet/secure_closet/brig{
+	id = "medcell";
+	name = "Medical Cell Locker"
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"bcu" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"bcu" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
 /obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"bcv" = (
 /obj/structure/table/glass,
-/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
+/obj/machinery/light/directional/east,
+/obj/machinery/button/door/directional/east{
+	id = "chemlock";
+	name = "Pharmacy Shutters";
+	req_one_access_txt = "5;69"
+	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"bcv" = (
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/starboard";
-	name = "Starboard Primary Hallway APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bcy" = (
-/obj/machinery/computer/crew{
-	dir = 4
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs)
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "bcE" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs)
+/obj/item/kirbyplants/random,
+/obj/structure/sign/departments/chemistry/pharmacy{
+	pixel_x = 30
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bcF" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
@@ -13862,21 +13861,18 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bdj" = (
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
-"bdo" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"bdo" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "bdp" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
@@ -13886,6 +13882,51 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bdv" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
+	},
+/obj/machinery/newscaster/directional/east,
+/obj/structure/table/glass,
+/obj/item/stack/package_wrap,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
+"bdy" = (
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/starboard";
+	name = "Starboard Primary Hallway APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"bdz" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs)
+"bdA" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs)
+"bdB" = (
+/obj/machinery/door/airlock{
+	name = "Cleaning Closet"
+	},
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
+"bdC" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bdF" = (
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_one_access_txt = "6;5;28"
@@ -13903,12 +13944,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"bdy" = (
+"bdG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
-"bdz" = (
+"bdH" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	id = "medcell";
@@ -13920,7 +13961,7 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/hallway/primary/starboard)
-"bdA" = (
+"bdI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/navbeacon/wayfinding,
 /obj/effect/turf_decal/tile/blue{
@@ -13934,52 +13975,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"bdB" = (
-/turf/closed/wall,
-/area/medical/pharmacy)
-"bdC" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bdF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"bdG" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"bdH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"bdI" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/structure/sign/departments/medbay/alt{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "bdJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -13998,12 +13993,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bdN" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/turf/closed/wall,
+/area/medical/pharmacy)
 "bdO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -14202,11 +14193,15 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "beI" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "beJ" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
@@ -14250,14 +14245,9 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "beU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "beW" = (
@@ -14265,6 +14255,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
+"beX" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bfb" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -14543,6 +14538,52 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"bgr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"bgt" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/structure/sign/departments/medbay/alt{
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"bgu" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"bgv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"bgw" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bgx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/bronze_cup{
@@ -78644,10 +78685,10 @@ aSx
 aVD
 aWA
 aOn
-aYK
 aZO
-aYK
-aYK
+aZO
+aZO
+aZO
 bdf
 bev
 bga
@@ -78901,9 +78942,9 @@ aTw
 aQu
 aWB
 aOn
-aYN
-aYO
-baZ
+aZO
+aZO
+aZO
 aYK
 bdf
 bev
@@ -79158,9 +79199,9 @@ aKB
 aQu
 aWB
 aOn
-aYO
-aYO
-aYN
+aZO
+aZO
+aZO
 aYK
 bdd
 bev
@@ -79415,9 +79456,9 @@ aQu
 aQu
 aWC
 aOn
-aYO
-aYO
-aYO
+aZO
+aZO
+aZO
 aYK
 bdf
 bev
@@ -79665,16 +79706,16 @@ rYR
 aOn
 aPh
 aQu
-aMu
+aMv
 aTv
 aTv
 aOQ
 aQu
 aWD
 aOn
-aYO
-aYN
-aYO
+aZO
+aZO
+aZO
 aYK
 bdf
 bev
@@ -79923,14 +79964,14 @@ aOn
 aPi
 dGr
 aOn
-aNg
-aNg
+aNK
+aNK
 aOn
 aTx
 aWE
 aOn
 aYK
-aYK
+aZO
 aYK
 aYK
 bdf
@@ -80184,11 +80225,11 @@ aOn
 aOn
 aOn
 aQu
-aPG
+aPE
 aOn
-aak
-aak
-aak
+aTJ
+aTK
+aXa
 aYK
 bdf
 aZO
@@ -80441,11 +80482,11 @@ aak
 aak
 aOn
 aQu
-aRc
+aPG
 aOn
-aak
-aaa
-aak
+aTK
+aTK
+aTJ
 aYK
 crn
 cvQ
@@ -80700,9 +80741,9 @@ aOn
 aOn
 aOn
 aOn
-aak
-aaa
-aak
+aTK
+aTK
+aTK
 aYK
 bdg
 cwu
@@ -80956,10 +80997,10 @@ aak
 aak
 aak
 aak
-aak
-aak
-aak
-aak
+aYK
+aTK
+aTJ
+aTK
 aYK
 bdh
 bdf
@@ -81214,9 +81255,9 @@ aIG
 aIG
 aIG
 aIG
-aIG
-aIG
-aIG
+aTL
+aTL
+aTL
 aYK
 aZO
 aUH
@@ -81461,19 +81502,19 @@ aNA
 aak
 aak
 aIf
+aIU
 aPj
 aPj
-aPj
-aMv
-aNK
+aMw
+aIU
 aOk
 aOR
-aPu
+aMw
+aRc
+aSQ
 aPj
-aMv
-aNK
-aTS
-aVO
+aPj
+aXh
 aYK
 aZO
 aUH
@@ -81720,20 +81761,20 @@ aak
 aIf
 aPj
 aPj
-aKA
+aKE
 aPj
 aPj
 aPj
 aPj
 aPj
-aIU
+aJj
 aPj
 aPj
-aTT
+aUW
 aQD
-aXh
+aXF
 bey
-aXn
+aXL
 bgh
 bhm
 biH
@@ -81975,19 +82016,19 @@ aNA
 aak
 aak
 aIf
-aIU
-aJA
-aKE
-aMw
-aMw
-aMw
-aMw
-aMw
+aJj
+aJB
+aLn
+aMy
+aMy
+aMy
+aMy
+aMy
 aRd
-aSJ
+aTz
 aPj
-aUz
-aVX
+aUY
+aXl
 aYK
 aYK
 bsv
@@ -82233,19 +82274,19 @@ azU
 aak
 aIf
 aPj
-aJA
-aLn
-aMy
-aMy
-aMy
-aMy
-aMy
+aJB
+aLM
+aMz
+aMz
+aMz
+aMz
+aMz
 aRh
-aSJ
-aTC
-aUK
-aWw
-aSE
+aTz
+aTM
+aVo
+aXn
+aXJ
 aSP
 bdf
 aZO
@@ -82490,20 +82531,20 @@ aNA
 aak
 aIf
 aPj
-aJB
-aLn
-aMz
+aJC
+aLM
+aMG
 aNL
 aOt
 aOU
-aMy
+aMz
 aRh
-aSJ
-aTD
-aUL
-aWw
+aTz
+aTS
+aVq
+aXn
 aSE
-aZO
+bdj
 aUH
 aZO
 aZO
@@ -82514,7 +82555,7 @@ bmX
 jVy
 bpM
 jVy
-bdj
+bdB
 btm
 btm
 crm
@@ -82747,27 +82788,27 @@ aNA
 aak
 aIf
 aPj
-aJC
-aLn
-aMG
-aMy
+aJI
+aLM
+aMO
+aMz
 aOu
-aMy
-aMy
+aMz
+aMz
 aRh
-aSJ
-aTD
-aUM
+aTz
+aTS
+aVz
 aPj
 aSE
-aZO
+bdj
 aUH
 aZO
 bhJ
 biI
 biI
 aYK
-bal
+bbi
 jVy
 jVy
 jVy
@@ -83004,29 +83045,29 @@ aNA
 aak
 aIf
 aPj
-aJA
-aLn
-aMO
+aJB
+aLM
+aMP
 aNP
-aMy
-aMy
-aPE
+aMz
+aMz
+aPu
 aRh
-aSJ
-aTI
-aUN
+aTz
+aTT
+aVK
 aPj
 aSE
-aZO
+bdj
 cwL
 aZO
 aZO
 aZO
 aZO
 aYK
-bap
-bbh
-bbm
+bbj
+bbn
+bco
 jVy
 aYK
 buQ
@@ -83261,20 +83302,20 @@ aNA
 aIf
 aIf
 aPj
-aJA
-aLn
-aMP
-aMy
-aMy
-aMy
-aMy
+aJB
+aLM
+aMQ
+aMz
+aMz
+aMz
+aMz
 aRh
-aSJ
-aTJ
-aUW
+aTz
+aUz
+aVN
 aRG
 aSE
-aZO
+bdj
 beF
 aZO
 aZO
@@ -83517,21 +83558,21 @@ aLj
 azU
 aPj
 aIG
+aJy
 aJj
-aIU
-aLM
-aMQ
+aLO
+aMR
 aQK
 aQK
 aQK
 aQK
 aRF
-aSJ
-aTD
-aUY
-aWN
+aTz
+aTS
+aVO
+aXw
 aSE
-aZO
+bdj
 beE
 bWI
 bWI
@@ -83542,9 +83583,9 @@ bWI
 bWI
 bWI
 bWI
-bdo
-bdF
-bdF
+bdC
+beU
+beU
 pZN
 btm
 btm
@@ -83775,18 +83816,18 @@ aHM
 aML
 aIS
 aML
-aJI
-aLO
-aMR
+aKg
+aMf
+aMS
 aQD
 aOv
 aQD
 aQD
 aQD
 aQD
-aTK
-aVo
-aWP
+aUK
+aVX
+aXC
 aSE
 bdh
 aUQ
@@ -84031,19 +84072,19 @@ aLj
 azU
 aIE
 aIG
-aJy
-aKg
-aMf
-aMS
-aKg
+aJz
+aKs
+aMg
+aMU
+aKs
 aOw
-aKg
-aMf
+aKs
+aMg
 aQE
 aQE
 aPj
-aKA
-aWR
+aKE
+aXD
 aSE
 aZO
 aUQ
@@ -84304,7 +84345,7 @@ crU
 aYK
 aZO
 beE
-aXJ
+aYO
 bhu
 cKy
 bko
@@ -84554,8 +84595,8 @@ aak
 aak
 aEd
 aQF
-fCC
-aRE
+aTB
+aUL
 aRE
 fCC
 aSI
@@ -84571,7 +84612,7 @@ cLv
 bpU
 cLv
 bgi
-bdG
+beX
 btm
 jmW
 btm
@@ -84819,7 +84860,7 @@ aYK
 aZO
 aZO
 bgi
-aXN
+aYZ
 cLv
 cLv
 blM
@@ -85075,7 +85116,7 @@ bdK
 bdK
 bgi
 bgi
-aXK
+aYV
 aXH
 cLv
 cLv
@@ -85084,7 +85125,7 @@ bmY
 cLv
 cLv
 cLv
-bdv
+bdF
 btm
 btm
 jmW
@@ -85590,13 +85631,13 @@ beO
 bdp
 cLv
 bgl
-aYb
+aZa
 cWw
 bro
 bro
 bro
 bro
-bbn
+bcp
 bro
 bgi
 bts
@@ -86102,17 +86143,17 @@ beO
 beO
 beO
 cAQ
-aXw
+aXN
 aVP
 bhA
-aZb
+aZS
 bks
-bac
+bap
 bow
 cAQ
-bbq
+bcs
 bhB
-bdy
+bdG
 btm
 btm
 jmW
@@ -86359,20 +86400,20 @@ beO
 beO
 beO
 cFF
-aXC
+aYb
 cyf
-aYi
-cyf
-bno
+aZb
 cyf
 bno
-bbi
+cyf
+bno
+bbq
 cyf
 brz
-bdz
 bdH
-bdH
-beI
+bgr
+bgr
+bgv
 btm
 btm
 bxt
@@ -86605,7 +86646,7 @@ aEd
 bdK
 beO
 aRK
-beO
+aSH
 beO
 beO
 beO
@@ -86616,20 +86657,20 @@ beO
 beO
 beO
 cFF
-aXD
+aYi
 bno
 bfj
-aZc
+aZV
 bfj
 bfj
 bfj
 beK
 bfj
 bkQ
-bbi
+bbq
 btu
 btu
-beU
+bgw
 btu
 btu
 bxt
@@ -86877,12 +86918,12 @@ bfb
 cyf
 cyf
 blL
-aZS
+bae
 bno
 cyf
-bbi
-bbu
-bco
+bbq
+bcu
+bcy
 cAQ
 btn
 btm
@@ -87132,10 +87173,10 @@ beO
 cFF
 cyf
 cyf
-aYj
+aZc
 cNm
-aZV
-bae
+baf
+baZ
 cAQ
 cAQ
 cAQ
@@ -87374,7 +87415,7 @@ aHx
 aNM
 aOx
 aPt
-aMg
+aMl
 beO
 beO
 beO
@@ -87387,7 +87428,7 @@ beO
 beO
 beO
 cAQ
-aXE
+aYj
 cFF
 cFF
 cFF
@@ -87646,11 +87687,11 @@ beO
 beO
 beO
 beO
-aYV
+aZf
 biP
 bck
 blR
-bbc
+bbk
 bky
 bky
 blQ
@@ -87903,7 +87944,7 @@ beO
 beO
 beO
 beO
-aYY
+aZn
 bky
 bky
 bky
@@ -88160,7 +88201,7 @@ beO
 beO
 beO
 beO
-aYZ
+aZo
 bky
 bky
 bky
@@ -88417,7 +88458,7 @@ beO
 beO
 beO
 beO
-aYY
+aZn
 bky
 bky
 bky
@@ -88425,7 +88466,7 @@ bky
 bky
 bky
 bky
-bdA
+bdI
 cpH
 btm
 crm
@@ -88675,7 +88716,7 @@ beO
 beO
 beO
 bhD
-aZf
+aZW
 bkv
 bky
 bky
@@ -89188,9 +89229,9 @@ beO
 beO
 beO
 beO
-aZa
+aZQ
 bky
-aZW
+bag
 bkv
 cXI
 bky
@@ -89429,7 +89470,7 @@ aHx
 aHx
 bla
 bdK
-aKs
+aKz
 aQT
 bta
 bta
@@ -89447,8 +89488,8 @@ beO
 beO
 bhD
 biW
-aZX
-baf
+baj
+bbc
 bky
 bky
 bky
@@ -89703,7 +89744,7 @@ beO
 beO
 beO
 bhD
-aZn
+aZX
 bkv
 bkv
 mrE
@@ -89968,7 +90009,7 @@ bky
 bky
 bry
 bhD
-bdI
+bgt
 btm
 adf
 btm
@@ -90201,7 +90242,7 @@ aHx
 aNV
 aRE
 aMV
-aMl
+aMm
 bta
 bta
 bte
@@ -90458,7 +90499,7 @@ aIR
 bwJ
 aHx
 bdK
-aMm
+aMu
 beO
 beO
 beO
@@ -90480,7 +90521,7 @@ bky
 bky
 bky
 bky
-bcp
+bcE
 bhD
 btn
 cJH
@@ -90724,9 +90765,9 @@ bZT
 bZT
 bZT
 bZT
-aVq
+aWw
 beO
-aXl
+aXK
 beO
 beO
 beO
@@ -90738,7 +90779,7 @@ bhL
 blW
 bkC
 bhK
-bdB
+bdN
 btm
 btm
 adf
@@ -90981,18 +91022,18 @@ bte
 aZh
 aZh
 aZh
-aVz
-aXa
+aWN
+aXE
 bte
 beO
 beO
 beO
 bhL
-aZo
+aZY
 bkD
-bag
+bbd
 bnq
-bag
+bbd
 bkD
 brB
 bhK
@@ -91227,10 +91268,10 @@ aNG
 aHx
 bSp
 cEt
-aJz
-aKz
+aJA
+aKA
 aPI
-aMU
+aNb
 aSS
 aTX
 aVb
@@ -91238,7 +91279,7 @@ bte
 aWX
 aXO
 aZi
-aVK
+aWP
 bbr
 bte
 beO
@@ -91251,7 +91292,7 @@ blX
 bnq
 blX
 bkE
-bcs
+bdo
 bhK
 btm
 btm
@@ -91487,13 +91528,13 @@ aEd
 csU
 aHx
 aVa
-aNb
+aNc
 aST
 aTW
 aVc
 bte
 aWY
-aSQ
+aTC
 aZj
 ape
 bbs
@@ -91744,15 +91785,15 @@ aEd
 csU
 aHx
 aVa
-aNc
+aNg
 aSU
 aOB
 aPn
 bte
 aWZ
-aTz
-aTL
-aVN
+aTD
+aUM
+aWR
 bbt
 bte
 beO
@@ -92001,14 +92042,14 @@ aEd
 csU
 aHx
 aVa
-aNb
+aNc
 aTb
 aUk
 aPn
 bte
-aSH
-aTB
-aTM
+aSJ
+aTI
+aUN
 bao
 bbH
 bte
@@ -92016,13 +92057,13 @@ cBw
 cBw
 cBw
 bhK
-aZQ
-aZY
-baj
+bac
+bal
+bbh
 blX
-bbj
-bbw
-bcu
+bbu
+bcv
+bdv
 bhK
 bty
 btm
@@ -92276,7 +92317,7 @@ bhK
 bhK
 bhK
 bhK
-bbd
+bbm
 bhK
 bhK
 bhK
@@ -92537,9 +92578,9 @@ kYQ
 bcJ
 bcJ
 bcJ
-bdC
-bdN
-bdF
+beI
+bgu
+beU
 pZN
 btm
 btm
@@ -92784,7 +92825,7 @@ bbl
 fCC
 fCC
 fCC
-aXF
+aYN
 aEd
 aHx
 aHx
@@ -92793,7 +92834,7 @@ aHx
 aHx
 aHx
 aHx
-bcv
+bdy
 aEd
 btA
 btm
@@ -93307,7 +93348,7 @@ bme
 bje
 boL
 bpY
-bcy
+bdz
 bje
 btB
 btm
@@ -93556,7 +93597,7 @@ aak
 aEd
 aHx
 bgE
-aXL
+aYY
 fCC
 bjv
 kYQ
@@ -93821,7 +93862,7 @@ bmy
 bje
 boN
 bqa
-bcE
+bdA
 bsj
 btB
 btm
@@ -94076,7 +94117,7 @@ bje
 bje
 bmh
 bje
-bbk
+bbw
 bqb
 brK
 bsk

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -3399,6 +3399,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "apg" = (
@@ -13215,6 +13216,7 @@
 /area/medical/storage)
 "aZj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "aZn" = (
@@ -39441,6 +39443,17 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/central)
+"dIi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -39801,6 +39814,13 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"fha" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fhP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -39981,6 +40001,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"fBh" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "fCp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41159,6 +41183,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
+"jKh" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "jKi" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -41239,6 +41267,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/space)
+"jSL" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "jUc" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -41660,6 +41692,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"lyT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "lAI" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41810,6 +41853,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
+"meB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mhQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -43800,6 +43854,11 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/space)
+"tDX" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tDZ" = (
 /obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron/dark,
@@ -85993,7 +86052,7 @@ bgi
 bgi
 aYV
 aXH
-cLv
+jSL
 cLv
 blN
 bmY
@@ -87786,7 +87845,7 @@ omY
 gEA
 uOh
 lOx
-aQT
+meB
 beO
 cFF
 bfb
@@ -88043,7 +88102,7 @@ omY
 uZi
 uOh
 lOx
-aQT
+dIi
 beO
 cFF
 uNo
@@ -89075,7 +89134,7 @@ pZH
 iyE
 iyE
 iKA
-oUF
+fha
 aZo
 xoz
 xoz
@@ -89578,7 +89637,7 @@ aPv
 aQN
 bta
 bta
-bta
+fBh
 bta
 gjU
 aSD
@@ -89593,7 +89652,7 @@ beO
 bhD
 aZW
 uYP
-bky
+jKh
 bky
 iMA
 bky
@@ -90099,7 +90158,7 @@ aSo
 tYg
 ptC
 eKn
-xZB
+tDX
 ptC
 dqs
 aQT
@@ -90355,7 +90414,7 @@ bta
 aSo
 pAu
 xZB
-rzp
+lyT
 xZB
 xZB
 nGc
@@ -90368,7 +90427,7 @@ bbc
 bky
 keH
 bky
-bky
+jKh
 bhF
 cpH
 btm
@@ -91135,7 +91194,7 @@ beO
 bhW
 bjd
 bky
-bky
+jKh
 bky
 bky
 bky
@@ -91901,7 +91960,7 @@ aWN
 aXE
 bte
 beO
-aQT
+dIi
 beO
 bhL
 aZY

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -25618,12 +25618,11 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "bYB" = (
-/obj/structure/cable,
-/obj/structure/rack,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/obj/structure/closet/crate{
+	name = "Excess Manuals"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bYC" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -25633,9 +25632,7 @@
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "bYM" = (
-/obj/structure/closet/crate{
-	name = "Excess Manuals"
-	},
+/obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bYN" = (
@@ -25660,9 +25657,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bYU" = (
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/command,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "bYV" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Central";
@@ -25989,14 +25987,18 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "caP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/command,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"caQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"caQ" = (
+/obj/structure/rack,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "caU" = (
@@ -26543,11 +26545,9 @@
 /area/tcommsat/computer)
 "cdV" = (
 /obj/structure/rack,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cdX" = (
@@ -26913,6 +26913,9 @@
 /area/maintenance/department/cargo)
 "cfJ" = (
 /obj/structure/cable,
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cfO" = (
@@ -27035,18 +27038,23 @@
 /area/command/heads_quarters/ce)
 "cgy" = (
 /obj/structure/rack,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cgz" = (
-/obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cgA" = (
+"cgz" = (
 /obj/machinery/vending/assist,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"cgA" = (
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/titanium/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/camera{
+	c_tag = "Secure Tech Storage";
+	dir = 1;
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cgB" = (
@@ -27107,7 +27115,6 @@
 	network = list("ss13","engineering")
 	},
 /obj/item/radio/intercom/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cgP" = (
@@ -27331,14 +27338,10 @@
 /area/hallway/primary/fore)
 "chN" = (
 /obj/structure/table,
-/obj/item/stack/sheet/mineral/titanium/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/machinery/camera{
-	c_tag = "Secure Tech Storage";
-	dir = 1;
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
+/obj/item/stack/sheet/rglass{
+	amount = 25
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "chO" = (
@@ -27671,11 +27674,11 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cjz" = (
-/obj/structure/table,
-/obj/item/stack/sheet/rglass{
-	amount = 25
-	},
-/obj/machinery/light/directional/east,
+/obj/structure/rack,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cjA" = (
@@ -27762,10 +27765,9 @@
 /area/tcommsat/computer)
 "cjM" = (
 /obj/structure/rack,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cjN" = (
@@ -27917,10 +27919,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ckp" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
+/obj/structure/table,
+/obj/item/stack/sticky_tape,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "ckq" = (
@@ -28405,7 +28407,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "clN" = (
-/obj/structure/cable,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -30119,12 +30120,12 @@
 /turf/closed/wall,
 /area/science/mixing)
 "csu" = (
-/obj/structure/table,
-/obj/item/stack/sticky_tape,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "csv" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
@@ -30503,17 +30504,19 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "ctB" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"ctC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"ctC" = (
+/obj/structure/rack,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "ctD" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -30641,11 +30644,12 @@
 /area/security/checkpoint/engineering)
 "cuf" = (
 /obj/structure/rack,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/machinery/light/directional/west,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cug" = (
@@ -30787,12 +30791,7 @@
 /area/cargo/storage)
 "cuH" = (
 /obj/structure/rack,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
+/obj/effect/spawner/lootdrop/techstorage/tcomms,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cuI" = (
@@ -30832,18 +30831,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cuS" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/tcomms,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cuU" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
 /obj/item/plant_analyzer,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cuV" = (
+"cuU" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 1
@@ -30854,14 +30848,33 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"cuW" = (
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
-"cuX" = (
+"cuV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
+"cuW" = (
+/turf/open/floor/iron,
+/area/engineering/engine_smes)
+"cuX" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -30896,24 +30909,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cvg" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/navbeacon/wayfinding,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "cvh" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -31067,15 +31070,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cvH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"cvJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
@@ -31084,6 +31078,18 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"cvJ" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Engineering";
+	name = "Delivery Beacon - Engineering"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cvK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -31653,16 +31659,14 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cxC" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Engineering";
-	name = "Delivery Beacon - Engineering"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/rack,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cxI" = (
 /obj/item/wrench,
 /turf/open/floor/iron,
@@ -37079,12 +37083,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cSm" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cSn" = (
@@ -38387,9 +38387,8 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cWa" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron/dark,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron,
 /area/engineering/storage/tech)
 "cWb" = (
 /obj/machinery/door/airlock/external{
@@ -39428,9 +39427,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "etz" = (
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "eud" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
@@ -39758,7 +39757,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fCp" = (
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "fCC" = (
@@ -39776,11 +39777,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "fEF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "fET" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40101,7 +40100,8 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gxs" = (
-/obj/structure/cable/multilayer/multiz,
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "gzW" = (
@@ -40160,10 +40160,9 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "gTq" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
+/obj/structure/stairs/north,
 /turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/area/engineering/lobby)
 "gXc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -40258,7 +40257,17 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "hjq" = (
-/obj/structure/stairs/north,
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Engineering Delivery";
+	req_one_access_txt = "10;24"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "hkj" = (
@@ -40478,18 +40487,21 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "icD" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 3
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access_txt = "23"
 	},
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Engineering Delivery";
-	req_one_access_txt = "10;24"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage/tech)
 "idi" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -40529,21 +40541,17 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ijl" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access_txt = "23"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
 	},
 /turf/open/floor/iron,
-/area/engineering/storage/tech)
+/area/engineering/lobby)
 "inh" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/dark,
@@ -40720,8 +40728,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -40773,13 +40782,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "jbv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -42824,8 +42828,12 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
 "qji" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -43653,15 +43661,16 @@
 /turf/open/floor/iron,
 /area/space)
 "ttD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ttL" = (
@@ -44047,14 +44056,15 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
 "uMD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -44452,18 +44462,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vZX" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 6
 	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/aft)
 "wbs" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -44827,7 +44830,7 @@
 /area/security/checkpoint/medical)
 "xur" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/aft)
@@ -44841,12 +44844,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xyD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/aft)
 "xyS" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -60621,7 +60618,7 @@ ctp
 cuE
 xhv
 cxm
-xur
+vZX
 cIl
 oop
 cAW
@@ -60878,7 +60875,7 @@ ctp
 xKA
 cwx
 cxY
-xyD
+xur
 cIm
 cAW
 cAW
@@ -61135,7 +61132,7 @@ ctp
 cvh
 xhv
 cya
-xyD
+xur
 cIm
 cAW
 cXq
@@ -69091,7 +69088,7 @@ cbY
 cbY
 cbY
 cbY
-iSy
+ijl
 cmU
 caU
 coW
@@ -69343,7 +69340,7 @@ bJj
 cfg
 cfg
 cdB
-bYB
+cfJ
 cgx
 chH
 cju
@@ -70371,12 +70368,12 @@ bJn
 cbd
 cfg
 cfg
-cfJ
+cfg
 cgO
 chU
 cbY
-gxs
-jbv
+fEF
+iSy
 cmU
 cnZ
 coW
@@ -70626,14 +70623,14 @@ bHm
 cbY
 cbY
 cbY
-bPA
-bPA
-bPA
 cbY
 cbY
 cbY
-gTq
-qji
+cbY
+cbY
+cbY
+gxs
+jbv
 cmY
 cnX
 hcM
@@ -70889,8 +70886,8 @@ bHn
 bHm
 eFy
 bXs
-hjq
-ttD
+gTq
+qji
 cmU
 nlF
 coW
@@ -71142,11 +71139,11 @@ bNm
 bNm
 bNm
 cjA
-bYM
+bYB
 bHm
 cjt
 bXs
-hjq
+gTq
 clN
 cmU
 lJc
@@ -71399,12 +71396,12 @@ bHm
 bHm
 bHm
 bNm
-bYU
+bYM
 bHm
-bHm
-cxC
-icD
-uMD
+bNm
+cvJ
+hjq
+ttD
 cmW
 caU
 coW
@@ -72427,8 +72424,8 @@ chX
 bMq
 bMq
 bTz
-caP
-caP
+bYU
+bYU
 chX
 aak
 bXs
@@ -72941,8 +72938,8 @@ chX
 bMr
 bRv
 bVD
-caQ
-chN
+caP
+cgA
 chX
 aak
 bXs
@@ -73199,7 +73196,7 @@ bMs
 ccf
 bWo
 ccf
-cjz
+chN
 bXv
 aak
 bXs
@@ -73712,10 +73709,10 @@ bZZ
 bMt
 bRx
 cdL
-cdV
-cjM
-cuf
-cSm
+caQ
+cjz
+ctC
+cxC
 bXs
 qTJ
 cmU
@@ -73972,7 +73969,7 @@ cdK
 nBG
 lpq
 lpq
-cWa
+cSm
 bXs
 clB
 cmV
@@ -74226,9 +74223,9 @@ bKv
 cch
 bSH
 cdL
-cgy
-ckp
-cuH
+cdV
+cjM
+cuf
 cjD
 bXs
 clU
@@ -74740,11 +74737,11 @@ bKw
 caZ
 bTl
 lpq
-cgz
+cgy
 cgH
-cuS
+cuH
 lpq
-ijl
+icD
 qTJ
 cmU
 caU
@@ -74997,10 +74994,10 @@ bKw
 caZ
 bTl
 cdO
-cgA
 cgz
+cgy
 cgH
-etz
+cWa
 bXs
 qTJ
 cmU
@@ -75512,8 +75509,8 @@ bMu
 ccl
 lpq
 cfr
-csu
-cuU
+ckp
+cuS
 cjF
 bXs
 clH
@@ -76026,9 +76023,9 @@ uys
 uys
 uys
 mOS
-ctB
-cuV
-fCp
+csu
+cuU
+etz
 cky
 cmU
 coc
@@ -76285,7 +76282,7 @@ bXK
 mOS
 cgK
 uys
-fEF
+fCp
 cjG
 bXs
 coH
@@ -76540,8 +76537,8 @@ bNY
 bTw
 cdT
 cfv
-ctC
-cuX
+ctB
+cuV
 cjJ
 cjG
 clX
@@ -77059,7 +77056,7 @@ chY
 bfr
 cjG
 vpX
-vZX
+uMD
 vpX
 bXs
 ejT
@@ -77312,7 +77309,7 @@ cjG
 cjG
 cjG
 cjG
-cvg
+cuX
 cjG
 cjG
 bXs
@@ -77569,7 +77566,7 @@ rOd
 rOd
 rOd
 bJe
-cvH
+cvg
 lUI
 ckA
 cma
@@ -77826,11 +77823,11 @@ bJe
 bJe
 bJe
 cgM
-cvH
+cvg
 bXy
 bJe
 bJe
-cvH
+cvg
 bJe
 bJe
 bJe
@@ -78083,11 +78080,11 @@ cph
 cph
 cph
 chT
-cvJ
+cvH
 jpH
 qwu
 qwu
-cvJ
+cvH
 qwu
 cph
 cph

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -1313,17 +1313,13 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "ahl" = (
-/obj/item/weldingtool,
+/obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ahn" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
@@ -1427,8 +1423,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "ahU" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/iron,
+/obj/structure/fluff/broken_flooring{
+	dir = 4
+	},
+/obj/item/stack/medical/suture,
+/turf/open/floor/plating,
 /area/medical/abandoned)
 "ahX" = (
 /obj/structure/table,
@@ -2438,10 +2437,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "alT" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "alU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -2458,10 +2456,9 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "alW" = (
-/obj/structure/chair,
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/obj/item/stack/sheet/iron/fifty,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "alX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -3396,8 +3393,14 @@
 /area/hallway/primary/fore)
 "ape" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/storage)
 "apg" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -3715,11 +3718,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/command/storage/eva)
-"aqe" = (
-/turf/closed/wall{
-	layer = 3
-	},
-/area/medical/treatment_center)
 "aqf" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -3962,10 +3960,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "aqU" = (
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/obj/item/weldingtool,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aqV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -5857,7 +5854,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ayj" = (
-/turf/open/floor/iron,
+/obj/structure/fluff/broken_flooring,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/medical/abandoned)
 "ayk" = (
 /obj/structure/cable,
@@ -7628,9 +7627,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "aCK" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aCM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -7726,9 +7729,10 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aDd" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/item/bodybag,
+/obj/structure/closet/crate/medical,
+/turf/open/floor/iron,
+/area/medical/abandoned)
 "aDe" = (
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/dark,
@@ -7747,9 +7751,9 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "aDh" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/iron,
+/area/medical/abandoned)
 "aDi" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/bedsheet/cosmos,
@@ -7909,10 +7913,10 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "aDH" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/item/stack/medical/bruise_pack,
+/turf/open/floor/iron,
+/area/medical/abandoned)
 "aDI" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/reagent_containers/food/drinks/bottle/cognac{
@@ -8281,45 +8285,42 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "aEU" = (
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aEV" = (
-/obj/structure/table_frame,
-/obj/item/shard,
-/turf/open/floor/iron,
-/area/medical/abandoned)
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aEW" = (
-/obj/structure/table/glass,
-/obj/item/wirecutters,
-/obj/item/crowbar/red{
-	desc = "A small crowbar. This handy tool is useful for lots of things, such as romerol tumors or alien babies. ";
-	name = "medical crowbar"
+/obj/structure/fluff/broken_flooring{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/item/bodybag,
+/turf/open/floor/plating,
 /area/medical/abandoned)
 "aEX" = (
-/obj/structure/table_frame,
-/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/bed/roller,
+/obj/item/wrench/medical,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aEY" = (
-/obj/structure/table/glass,
-/obj/item/pen,
-/obj/item/hatchet,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron,
-/area/medical/abandoned)
-"aEZ" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/bottle/absinthe{
-	desc = "Good disinfectant. Also good for getting drunk very fast.";
-	name = "medical-grade absinthe"
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -30
 	},
-/obj/item/lighter,
-/turf/open/floor/iron,
-/area/medical/abandoned)
+/obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"aEZ" = (
+/obj/item/organ/tail/lizard,
+/obj/item/picket_sign,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "aFa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -8386,7 +8387,11 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aFp" = (
-/obj/machinery/vending/medical,
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aFr" = (
@@ -8596,49 +8601,51 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"aFR" = (
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "aFS" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "aFT" = (
-/obj/item/bodypart/l_leg/monkey,
-/obj/vehicle/ridden/wheelchair,
+/obj/item/bodypart/r_leg,
+/obj/structure/bed/roller,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aFU" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4
+/obj/machinery/power/terminal{
+	dir = 8
 	},
-/obj/item/stack/medical/suture,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/medical/abandoned)
+/area/maintenance/department/medical)
 "aFV" = (
-/obj/item/shard{
-	icon_state = "small"
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
 	},
-/turf/open/floor/iron,
-/area/medical/abandoned)
-"aFW" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/medical/abandoned)
-"aFX" = (
-/obj/structure/fluff/broken_flooring,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/medical/abandoned)
+/area/maintenance/department/medical)
+"aFW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"aFX" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/maintenance/department/medical)
 "aFY" = (
+/obj/structure/table_frame,
 /obj/item/shard{
 	icon_state = "medium"
 	},
-/obj/item/stack/medical/bruise_pack,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/medical/abandoned)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aFZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -8742,9 +8749,15 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "aGr" = (
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aGt" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
@@ -8799,42 +8812,51 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aGC" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/light/small/directional/west,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aGD" = (
-/obj/item/bodypart/head,
+/obj/structure/table_frame,
+/obj/item/shard,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aGE" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/landmark/blobstart,
+/obj/structure/table/glass,
+/obj/item/wirecutters,
+/obj/item/crowbar/red{
+	desc = "A small crowbar. This handy tool is useful for lots of things, such as romerol tumors or alien babies. ";
+	name = "medical crowbar"
+	},
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aGF" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/neck/stethoscope,
-/obj/structure/cable,
+/obj/structure/table_frame,
+/obj/item/bedsheet/random,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aGG" = (
-/obj/item/bodypart/l_arm,
-/obj/item/stack/medical/gauze,
+/obj/structure/table/glass,
+/obj/item/pen,
+/obj/item/hatchet,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aGH" = (
-/obj/item/stack/medical/suture,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/bottle/absinthe{
+	desc = "Good disinfectant. Also good for getting drunk very fast.";
+	name = "medical-grade absinthe"
+	},
+/obj/item/lighter,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aGI" = (
-/obj/item/storage/box/bodybags,
-/obj/machinery/light/small/directional/east,
+/obj/machinery/vending/medical,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aGJ" = (
-/obj/machinery/atmospherics/components/tank/air,
+/obj/structure/filingcabinet,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aGP" = (
@@ -9030,47 +9052,41 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aHy" = (
-/obj/item/bodybag,
-/obj/structure/closet/crate/medical,
+/obj/item/bodypart/l_leg/monkey,
+/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aHz" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/obj/item/stack/medical/bruise_pack,
+/obj/item/shard{
+	icon_state = "small"
+	},
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aHA" = (
-/obj/effect/decal/cleanable/blood/innards,
-/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aHB" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"aHC" = (
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/stack/medical/bruise_pack,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/medical/abandoned)
+"aHD" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/medical/abandoned)
-"aHC" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 1
-	},
-/obj/item/bodybag,
-/turf/open/floor/plating,
-/area/medical/abandoned)
-"aHD" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/bed/roller,
-/obj/item/wrench/medical,
-/turf/open/floor/iron,
-/area/medical/abandoned)
 "aHE" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -30
-	},
-/obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 5
-	},
+/obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aHF" = (
@@ -9088,25 +9104,27 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aHL" = (
-/obj/structure/chair,
-/obj/item/toy/plush/awakenedplushie,
-/turf/open/floor/iron,
-/area/maintenance/port/fore)
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aHM" = (
-/obj/structure/chair,
-/turf/open/floor/iron,
-/area/maintenance/port/fore)
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aHN" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aHO" = (
-/obj/structure/fluff/broken_flooring,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
+/obj/structure/chair/stool,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/medical)
 "aHP" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
@@ -9206,72 +9224,51 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "aIe" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 4
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 30
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aIf" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/department/medical)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aIg" = (
 /obj/structure/frame/computer,
 /obj/item/circuitboard/computer/atmos_alert,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aIi" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/plating,
+/obj/item/bodypart/head,
+/turf/open/floor/iron,
 /area/medical/abandoned)
 "aIj" = (
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aIk" = (
-/obj/structure/fluff/broken_flooring,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/structure/table,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/neck/stethoscope,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/medical/abandoned)
 "aIl" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/item/bodypart/l_arm,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aIm" = (
-/obj/machinery/iv_drip,
+/obj/item/stack/medical/suture,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "aIn" = (
-/obj/item/bodypart/r_leg,
-/obj/structure/bed/roller,
-/obj/machinery/airalarm/directional/east,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron,
 /area/medical/abandoned)
-"aIo" = (
-/obj/structure/closet/wardrobe/yellow,
-/obj/item/stock_parts/cell,
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aIp" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -9299,11 +9296,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aIE" = (
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/obj/structure/fluff/broken_flooring,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aIF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -9312,8 +9308,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aIG" = (
-/turf/open/floor/iron,
-/area/maintenance/port/fore)
+/turf/closed/wall,
+/area/maintenance/central)
 "aIH" = (
 /obj/structure/chair{
 	dir = 4
@@ -9326,7 +9322,7 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain/private)
 "aIJ" = (
-/obj/machinery/atmospherics/components/binary/valve,
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aIM" = (
@@ -9367,38 +9363,35 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aIR" = (
-/obj/machinery/power/smes{
-	charge = 500000
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aIS" = (
-/obj/machinery/power/terminal{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aIT" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aIU" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/structure/closet/emcloset,
+/obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/central)
 "aIV" = (
+/obj/effect/decal/cleanable/blood/innards,
 /obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock{
-	name = "Abandoned Medical Aux Room"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/medical/abandoned)
@@ -9429,8 +9422,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aJj" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aJl" = (
 /obj/structure/chair{
 	dir = 8
@@ -9442,10 +9439,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aJo" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Emergency Oxygen Supply"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aJs" = (
@@ -9479,60 +9476,67 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aJy" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
 /obj/structure/cable,
-/turf/closed/wall,
-/area/maintenance/department/medical)
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aJz" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Backup Power Supply"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aJA" = (
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/chair,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aJB" = (
-/obj/structure/table_frame,
-/obj/item/shard{
-	icon_state = "medium"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/chair,
+/obj/item/toy/plush/awakenedplushie,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aJC" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
+/obj/structure/chair,
+/obj/structure/fluff/broken_flooring{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/turf/open/floor/plating,
+/area/maintenance/central)
+"aJD" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron,
+/area/medical/abandoned)
+"aJE" = (
+/obj/structure/fluff/broken_flooring{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/dead_body_placer,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
-"aJD" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"aJE" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/medical/abandoned)
 "aJG" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/medical/abandoned)
 "aJH" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/iv_drip,
+/turf/open/floor/iron,
+/area/medical/abandoned)
 "aJI" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aJJ" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -9597,20 +9601,17 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "aKg" = (
-/obj/structure/table,
-/obj/item/shard/plasma,
-/obj/item/stack/rods,
-/obj/item/kitchen/rollingpin,
-/obj/item/shard{
-	icon_state = "medium"
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 30
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/port/fore)
+/area/maintenance/central)
 "aKh" = (
 /turf/closed/wall,
 /area/space)
 "aKi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aKk" = (
@@ -9670,9 +9671,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aKs" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "aKt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -9707,29 +9708,15 @@
 /turf/open/floor/iron/white,
 /area/science)
 "aKz" = (
-/obj/structure/cable,
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aKA" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/central)
 "aKB" = (
 /obj/structure/punching_bag,
 /turf/open/floor/iron,
@@ -9757,15 +9744,12 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/science/research)
 "aKE" = (
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/central)
 "aKM" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -9842,9 +9826,10 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aLb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/door/airlock/maintenance{
+	name = "Emergency Oxygen Supply"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aLc" = (
@@ -9908,19 +9893,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aLn" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/grille,
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/maintenance/central)
 "aLo" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -9932,8 +9909,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aLp" = (
-/turf/closed/wall/r_wall,
-/area/command/heads_quarters/cmo)
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aLq" = (
 /obj/structure/frame/computer{
 	dir = 8
@@ -9941,19 +9920,6 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aLs" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Medbay Maintenance";
-	req_access_txt = "5"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
-"aLu" = (
-/obj/machinery/holopad,
-/turf/closed/wall,
-/area/medical/patients_rooms)
 "aLG" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -9986,9 +9952,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "aLM" = (
-/obj/structure/window,
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aLN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -9996,10 +9965,14 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aLO" = (
-/obj/structure/window,
-/obj/item/melee/flyswatter,
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "singular"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aLP" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -10075,76 +10048,53 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMe" = (
-/obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
-/obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	departmentType = 5;
-	name = "Chief Medical Officer"
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
-"aMf" = (
-/obj/structure/closet/secure_closet/chief_medical,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
-"aMg" = (
-/obj/structure/chair,
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Backup Power Supply"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/department/medical)
+"aMf" = (
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aMg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "aMk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/area/medical/medbay/central)
 "aMm" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Break Room";
-	name = "Medbay Break Room Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/patients_rooms)
-"aMn" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/area/medical/medbay/central)
 "aMo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aMp" = (
-/turf/closed/wall,
-/area/medical/patients_rooms)
 "aMs" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
@@ -10156,39 +10106,30 @@
 	},
 /area/maintenance/port/fore)
 "aMu" = (
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
-/area/maintenance/port/fore)
+/area/commons/fitness/recreation)
 "aMv" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
 /turf/open/floor/iron,
-/area/maintenance/port/fore)
+/area/maintenance/central)
 "aMw" = (
-/obj/structure/fluff/broken_flooring{
-	icon_state = "singular"
-	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/grille,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/central)
 "aMy" = (
-/obj/machinery/suit_storage_unit/cmo,
-/obj/machinery/light/directional/north,
-/obj/machinery/button/door/directional/east{
-	id = "cmoprivacy";
-	name = "CMO Shutter Control";
-	pixel_y = 6;
-	req_access_txt = "40"
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aMz" = (
-/obj/structure/table,
-/obj/item/toy/mecha/odysseus,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aMA" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -10215,12 +10156,11 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "aMG" = (
-/obj/structure/sign/departments/medbay/alt{
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aMH" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -10260,46 +10200,58 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aML" = (
-/obj/item/organ/tail/lizard,
-/obj/item/picket_sign,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aMM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMO" = (
-/obj/machinery/modular_computer/console/preset/id{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aMP" = (
-/obj/machinery/camera{
-	c_tag = "CMO";
-	name = "CMO Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/cmo{
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aMQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aMR" = (
-/obj/item/toy/cattoy,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aMS" = (
-/obj/structure/chair/office/light,
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/structure/cable,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aMT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -10311,16 +10263,18 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aMU" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/cryo)
 "aMV" = (
-/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_access_txt = "5"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/maintenance/department/medical)
 "aMW" = (
 /mob/living/carbon/human/species/monkey/punpun,
 /turf/open/floor/carpet,
@@ -10339,46 +10293,28 @@
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
-"aNa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "aNb" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/iron/dark,
+/area/medical/cryo)
 "aNc" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/command/heads_quarters/cmo";
-	dir = 4;
-	name = "Chief Medical Officer's Office APC";
-	pixel_x = 24
+/obj/structure/table/glass,
+/obj/item/wrench/medical,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"aNd" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"aNg" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 25;
-	pixel_y = 25
+/obj/machinery/camera{
+	c_tag = "Cryogenics";
+	name = "Cryogenics Camera";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/area/medical/cryo)
+"aNg" = (
+/obj/structure/stairs/east,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "aNh" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -10519,9 +10455,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aNA" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/fore)
 "aNB" = (
 /obj/structure/closet/crate{
@@ -10555,48 +10491,35 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aNG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
+"aNJ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
-	req_one_access_txt = "5;12"
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aNI" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
-"aNJ" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
 "aNK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aNL" = (
-/obj/structure/table/glass,
-/obj/item/cartridge/medical,
-/obj/item/cartridge/medical,
-/obj/item/cartridge/medical,
-/obj/item/cartridge/chemistry,
-/obj/item/toy/figure/cmo,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/item/melee/baseball_bat,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aNM" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aNN" = (
 /obj/structure/sign/poster/official/safety_report{
 	pixel_x = 30
@@ -10604,9 +10527,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aNP" = (
-/obj/structure/stairs/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aNQ" = (
 /obj/machinery/atmospherics/pipe/multiz/orange/visible{
 	dir = 4
@@ -10618,28 +10543,33 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aNU" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aNV" = (
-/obj/structure/table,
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1;
+	piping_layer = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aNW" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aNZ" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp/cmo,
-/obj/item/stamp/denied,
-/obj/machinery/newscaster/directional/east,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/area/medical/cryo)
 "aOa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -10677,8 +10607,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aOk" = (
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aOm" = (
 /turf/closed/wall,
 /area/service/lawoffice)
@@ -10716,83 +10650,67 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aOt" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aOu" = (
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/machinery/light/floor,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aOv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aOw" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aOx" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aOy" = (
 /obj/item/stack/sheet/glass,
 /turf/open/space/basic,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aOz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/space/nearstation)
 "aOA" = (
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aOB" = (
-/obj/machinery/door/airlock/medical{
-	name = "Break Room";
-	req_access_txt = "5"
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/patients_rooms)
+/area/medical/cryo)
 "aOC" = (
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
 "aOD" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock{
+	name = "Abandoned Medical Aux Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/department/medical)
 "aOF" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
@@ -10861,22 +10779,16 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aOQ" = (
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "aOR" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4;
-	icon_state = "singular"
-	},
-/obj/structure/closet/boxinggloves,
+/obj/structure/fluff/broken_flooring,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/maintenance/central)
 "aOS" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -10887,9 +10799,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aOU" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aOV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -10974,17 +10888,18 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aPi" = (
-/obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"aPj" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
 	},
-/turf/closed/wall,
-/area/commons/fitness/recreation)
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aPj" = (
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aPk" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11000,24 +10915,20 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aPm" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/obj/effect/spawner/bundle/costume/pirate,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "aPn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
-"aPo" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Chemistry";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/obj/machinery/computer/cargo/request,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/turf/open/floor/iron/white,
+/area/medical/cryo)
+"aPo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aPq" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -11035,33 +10946,23 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aPt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "CMO Office"
+/obj/machinery/door/airlock/maintenance{
+	name = "Medbay Maintenance";
+	req_access_txt = "5"
 	},
-/turf/open/floor/plating,
-/area/command/heads_quarters/cmo)
-"aPu" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Medical Officer's Office";
-	req_access_txt = "40"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/command/heads_quarters/cmo)
+/area/maintenance/department/medical)
+"aPu" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aPv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/stairs/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aPA" = (
@@ -11071,9 +10972,11 @@
 /turf/open/floor/iron/white,
 /area/science)
 "aPB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aPC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -11086,40 +10989,18 @@
 /turf/open/floor/iron/white,
 /area/science)
 "aPE" = (
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/item/melee/flyswatter,
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aPG" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/patients_rooms)
-"aPH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/bot_red,
+/obj/structure/closet/lasertag/red,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "aPI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aPJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/medical/cryo)
 "aPW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -11165,17 +11046,6 @@
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/eighties,
 /area/maintenance/port/fore)
-"aQd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aQe" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/cut,
@@ -11283,6 +11153,15 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aQD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aQE" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aQF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -11292,7 +11171,7 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aQE" = (
+"aQG" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -11302,49 +11181,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"aQF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"aQG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aQK" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/department/medical)
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/grille,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aQN" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - CMO";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/sign/departments/medbay{
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aQS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aQT" = (
@@ -11354,7 +11208,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aQU" = (
@@ -11368,17 +11222,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"aQX" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aQY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 4
@@ -11393,20 +11236,27 @@
 /area/science/explab)
 "aRb" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aRc" = (
-/turf/closed/wall/r_wall,
-/area/security/checkpoint/medical)
+/obj/structure/closet/athletic_mixed,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "aRd" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
+/obj/structure/window/reinforced/spawner/west,
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aRf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -11417,15 +11267,11 @@
 /turf/open/floor/plating,
 /area/commons/dorms)
 "aRh" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/central";
-	dir = 4;
-	name = "Medbay APC";
-	pixel_x = 24
-	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/spawner,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/turf/open/floor/iron/dark,
+/area/maintenance/central)
 "aRi" = (
 /obj/machinery/power/solar_control{
 	id = "foreport";
@@ -11542,24 +11388,21 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aRE" = (
-/obj/machinery/computer/security/telescreen{
-	name = "Security Medbay monitor";
-	network = list("medbay")
-	},
-/obj/structure/table,
-/obj/structure/sign/nanotrasen{
-	pixel_x = -30
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"aRF" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"aRG" = (
-/obj/effect/spawner/bundle/costume/pirate,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/area/maintenance/department/medical)
+"aRF" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"aRG" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aRK" = (
 /obj/structure/window{
 	dir = 1
@@ -11572,25 +11415,16 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "aRN" = (
-/obj/structure/noticeboard{
-	dir = 1;
-	pixel_y = -32
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aRO" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Psychology Maintenance";
-	req_access_txt = "70"
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aRP" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -11634,14 +11468,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
-"aRT" = (
-/turf/closed/wall,
-/area/medical/treatment_center)
-"aRU" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "aSd" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -11658,17 +11484,16 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "aSe" = (
-/obj/item/melee/baseball_bat,
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aSf" = (
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aSg" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aSh" = (
@@ -11699,11 +11524,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aSo" = (
-/obj/structure/window{
-	dir = 4
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/area/medical/storage)
 "aSp" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/costume,
@@ -11775,22 +11603,24 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aSD" = (
-/obj/structure/chair/office{
+/obj/machinery/light/directional/east,
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"aSE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/medical/storage)
+"aSE" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/closed/wall,
-/area/maintenance/department/medical)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aSF" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
@@ -11801,84 +11631,25 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aSH" = (
-/turf/closed/wall/r_wall,
-/area/medical/surgery)
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aSI" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "aSJ" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"aSK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/storage)
-"aSL" = (
-/obj/structure/closet/secure_closet/medical3,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/belt/medical,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aSM" = (
-/obj/structure/table,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/storage/belt/medical,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/gun/syringe,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/machinery/camera{
-	c_tag = "Medical Storage";
-	name = "Medical Storage Camera";
-	network = list("ss13","medbay")
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aSN" = (
-/obj/structure/cable,
-/obj/structure/closet/secure_closet/medical3,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/storage";
-	dir = 1;
-	name = "Medbay Storage APC";
-	pixel_y = 24
-	},
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/belt/medical,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aSO" = (
-/obj/structure/table,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/syringes,
-/obj/item/storage/box/rxglasses,
-/obj/item/sensor_device,
-/obj/item/gun/syringe,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aSP" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate{
@@ -11887,51 +11658,35 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aSQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aSS" = (
-/obj/structure/closet/secure_closet/medical1,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"aST" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"aSU" = (
-/obj/machinery/camera{
-	c_tag = "Stasis N";
-	name = "Stasis Camera";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"aSV" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"aSS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
+"aST" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
+"aSU" = (
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "aSX" = (
-/obj/structure/sign/departments/examroom{
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aSY" = (
@@ -11943,13 +11698,12 @@
 /turf/open/space/basic,
 /area/space)
 "aTb" = (
-/obj/machinery/computer/med_data{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/cryo)
 "aTc" = (
 /obj/structure/cable,
 /obj/structure/closet/emcloset,
@@ -11963,7 +11717,6 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aTe" = (
-/obj/structure/cable,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -12098,7 +11851,9 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aTv" = (
-/obj/structure/stairs/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aTw" = (
@@ -12106,12 +11861,7 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aTx" = (
-/obj/effect/turf_decal/bot_white{
-	color = "#0000ff";
-	name = "bot blue"
-	},
-/obj/structure/closet/lasertag/blue,
-/obj/effect/landmark/start/hangover/closet,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aTy" = (
@@ -12122,38 +11872,49 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aTz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aTA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aTB" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aTC" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/structure/table,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/medical/storage)
+"aTC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aTD" = (
-/obj/effect/landmark/start/depsec/medical,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aTF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -12163,109 +11924,77 @@
 /turf/open/floor/plating,
 /area/service/lawoffice)
 "aTI" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aTJ" = (
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aTK" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/camera{
-	c_tag = "Surgery A";
-	name = "Surgery Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aTL" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/reagent_containers/blood/lizard,
-/obj/item/reagent_containers/blood/universal,
-/obj/item/reagent_containers/blood/a_minus,
-/obj/item/reagent_containers/blood/a_plus,
-/obj/item/reagent_containers/blood/b_minus,
-/obj/item/reagent_containers/blood/b_plus,
-/obj/item/reagent_containers/blood/o_minus,
-/obj/item/reagent_containers/blood/o_plus,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aTM" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Medbay";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aTJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aTK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"aTN" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aTO" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aTL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"aTP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aTQ" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aTR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
+"aTM" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northright{
+	dir = 8;
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/medical/storage)
 "aTS" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery";
-	dir = 4;
-	name = "Surgery APC";
-	pixel_x = 23
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aTT" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/firealarm/directional/east,
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aTU" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "aTV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -12277,12 +12006,17 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "aTW" = (
-/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/cryo)
 "aTX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/cryo)
 "aUd" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Port Bow Solar Access";
@@ -12327,11 +12061,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aUk" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/cryo)
 "aUl" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Test Chamber";
@@ -12436,12 +12172,14 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aUz" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/area/maintenance/central)
 "aUB" = (
 /obj/machinery/door/airlock{
 	name = "Law Office A";
@@ -12477,20 +12215,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"aUF" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aUG" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aUH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -12498,18 +12222,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"aUI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -12523,23 +12235,32 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "aUK" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aUL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aUM" = (
-/obj/machinery/computer/operating{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aUL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aUM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aUN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aUO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -12547,90 +12268,52 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aUQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aUR" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "aUW" = (
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aUY" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aUZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aUY" = (
+/obj/structure/fluff/broken_flooring{
+	icon_state = "singular"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aVa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/turf/closed/wall,
+/area/medical/cryo)
 "aVb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/cryo)
 "aVc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"aVd" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medbay Storage";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
+/area/medical/cryo)
 "aVh" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -12680,19 +12363,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aVo" = (
-/obj/structure/table,
-/obj/item/screwdriver,
-/obj/item/radio/off,
-/obj/machinery/requests_console/directional/west{
-	department = "Security";
-	departmentType = 5;
-	name = "Medical Security Post";
-	pixel_x = 0;
-	pixel_y = -30
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
-/obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aVp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -12705,7 +12380,10 @@
 /area/science/explab)
 "aVq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -12768,9 +12446,29 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aVz" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aVA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible,
 /turf/open/floor/engine,
@@ -12802,13 +12500,20 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
 "aVG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Medical Security Post Morgue Access";
+	req_access_txt = "63;5"
+	},
+/turf/open/floor/iron/dark,
+/area/security/checkpoint/medical)
 "aVH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -12826,10 +12531,6 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aVK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -12838,10 +12539,22 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/maintenance/department/medical)
+/area/medical/storage)
 "aVN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aVO" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
+"aVP" = (
+/obj/effect/landmark/start/depsec/medical,
 /obj/structure/cable,
-/obj/structure/table/optable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -12849,22 +12562,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery)
-"aVO" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aVP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "aVR" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/research{
@@ -12885,119 +12583,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"aVT" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/obj/machinery/light/directional/south,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"aVU" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
-"aVV" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/northleft{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
-"aVW" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/northright{
-	name = "First-Aid Supplies";
-	red_alert_access = 1;
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
 "aVX" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"aVY" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/bottle/multiver,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/item/reagent_containers/glass/bottle/salglu_solution,
-/obj/item/reagent_containers/syringe,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"aWj" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/firstaid/brute,
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
-/area/medical/storage)
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aWq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -13042,15 +12632,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aWw" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/treatment_center";
-	dir = 8;
-	name = "Medbay Treatment APC";
-	pixel_x = -23
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aWz" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -13076,12 +12660,18 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aWD" = (
+/obj/structure/closet/athletic_mixed,
+/obj/effect/turf_decal/bot_white,
 /obj/machinery/bluespace_vendor/south,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aWE" = (
-/obj/effect/turf_decal/bot_red,
-/obj/structure/closet/lasertag/red,
+/obj/effect/turf_decal/bot_white{
+	color = "#0000ff";
+	name = "bot blue"
+	},
+/obj/structure/closet/lasertag/blue,
+/obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aWH" = (
@@ -13104,60 +12694,74 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aWN" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/table,
+/obj/item/megaphone,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aWP" = (
 /obj/structure/table,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/color/latex,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/item/shard/plasma,
+/obj/item/stack/rods,
+/obj/item/kitchen/rollingpin,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aWR" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron,
+/area/maintenance/central)
 "aWS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"aWU" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/r_wall,
-/area/medical/storage)
-"aWV" = (
-/turf/closed/wall/r_wall,
-/area/medical/storage)
 "aWX" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/chem_pack,
-/obj/item/stack/medical/gauze/twelve,
-/obj/item/reagent_containers/chem_pack,
-/obj/machinery/light/directional/west,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/machinery/camera{
+	c_tag = "Medical Storage";
+	name = "Medical Storage Camera";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/storage)
 "aWY" = (
-/obj/machinery/holopad,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/storage)
 "aWZ" = (
-/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/storage)
 "aXa" = (
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/reagent_containers/medigel/sterilizine,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medbay Storage";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "aXc" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -13183,14 +12787,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aXh" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Storage";
-	dir = 8;
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aXi" = (
 /turf/closed/wall,
 /area/service/chapel/office)
@@ -13202,11 +12806,8 @@
 /turf/open/floor/iron/white,
 /area/science)
 "aXl" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Stasis";
-	dir = 4;
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = 32
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -13214,9 +12815,11 @@
 /turf/closed/wall,
 /area/commons/dorms)
 "aXn" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/maintenance/port/fore)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aXo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -13228,19 +12831,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aXs" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 4;
-	name = "Chemistry APC";
-	pixel_x = 25;
-	pixel_y = 3
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "aXu" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -13255,12 +12845,9 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "aXw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/structure/stairs/north,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "aXx" = (
 /obj/machinery/sparker{
 	id = "testigniter";
@@ -13273,11 +12860,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/science/explab)
-"aXz" = (
-/obj/structure/stairs/east,
-/obj/structure/railing,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
 "aXA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -13299,70 +12881,100 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "aXC" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/surgery,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/structure/filingcabinet,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "aXD" = (
 /obj/structure/table,
-/obj/item/cautery,
-/obj/item/retractor,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/machinery/recharger,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "aXE" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Medbay";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "aXF" = (
-/obj/structure/table,
-/obj/item/scalpel,
-/obj/item/hemostat,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aXH" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Morgue";
-	dir = 5;
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aXJ" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aXK" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/medical/medbay/central)
-"aXL" = (
-/obj/structure/table/glass,
-/obj/item/wrench/medical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
+/area/medical/morgue)
+"aXJ" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Morgue Maintenance";
+	req_one_access_txt = "6;5"
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron/dark,
+/area/maintenance/starboard/fore)
+"aXK" = (
+/obj/machinery/smartfridge/organ,
+/turf/closed/wall,
+/area/medical/morgue)
+"aXL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_one_access_txt = "5;12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "aXM" = (
 /obj/item/stack/cable_coil/five,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aXN" = (
-/obj/structure/table,
-/obj/item/surgicaldrill,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
-/area/medical/surgery)
+/area/medical/morgue)
 "aXO" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
+/obj/structure/table,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/syringes,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/storage)
 "aYa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -13377,25 +12989,30 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYb" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aYi" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/machinery/camera{
-	c_tag = "Cryogenics";
-	name = "Cryogenics Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
+"aYi" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "aYj" = (
-/obj/machinery/light/directional/west,
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	dir = 8;
+	name = "Security Medbay monitor";
+	network = list("medbay")
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "aYk" = (
 /obj/structure/chair{
 	dir = 4
@@ -13544,81 +13161,120 @@
 "aYV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/medical/surgery)
+/area/medical/medbay/lobby)
 "aYY" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aYZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aZa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"aZb" = (
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/medbay/lobby)
+"aYZ" = (
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"aZa" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Reception";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"aZb" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "aZc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "aZf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/medical/medbay/lobby)
 "aZh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/storage)
 "aZi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/sensor_device,
+/obj/item/storage/box/rxglasses,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/storage)
 "aZj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"aZn" = (
+/obj/machinery/computer/med_data{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"aZn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Medbay Lobby NE";
+	name = "Medbay Lobby Camera";
+	network = list("ss13","medbay")
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/medbay/lobby)
 "aZo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/structure/closet/secure_closet/chemical,
+/obj/item/storage/box/syringes,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/assembly/signaler,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/pharmacy)
 "aZp" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -13649,15 +13305,27 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aZQ" = (
-/obj/machinery/computer/crew,
+/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/assembly/igniter,
+/obj/item/gun/syringe,
+/obj/item/toy/figure/chemist,
+/obj/machinery/light_switch/directional/east,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/pharmacy)
 "aZS" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "medcell";
-	name = "Medical Cell Locker"
+/obj/effect/landmark/start/depsec/medical,
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "aZU" = (
@@ -13668,24 +13336,43 @@
 /turf/open/floor/carpet/green,
 /area/service/chapel/main)
 "aZV" = (
-/turf/closed/wall,
-/area/medical/surgery)
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "aZW" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "aZX" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	desc = "A door remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = 32;
+	req_access_txt = "5"
 	},
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "aZY" = (
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/structure/table/glass,
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/assembly/timer,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/screwdriver,
+/obj/item/wirecutters,
+/obj/structure/sign/departments/chemistry/pharmacy{
+	pixel_x = 30
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "bab" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -13696,31 +13383,39 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bac" = (
-/obj/machinery/holopad,
+/obj/structure/sign/nanotrasen{
+	pixel_x = -30
+	},
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bad" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/medical/storage)
+/area/security/checkpoint/medical)
 "bae" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+/obj/machinery/computer/crew{
 	dir = 8
 	},
+/obj/machinery/requests_console/directional/west{
+	department = "Security";
+	departmentType = 5;
+	name = "Medical Security Post";
+	pixel_x = 0;
+	pixel_y = -30
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "baf" = (
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/obj/structure/table,
+/obj/structure/cable,
+/obj/item/reagent_containers/food/drinks/britcup,
+/turf/open/floor/iron/dark,
+/area/medical/medbay/lobby)
 "bag" = (
-/obj/structure/chair{
+/obj/structure/chair/office/light{
 	dir = 8
 	},
+/obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/pharmacy)
 "bah" = (
-/obj/structure/cable,
 /obj/structure/closet/wardrobe/white,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -13732,34 +13427,48 @@
 /turf/open/floor/iron/white,
 /area/science)
 "baj" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Surgery Observation";
-	dir = 8;
-	name = "Surgery Observation Camera";
-	network = list("ss13","medbay")
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	pixel_y = 15
 	},
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/item/reagent_containers/glass/bottle/epinephrine,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "bal" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/rack,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
 "bao" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/delivery/red,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/obj/structure/table,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	req_access_txt = "5"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/medical/storage)
 "bap" = (
-/obj/structure/cable,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/ammonia,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
 "baq" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
@@ -13792,25 +13501,38 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "bba" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/fluff/broken_flooring,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/department/medical)
+/area/medical/abandoned)
 "bbc" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"bbd" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "meddoor";
-	name = "Medical Cell";
-	req_access_txt = "63"
+/obj/structure/chair,
+/obj/structure/sign/departments/psychology{
+	pixel_x = -32
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/medbay/lobby)
+"bbd" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Pharmacy Maintenance";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/department/medical)
 "bbf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -13832,39 +13554,31 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bbh" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
 "bbi" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "bbj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+/obj/machinery/disposal/bin,
+/obj/machinery/camera{
+	c_tag = "Pharmacy";
+	dir = 8;
+	name = "Pharmacy Camera";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "bbk" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/storage/box/ids,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs)
 "bbl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -13872,15 +13586,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bbm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/maintenance/starboard/fore)
 "bbn" = (
-/obj/structure/table,
-/obj/item/soap/nanotrasen,
-/obj/item/book/manual/wiki/medicine,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/light/blacklight/directional/east,
+/obj/machinery/firealarm/directional/east,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "bbo" = (
 /obj/structure/sign/directions/command{
 	dir = 4;
@@ -13890,58 +13606,43 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bbq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/structure/closet/secure_closet/brig{
+	id = "medcell";
+	name = "Medical Cell Locker"
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "bbr" = (
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
-	},
-/obj/machinery/camera{
-	c_tag = "Stasis S";
-	dir = 1;
-	name = "Stasis Camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"bbs" = (
-/obj/structure/sink{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = -8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"bbt" = (
-/obj/machinery/iv_drip,
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/storage)
+"bbs" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"bbt" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "bbu" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "bbw" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/hand_labeler,
+/obj/machinery/light/directional/east,
+/obj/machinery/button/door/directional/east{
+	id = "chemlock";
+	name = "Pharmacy Shutters";
+	req_one_access_txt = "5;69"
 	},
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "bbD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -13954,10 +13655,25 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "bbH" = (
-/obj/machinery/iv_drip,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/obj/structure/table,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/medical/storage)
 "bbJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -13973,15 +13689,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"bcb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bcf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -14012,14 +13719,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/science/explab)
-"bcm" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryblock";
-	name = "Surgery B Privacy Door"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/surgery/room_b)
 "bcn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -14030,22 +13729,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bco" = (
-/obj/machinery/door_timer{
-	id = "medcell";
-	name = "Medical Cell";
-	pixel_x = 32
+/obj/structure/chair{
+	dir = 8
 	},
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "bcp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/item/kirbyplants/random,
+/obj/structure/sign/departments/chemistry/pharmacy{
+	pixel_x = 30
 	},
-/obj/structure/cable,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/medbay/lobby)
 "bcr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -14053,51 +13749,41 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bcs" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Surgery Observation"
+/obj/structure/chair/office/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/pharmacy)
 "bcu" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/medbay/central)
-"bcv" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	id = "medcell";
-	name = "Medical Cell";
-	req_access_txt = "63"
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/east,
+/obj/structure/table/glass,
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"bcw" = (
-/obj/structure/grille,
+/area/medical/pharmacy)
+"bcv" = (
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/starboard";
+	name = "Starboard Primary Hallway APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bcy" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/customs)
 "bcE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/chair/office/light,
+/turf/open/floor/iron,
+/area/security/checkpoint/customs)
 "bcF" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
@@ -14175,123 +13861,125 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bdi" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "bdj" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
+/obj/machinery/door/airlock{
+	name = "Cleaning Closet"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "bdo" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bdp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_access_txt = "6;5"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bdq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bdt" = (
-/obj/machinery/vending/drugs,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "bdv" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Surgery";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+/obj/machinery/door/airlock/medical{
+	name = "Morgue";
+	req_one_access_txt = "6;5;28"
 	},
-/obj/structure/sign/departments/medbay/alt{
-	pixel_y = 30
+/obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "bdy" = (
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "bdz" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
-"bdA" = (
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/toy/figure/paramedic,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
-"bdB" = (
-/obj/structure/window{
-	dir = 4
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	id = "medcell";
+	name = "Medical Cell";
+	req_access_txt = "63"
 	},
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
-"bdC" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/hallway/primary/starboard)
+"bdA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"bdB" = (
+/turf/closed/wall,
+/area/medical/pharmacy)
+"bdC" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bdF" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Pharmacy";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"bdG" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"bdH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"bdI" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
 	},
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = 30
 	},
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bdG" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bdH" = (
-/obj/structure/table,
-/obj/item/storage/box/masks,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bdI" = (
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bdJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -14306,31 +13994,22 @@
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bdL" = (
-/obj/item/trash/can,
-/obj/effect/loot_site_spawner,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bdM" = (
-/obj/item/trash/cheesie,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bdN" = (
-/obj/item/trash/can,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bdO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"bdP" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/surgery,
-/obj/item/reagent_containers/medigel/sterilizine,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "bdQ" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -14341,13 +14020,6 @@
 "bdS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
-"bdT" = (
-/obj/structure/stairs/east,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
 "bdU" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/iron/chapel{
@@ -14501,17 +14173,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "beE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
-	name = "Morgue APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -14535,29 +14202,34 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "beI" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"beJ" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"beJ" = (
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "beK" = (
-/obj/machinery/light_switch/directional/east,
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 11
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "meddoor";
+	name = "Medical Cell";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"beL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "beM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -14578,51 +14250,42 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "beU" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/start/paramedic,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "beW" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
-"beX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bfb" = (
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bfd" = (
-/obj/item/trash/can/food/peaches,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bfe" = (
-/obj/structure/reagent_dispensers/peppertank/directional/west,
-/obj/structure/filingcabinet,
-/obj/machinery/firealarm/directional/south,
+/obj/structure/table,
+/obj/item/screwdriver,
+/obj/item/radio/off,
+/obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
-"bfj" = (
-/obj/structure/table/optable,
-/obj/machinery/defibrillator_mount{
-	pixel_x = 28
+"bfe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"bfj" = (
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/security/checkpoint/medical)
 "bfk" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/poster/official/random{
@@ -14866,59 +14529,20 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bgk" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/bodycontainer/morgue,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/medical/abandoned)
 "bgl" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bgn" = (
-/obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bgr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
 	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
-"bgt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bgu" = (
-/obj/structure/cable,
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bgv" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bgw" = (
-/obj/structure/sign/departments/chemistry/pharmacy{
-	pixel_y = -30
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "bgx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/trophy/bronze_cup{
@@ -14931,14 +14555,6 @@
 	},
 /turf/open/floor/iron/chapel,
 /area/service/chapel/main)
-"bgy" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bgz" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bgA" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/cow,
@@ -14952,8 +14568,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bgE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bgF" = (
@@ -15013,11 +14634,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"bha" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bhd" = (
 /obj/item/storage/box/lights/mixed,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
@@ -15094,22 +14710,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
-"bhr" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
-"bhs" = (
-/obj/machinery/camera{
-	c_tag = "Morgue N";
-	name = "Morgue Camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "bhu" = (
-/obj/structure/table/optable,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bhv" = (
@@ -15125,36 +14733,21 @@
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"bhx" = (
-/obj/structure/table/glass,
-/obj/item/scalpel,
-/obj/item/retractor,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "bhy" = (
 /obj/machinery/component_printer,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"bhz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+"bhA" = (
+/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bhA" = (
+/area/security/checkpoint/medical)
+"bhB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bhB" = (
-/obj/structure/table/glass,
-/obj/item/surgical_drapes,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/security/checkpoint/medical)
 "bhD" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
@@ -15166,43 +14759,6 @@
 "bhF" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/medical/medbay/lobby)
-"bhG" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Reception";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"bhH" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bhJ" = (
 /obj/structure/window{
@@ -15229,61 +14785,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"bhN" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"bhO" = (
-/obj/structure/table,
-/obj/structure/showcase/machinery/tv,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bhP" = (
-/obj/item/trash/cheesie,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bhQ" = (
-/obj/structure/chair/comfy/black{
+"bhR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"bhR" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bhW" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/lobby)
-"bhX" = (
-/obj/structure/cable,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 30
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bhY" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2,
@@ -15471,12 +14986,9 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"biD" = (
-/obj/structure/bodycontainer/morgue,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "biE" = (
+/obj/machinery/light/blacklight/directional/west,
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "biH" = (
@@ -15496,54 +15008,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"biN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
-"biO" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_access_txt = "6;5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/morgue)
 "biP" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"biR" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
-"biS" = (
+"biU" = (
 /mob/living/simple_animal/bot/cleanbot{
 	name = "C.L.E.A.N."
 	},
 /obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"biU" = (
+"biW" = (
 /obj/structure/cable,
 /obj/structure/chair/office/light{
 	dir = 4
@@ -15557,32 +15033,7 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"biV" = (
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Lobby NE";
-	name = "Medbay Lobby Camera";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"biW" = (
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
 "biX" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Pharmacy";
-	req_access_txt = "5; 69"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 1;
@@ -15592,19 +15043,14 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"biZ" = (
-/obj/structure/closet/secure_closet/chemical,
-/obj/item/storage/box/syringes,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/assembly/signaler,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Pharmacy";
+	req_access_txt = "5; 69"
+	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "bjd" = (
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bje" = (
@@ -15618,23 +15064,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bjg" = (
-/obj/structure/table/glass,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/gun/syringe,
-/obj/item/toy/figure/chemist,
-/obj/machinery/light_switch/directional/east,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "bjh" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod";
@@ -15723,6 +15152,7 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bjw" = (
@@ -15960,25 +15390,8 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bkm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
-"bkn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "bko" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bkp" = (
@@ -15986,28 +15399,12 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "bks" = (
-/obj/machinery/light/directional/south,
+/obj/structure/reagent_dispensers/peppertank/directional/west,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "bkv" = (
 /obj/structure/table,
 /turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
-"bkw" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"bkx" = (
-/obj/structure/cable,
-/obj/machinery/button/door/directional/east{
-	desc = "A door remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bky" = (
 /turf/open/floor/iron/white,
@@ -16021,39 +15418,24 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"bkB" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "bkC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "chemlock";
+	name = "Chemistry Lockdown Door"
+	},
+/turf/open/floor/plating,
+/area/medical/pharmacy)
+"bkD" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"bkD" = (
+"bkE" = (
 /obj/machinery/chem_master,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"bkE" = (
-/obj/machinery/chem_heater/withbuffer,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"bkH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/pharmacy";
-	dir = 8;
-	name = "Pharmacy APC";
-	pixel_x = -24
-	},
-/obj/effect/spawner/lootdrop/glowstick,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bkI" = (
 /obj/structure/cable,
-/obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
 	},
@@ -16062,14 +15444,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"bkJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "chemlock";
-	name = "Chemistry Lockdown Door"
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "bkL" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/iron,
@@ -16091,29 +15465,13 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
-"bkP" = (
-/obj/structure/table/glass,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/assembly/timer,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/screwdriver,
-/obj/item/wirecutters,
-/obj/structure/sign/departments/chemistry/pharmacy{
-	pixel_x = 30
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "bkQ" = (
-/obj/machinery/computer/operating{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/security/checkpoint/medical)
 "bkR" = (
 /obj/machinery/camera{
 	c_tag = "Escape Pod N";
@@ -16172,16 +15530,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
-"blb" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	dir = 4;
-	name = "Customs Desk APC";
-	pixel_x = 25
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
@@ -16258,12 +15606,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
-"blq" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/turf/open/floor/iron,
 /area/maintenance/port/fore)
 "blr" = (
 /obj/structure/table,
@@ -16363,60 +15705,32 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"blI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
-"blJ" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "blK" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "blL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"blM" = (
-/turf/closed/wall,
-/area/medical/surgery/room_b)
-"blN" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "surgeryblock";
-	name = "Surgery B Privacy Door"
-	},
-/turf/open/floor/plating,
-/area/medical/surgery/room_b)
-"blO" = (
-/obj/machinery/door/airlock/medical{
-	name = "Surgery B";
+/obj/machinery/button/door/directional/east{
+	desc = "A door remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = 32;
 	req_access_txt = "5"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/security/checkpoint/medical)
+"blM" = (
+/obj/structure/table/optable,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
+"blN" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "blQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -16427,6 +15741,12 @@
 /obj/item/radio/intercom/directional/west,
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
+/obj/machinery/camera{
+	c_tag = "Medbay Lobby SW";
+	dir = 4;
+	name = "Medbay Lobby Camera";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "blS" = (
@@ -16436,16 +15756,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"blT" = (
+"blU" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
-"blU" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/item/reagent_containers/food/drinks/britcup,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "blV" = (
@@ -16456,27 +15770,21 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "blW" = (
-/obj/structure/chair/office/light{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "chemlock";
+	name = "Chemistry Lockdown Door"
 	},
-/obj/effect/landmark/start/chemist,
+/obj/machinery/door/window/eastright{
+	name = "Pharmacy Desk";
+	req_access_txt = "69"
+	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "blX" = (
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"blY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"bma" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "bmb" = (
 /obj/structure/noticeboard/directional/south,
 /obj/machinery/door/firedoor,
@@ -16499,19 +15807,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"bmg" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "chemlock";
-	name = "Chemistry Lockdown Door"
-	},
-/obj/machinery/door/window/eastright{
-	name = "Pharmacy Desk";
-	req_access_txt = "69"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "bmh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Customs Maintenance";
@@ -16550,15 +15845,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"bmq" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 15
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/item/reagent_containers/glass/bottle/epinephrine,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "bmr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -16686,13 +15972,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"bmL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bmM" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -16763,45 +16042,11 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "bmY" = (
-/obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/surgery,
-/obj/item/reagent_containers/medigel/sterilizine,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery/room_b";
-	dir = 8;
-	name = "Surgery B APC";
-	pixel_x = -23
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"bmZ" = (
-/obj/structure/cable,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"bna" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"bnb" = (
-/obj/machinery/button/door/directional/north{
-	id = "surgeryblock";
-	name = "Privacy Button";
-	pixel_x = -4;
-	pixel_y = 30;
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/obj/structure/table,
+/obj/item/bodybag,
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "bnc" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
@@ -16815,19 +16060,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bnf" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Lobby SW";
-	dir = 4;
-	name = "Medbay Lobby Camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/railing/corner,
-/obj/structure/sign/departments/psychology{
-	pixel_x = -32
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "bng" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Lab";
@@ -16852,20 +16084,8 @@
 /obj/structure/chair,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"bni" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "bnj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bnm" = (
@@ -16878,9 +16098,9 @@
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "bno" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
+/area/security/checkpoint/medical)
 "bnq" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
@@ -16888,50 +16108,15 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"bnr" = (
-/obj/structure/railing,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"bns" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall/r_wall,
-/area/medical/medbay/lobby)
-"bnt" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Pharmacy Maintenance";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/department/medical)
 "bnu" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
-	},
+/obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "bnv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/holopad,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
@@ -16982,11 +16167,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"bnG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bnH" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -30
@@ -17017,15 +16197,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"bnM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bnN" = (
 /obj/machinery/camera{
 	c_tag = "Base Construction";
@@ -17186,63 +16357,25 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
-"bos" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "bot" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/wrench,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"bou" = (
-/obj/machinery/door/airlock{
-	name = "Cleaning Closet"
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
-"bov" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "bow" = (
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"box" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"boy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/door_timer{
+	id = "medcell";
+	name = "Medical Cell";
+	pixel_y = -32
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"boz" = (
-/obj/effect/mapping_helpers/dead_body_placer,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
+/area/security/checkpoint/medical)
 "boA" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/engine,
 /area/science/explab)
-"boC" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "boD" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -17258,12 +16391,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"boF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "boG" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Lab";
@@ -17292,33 +16419,26 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "boJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"boK" = (
+"boL" = (
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
-"boL" = (
+"boM" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
-"boM" = (
+"boN" = (
 /obj/machinery/photocopier,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs)
-"boN" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/storage/box/ids,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "boP" = (
@@ -17397,16 +16517,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"bpg" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/camera{
-	c_tag = "Pharmacy";
-	dir = 8;
-	name = "Pharmacy Camera";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "bph" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 1
@@ -17574,12 +16684,8 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"bpL" = (
-/obj/item/beacon,
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
 "bpM" = (
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/item/beacon,
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "bpN" = (
@@ -17588,20 +16694,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"bpO" = (
-/obj/structure/table/optable,
-/obj/item/toy/figure/md,
-/obj/machinery/defibrillator_mount{
-	pixel_x = -28
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"bpP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "bpQ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
@@ -17618,17 +16710,8 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"bpT" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "bpU" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
+/obj/effect/mapping_helpers/dead_body_placer,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bpV" = (
@@ -17642,29 +16725,21 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"bpX" = (
+"bpY" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
-"bpY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs)
 "bqa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
 "bqb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -17747,17 +16822,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"bqq" = (
-/obj/structure/table/glass,
-/obj/item/hand_labeler,
-/obj/machinery/light/directional/east,
-/obj/machinery/button/door/directional/east{
-	id = "chemlock";
-	name = "Pharmacy Shutters";
-	req_one_access_txt = "5;69"
-	},
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "bqr" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/west,
@@ -17988,25 +17052,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"bre" = (
-/obj/item/mop,
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
-"brf" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bottle/ammonia,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron,
-/area/maintenance/starboard/fore)
-"brg" = (
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
-"brh" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "brj" = (
 /obj/machinery/camera{
 	c_tag = "Garden SE";
@@ -18027,43 +17072,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"brl" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"brm" = (
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
 "bro" = (
-/obj/structure/table/glass,
-/obj/item/scalpel,
-/obj/item/retractor,
-/turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"brq" = (
-/obj/machinery/camera{
-	c_tag = "Morgue S";
-	dir = 1;
-	name = "Morgue Camera";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
-"brs" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"brt" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
+"brq" = (
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bru" = (
@@ -18079,57 +17095,35 @@
 /obj/item/beacon,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"brx" = (
+"bry" = (
 /obj/effect/turf_decal/loading_area/red{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"bry" = (
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/medical_kiosk,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "brz" = (
-/obj/machinery/camera{
-	c_tag = "Surgery B";
-	dir = 1;
-	name = "Surgery B Camera";
-	network = list("ss13","medbay")
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery/room_b)
-"brA" = (
+/area/security/checkpoint/medical)
+"brB" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/grenades,
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"brB" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"brD" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "brE" = (
-/obj/item/kirbyplants/random,
-/obj/structure/sign/departments/chemistry/pharmacy{
-	pixel_x = 30
-	},
-/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/medical_kiosk,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"brF" = (
+"brG" = (
 /obj/machinery/shower{
 	dir = 1;
 	name = "emergency shower"
@@ -18142,25 +17136,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"brG" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/obj/machinery/newscaster/directional/east,
-/obj/structure/table/glass,
-/obj/item/stack/package_wrap,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"brH" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/customs)
-"brJ" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/iron,
-/area/security/checkpoint/customs)
 "brK" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
@@ -18220,22 +17195,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"brS" = (
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/starboard";
-	name = "Starboard Primary Hallway APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "brT" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable/multilayer/multiz,
@@ -18380,10 +17339,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bsj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/customs)
-"bsk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/southright{
@@ -18392,6 +17347,10 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/iron,
+/area/security/checkpoint/customs)
+"bsk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/checkpoint/customs)
 "bsl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -18569,13 +17528,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bsO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bsP" = (
 /obj/structure/sign/directions/command{
 	dir = 4;
@@ -18616,28 +17568,11 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bsY" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bsZ" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bta" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "btc" = (
@@ -18652,14 +17587,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bte" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/turf/closed/wall/r_wall,
 /area/medical/storage)
 "btf" = (
 /obj/machinery/firealarm/directional/north,
@@ -18694,12 +17622,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"btl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "btm" = (
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -18707,11 +17629,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"btq" = (
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "btr" = (
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	pixel_y = 36
+	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Morgue";
 	name = "Hallway Camera"
@@ -18720,10 +17642,6 @@
 /area/hallway/primary/starboard)
 "bts" = (
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"btt" = (
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "btu" = (
@@ -19069,9 +17987,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "buQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "buR" = (
@@ -19098,22 +18014,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"buV" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"buW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "buX" = (
 /obj/structure/cable,
 /obj/effect/landmark/event_spawn,
@@ -19359,14 +18259,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bvP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "bvQ" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Security Post";
@@ -19384,16 +18276,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bvR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "bvS" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -19424,16 +18306,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bvX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bvY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -19466,10 +18338,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"bwd" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bwe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -19551,15 +18419,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"bwu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "bww" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -19671,15 +18530,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bwG" = (
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_y = 32
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "bwH" = (
@@ -19857,9 +18714,6 @@
 	},
 /turf/open/floor/plating,
 /area/service/bar)
-"bxi" = (
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "bxj" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
@@ -20624,23 +19478,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"bzn" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue";
-	req_one_access_txt = "6;5;28"
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "bzo" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
@@ -25390,17 +24227,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bSo" = (
-/obj/machinery/modular_computer/console/preset/cargochat/medical,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
 "bSp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "bSr" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -25417,20 +24253,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"bSF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/navbeacon/wayfinding,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "bSG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -26401,12 +25223,11 @@
 /turf/open/floor/plating,
 /area/science/server)
 "bWI" = (
-/obj/structure/table,
-/obj/item/bodybag,
-/obj/item/storage/box/bodybags,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "bWJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/coldtemp,
@@ -26760,13 +25581,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"bYA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bYB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -26833,12 +25647,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
-"bYS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bYT" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
@@ -26895,9 +25703,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bZc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "bZe" = (
@@ -27004,8 +25810,8 @@
 /area/tcommsat/computer)
 "bZT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bZU" = (
@@ -27400,11 +26206,7 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "cbT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/plating/elevatorshaft,
 /area/medical/storage)
 "cbV" = (
 /obj/structure/cable,
@@ -27472,10 +26274,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
-"ccp" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "ccr" = (
 /obj/machinery/door/airlock/mining{
 	name = "Commissary";
@@ -28816,12 +27614,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"cin" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "cit" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -29058,13 +27850,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"cjv" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "cjw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -29154,15 +27939,6 @@
 /obj/item/stock_parts/subspace/filter,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cjI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "cjJ" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
@@ -29230,15 +28006,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"cjT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "cjW" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Engineering";
@@ -30426,11 +29193,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"cnU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "cnV" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -31444,8 +30206,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "crU" = (
-/turf/closed/wall,
-/area/security/checkpoint/medical)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "crV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -31502,10 +30266,6 @@
 /obj/item/toy/toy_xeno,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"csf" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "csg" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable,
@@ -31727,9 +30487,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "csU" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "csV" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -32244,7 +31010,8 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cuR" = (
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cuS" = (
@@ -32770,10 +31537,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cwF" = (
-/obj/machinery/chem_mass_spec,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "cwG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -32807,11 +31570,11 @@
 /area/cargo/office)
 "cwL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -33171,14 +31934,8 @@
 /turf/open/floor/iron,
 /area/space)
 "cyf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "cyj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -33372,11 +32129,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cyS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -33520,13 +32277,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"czD" = (
-/obj/structure/window,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/port/fore)
 "czE" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -33802,15 +32552,6 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"cAA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "cAD" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
@@ -33833,15 +32574,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/space)
-"cAF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "cAG" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -33897,11 +32629,8 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
 "cAQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/security/checkpoint/medical)
 "cAR" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -34019,15 +32748,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"cBm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "cBn" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Lobby N";
@@ -34085,7 +32805,7 @@
 /area/engineering/atmos)
 "cBw" = (
 /obj/structure/stairs/east,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cBx" = (
 /obj/machinery/meter,
@@ -34805,8 +33525,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_one_access_txt = "5;12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "cEy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
 	dir = 4
@@ -35062,10 +33786,9 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cFF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "cFK" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -35738,16 +34461,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cHG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "cHH" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -36563,13 +35276,7 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cKy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/light/blacklight/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "cKz" = (
@@ -36833,15 +35540,8 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cLv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "cLw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
@@ -37131,13 +35831,13 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "cMH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cMI" = (
@@ -37174,10 +35874,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"cMQ" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron,
-/area/maintenance/port/fore)
 "cMR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37279,14 +35975,9 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "cNm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/structure/table,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "cNn" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -39766,15 +38457,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"cVK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "cVL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -40015,16 +38697,9 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cWw" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/machinery/light/blacklight/directional/east,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "cWx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -40199,18 +38874,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/maintenance/department/medical)
-"cXh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Morgue Maintenance";
-	req_one_access_txt = "6;5;12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/fore)
 "cXi" = (
 /obj/structure/rack,
 /obj/item/tank/jetpack,
@@ -40286,13 +38951,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"cXv" = (
-/obj/structure/sign/directions/medical{
-	dir = 4;
-	pixel_y = 36
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "cXw" = (
 /obj/structure/sign/directions/science{
 	dir = 4;
@@ -40386,14 +39044,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
 "cXI" = (
-/obj/structure/cable,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "cXJ" = (
@@ -40402,9 +39053,8 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "cXK" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/customs)
@@ -40675,10 +39325,12 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "dGr" = (
-/obj/structure/closet/athletic_mixed,
-/obj/effect/turf_decal/bot_white,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
 /turf/open/floor/iron,
-/area/commons/fitness/recreation)
+/area/maintenance/central)
 "dIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -40686,13 +39338,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "dJu" = (
+/obj/machinery/power/smes{
+	charge = 500000
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "dLC" = (
@@ -41153,15 +39802,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "fCC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "fEA" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -41683,7 +40328,9 @@
 /turf/open/floor/iron/white,
 /area/science)
 "hBv" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/wardrobe/yellow,
+/obj/item/stock_parts/cell,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "hBT" = (
@@ -41749,16 +40396,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hTh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "hTK" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -41990,6 +40627,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "jes" = (
@@ -42044,8 +40682,12 @@
 /area/space)
 "jmW" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "jpa" = (
@@ -42303,15 +40945,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engineering/atmos)
-"kfD" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/maintenance/port/fore)
 "khy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -42356,12 +40989,10 @@
 /area/space)
 "kyq" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "kBU" = (
@@ -42393,10 +41024,6 @@
 "kId" = (
 /turf/open/floor/plating,
 /area/commons/dorms)
-"kJn" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "kJX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -42540,13 +41167,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
-"lgJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Fight Club"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/iron,
-/area/maintenance/port/fore)
 "ljM" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -42801,13 +41421,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "mrE" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "msL" = (
@@ -43314,9 +41928,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ogF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/white,
@@ -43523,11 +42135,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"piO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "pjl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43659,17 +42266,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"pYb" = (
-/obj/machinery/bounty_board/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "pZN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "qaf" = (
@@ -43766,15 +42366,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"qAH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44103,16 +42694,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"rSB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "rSY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -44160,6 +42741,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rYx" = (
@@ -44183,11 +42765,6 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/space)
-"sbw" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "sgD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -44635,9 +43212,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
 "ucU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "ueZ" = (
@@ -45240,10 +43815,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "xbW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/structure/table,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "xcr" = (
 /obj/effect/landmark/event_spawn,
@@ -45520,8 +44095,8 @@
 /area/security/interrogation)
 "ykc" = (
 /obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
+/turf/closed/wall,
+/area/maintenance/department/medical)
 
 (1,1,1) = {"
 aaa
@@ -66428,7 +65003,7 @@ aaa
 aaa
 aaa
 aaa
-aak
+aaa
 aak
 aak
 aak
@@ -66685,6 +65260,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aaj
 azn
 azn
@@ -66695,7 +65271,6 @@ azn
 azn
 azn
 aak
-aaa
 azQ
 aQc
 aQa
@@ -66946,13 +65521,13 @@ aaa
 aaa
 aaa
 aaa
-aak
-aak
-aaa
 aaa
 aak
 aak
 aaa
+aDq
+aak
+aak
 azQ
 aQa
 aRn
@@ -67200,6 +65775,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aaq
 aaa
 aam
@@ -67209,7 +65785,6 @@ azn
 azn
 azn
 aak
-aaa
 azQ
 aQa
 aQa
@@ -67462,11 +66037,11 @@ aaa
 aaa
 aaa
 aaa
-aak
-aak
-aak
-aak
 aaa
+aak
+aak
+aak
+aak
 azQ
 aQw
 aQa
@@ -67719,11 +66294,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aaj
 azn
 azn
 aak
-aaa
 azQ
 azQ
 azQ
@@ -67970,16 +66545,16 @@ aaa
 aaa
 aaa
 aaa
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
 aaa
-azQ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aak
+aak
+aOd
 aOd
 aOd
 aOd
@@ -68227,16 +66802,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-azQ
-azQ
-aDr
-aDr
-aDr
-aDr
-aDr
-azQ
-azQ
+aak
 aak
 azQ
 bfq
@@ -68484,16 +67059,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-azQ
-aHL
-aIE
-aSe
-aJj
-aJj
-aLM
-aMu
-azQ
+aaa
 aaa
 azQ
 aAi
@@ -68741,16 +67316,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-azQ
-aMg
-aIE
-aJj
-aVz
-aJj
-aLM
-aMu
-azQ
+aak
 aak
 azQ
 aAi
@@ -68998,15 +67573,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-azQ
-aHM
-aIE
-aJj
-aJj
-aJj
-aLO
-kfD
 azQ
 azQ
 azQ
@@ -69254,16 +67829,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-aak
-azQ
-aHM
-aOQ
-aSo
-aJj
-aSo
-czD
-aMu
 azQ
 nNd
 aOK
@@ -69511,16 +68086,16 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-azQ
-aHO
-aIG
-aIG
-aXn
-aIG
-aIG
-aMw
 azQ
 aOe
 aAi
@@ -69770,14 +68345,14 @@ aaa
 aaa
 aak
 aak
-azQ
-aMv
-aOR
-aIG
-aKg
-blq
-cMQ
-aAi
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
 azQ
 azQ
 azQ
@@ -70034,7 +68609,7 @@ aDr
 azQ
 azQ
 azQ
-lgJ
+azQ
 azQ
 aAi
 aAi
@@ -80833,10 +79408,10 @@ rYR
 aOn
 aPg
 aQu
-aqU
+aTw
+aQu
 bZc
-bZc
-aUz
+aQu
 aQu
 aWC
 aOn
@@ -81090,11 +79665,11 @@ rYR
 aOn
 aPh
 aQu
-aOn
+aMu
 aTv
 aTv
-aOn
-kJn
+aOQ
+aQu
 aWD
 aOn
 aYO
@@ -81348,8 +79923,8 @@ aOn
 aPi
 dGr
 aOn
-aOn
-aOn
+aNg
+aNg
 aOn
 aTx
 aWE
@@ -81601,15 +80176,15 @@ aAs
 aNA
 aak
 aak
-aOn
+aIG
+aPj
 aPj
 aOn
 aOn
-aak
-aak
 aOn
 aOn
-aOn
+aQu
+aPG
 aOn
 aak
 aak
@@ -81858,16 +80433,16 @@ aBi
 aNA
 aak
 aak
+aIG
+aPj
+aPj
+aIG
 aak
 aak
-aak
-aak
-aaa
-aak
-aak
-aak
-aak
-aak
+aOn
+aQu
+aRc
+aOn
 aak
 aaa
 aak
@@ -82114,18 +80689,18 @@ aLj
 aAs
 aNA
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aak
+aIG
+aPj
+aPj
+aIG
+aak
+aak
+aOn
+aOn
+aOn
+aOn
+aak
 aaa
 aak
 aYK
@@ -82371,19 +80946,19 @@ aMo
 azU
 azU
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aak
+aIG
+aPj
+aPj
+aIG
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
 aak
 aYK
 bdh
@@ -82628,20 +81203,20 @@ aLj
 aNA
 aak
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
+aIG
+aIG
+dGr
+dGr
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
 aYK
 aZO
 aUH
@@ -82884,21 +81459,21 @@ aJw
 aMd
 aNA
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aak
+aIf
+aPj
+aPj
+aPj
+aMv
+aNK
+aOk
+aOR
+aPu
+aPj
+aMv
+aNK
+aTS
+aVO
 aYK
 aZO
 aUH
@@ -83141,24 +81716,24 @@ aJv
 aMd
 aNA
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aak
-aYK
-aZO
-bdf
+aIf
+aPj
+aPj
+aKA
+aPj
+aPj
+aPj
+aPj
+aPj
+aIU
+aPj
+aPj
+aTT
+aQD
+aXh
+bey
+aXn
 bgh
 bhm
 biH
@@ -83399,20 +81974,20 @@ aLj
 aNA
 aak
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
+aIf
+aIU
+aJA
+aKE
+aMw
+aMw
+aMw
+aMw
+aMw
+aRd
+aSJ
+aPj
+aUz
+aVX
 aYK
 aYK
 bsv
@@ -83656,21 +82231,21 @@ aLj
 azU
 azU
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aYK
+aIf
+aPj
+aJA
+aLn
+aMy
+aMy
+aMy
+aMy
+aMy
+aRh
+aSJ
+aTC
+aUK
+aWw
+aSE
 aSP
 bdf
 aZO
@@ -83680,8 +82255,8 @@ bkj
 aYK
 bmW
 jVy
-bpL
-bre
+jVy
+jVy
 aYK
 btm
 btm
@@ -83913,22 +82488,22 @@ aMT
 aQB
 aNA
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aYK
-bdj
+aIf
+aPj
+aJB
+aLn
+aMz
+aNL
+aOt
+aOU
+aMy
+aRh
+aSJ
+aTD
+aUL
+aWw
+aSE
+aZO
 aUH
 aZO
 aZO
@@ -83938,9 +82513,9 @@ aYK
 bmX
 jVy
 bpM
-brf
-aYK
-btn
+jVy
+bdj
+btm
 btm
 crm
 btm
@@ -84170,21 +82745,21 @@ azU
 aLk
 aNA
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aak
-aak
-aYK
+aIf
+aPj
+aJC
+aLn
+aMG
+aMy
+aOu
+aMy
+aMy
+aRh
+aSJ
+aTD
+aUM
+aPj
+aSE
 aZO
 aUH
 aZO
@@ -84192,12 +82767,12 @@ bhJ
 biI
 biI
 aYK
+bal
+jVy
+jVy
+jVy
 aYK
-bou
-aYK
-aYK
-aYK
-btm
+btn
 btm
 buN
 btm
@@ -84421,41 +82996,41 @@ aDP
 aGy
 aak
 aak
-aak
-aak
+azU
+aEZ
 azU
 aMd
 aNA
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aYK
-aYK
-aYK
+aIf
+aPj
+aJA
+aLn
+aMO
+aNP
+aMy
+aMy
+aPE
+aRh
+aSJ
+aTI
+aUN
+aPj
+aSE
 aZO
 cwL
-cnr
-cnr
-cnr
-cnr
-cnr
-cnr
-cnr
-cnr
-cnr
-rSB
+aZO
+aZO
+aZO
+aZO
+aYK
+bap
+bbh
+bbm
+jVy
+aYK
 buQ
-buQ
+btm
 jmW
 btm
 btm
@@ -84678,39 +83253,39 @@ aDP
 aGy
 aak
 aak
-aak
-aak
+azU
+azU
 azU
 aLj
 aNA
-aak
-aak
-aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aak
-aak
-aak
-aak
-aYK
+aIf
+aIf
+aPj
+aJA
+aLn
+aMP
+aMy
+aMy
+aMy
+aMy
+aRh
+aSJ
+aTJ
+aUW
 aRG
-aYK
+aSE
 aZO
 beF
-bgi
-bgi
-bgi
-bgi
-bgi
-bgi
-bgi
-bgi
-bgi
-bgi
+aZO
+aZO
+aZO
+aZO
+aYK
+aYK
+aYK
+aYK
+aYK
+aYK
 btm
 btm
 qLZ
@@ -84940,37 +83515,37 @@ aak
 azU
 aLj
 azU
-azU
-azU
-aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
+aPj
+aIG
+aJj
+aIU
+aLM
+aMQ
 aQK
-aEd
-aEd
-aEd
-aEd
-aEd
-aEd
+aQK
+aQK
+aQK
+aRF
+aSJ
+aTD
+aUY
+aWN
+aSE
 aZO
 beE
-bgi
-bhr
 bWI
-brg
-brg
-brg
-brg
-biD
-brg
-bgi
-btm
-btm
-qLZ
+bWI
+bWI
+bWI
+bWI
+bWI
+bWI
+bWI
+bWI
+bdo
+bdF
+bdF
+pZN
 btm
 btm
 bxm
@@ -85195,36 +83770,36 @@ aak
 aak
 aak
 azU
-aLj
-azU
+aFW
+aHM
 aML
-azU
-aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aQK
+aIS
+aML
+aJI
+aLO
+aMR
 aQD
-bba
-bba
-bba
-bba
+aOv
+aQD
+aQD
+aQD
+aQD
+aTK
+aVo
+aWP
 aSE
-aTB
-aUI
-bgi
-bhs
-biE
-bkm
-blI
-biE
-biE
-biE
-brh
-bgi
+bdh
+aUQ
+aZO
+aZO
+aZO
+aZO
+aZO
+aZO
+aZO
+aZO
+aZO
+aYK
 nBH
 btm
 qLZ
@@ -85454,34 +84029,34 @@ aak
 azU
 aLj
 azU
-azU
-azU
-aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aQK
+aIE
+aIG
+aJy
+aKg
+aMf
+aMS
+aKg
+aOw
+aKg
+aMf
 aQE
-aIT
-aHx
-aHx
-aHx
-aEd
+aQE
+aPj
+aKA
+aWR
+aSE
 aZO
 aUQ
-cXh
-biN
-cHG
-bkn
-blJ
-biE
-bos
-biE
-biE
-bzn
+bgi
+bgi
+bgi
+bgi
+bgi
+bgi
+bgi
+bgi
+bgi
+bgi
 nBH
 buh
 kyq
@@ -85710,38 +84285,38 @@ aAc
 aak
 azU
 aLj
-aIP
 azU
-aak
-aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aQK
-bwu
-aIT
-crU
-crU
-aRO
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aIG
+aEd
 crU
 crU
 crU
 crU
+crU
+aYK
+aZO
+beE
+aXJ
 bhu
 cKy
 bko
-bma
-bdi
-boz
+brq
+brq
+brq
 biE
 brq
 bgi
 nBH
 btm
-buR
+jmW
 btm
 bwr
 bxo
@@ -85970,35 +84545,35 @@ aLj
 aIP
 aMM
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aak
-aQK
+aak
+aak
+aak
+aak
+aak
+aak
+aEd
 aQF
-aIT
-crU
+fCC
 aRE
-aRU
+aRE
+fCC
 aSI
-aTC
+cnr
 bfe
-crU
-bhR
-cKy
-bkB
-brt
-brt
-boC
-bpU
-brt
 bgi
-btn
+bhR
+cLv
+cLv
+cLv
+cLv
+cLv
+bpU
+cLv
+bgi
+bdG
 btm
-buR
+jmW
 btm
 bws
 bxo
@@ -86231,31 +84806,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aak
-aQK
+aKh
+aOz
+aEd
 aQG
 aIT
-crU
-aRF
-aSD
-aSJ
-aTD
-aVo
-crU
+aHx
+aHx
+aHx
+aYK
+aZO
+aZO
 bgi
-biO
+aXN
+cLv
+cLv
+blM
+cLv
+cLv
+cLv
+cLv
 bgi
-blM
-blM
-blM
-blM
-blM
-blM
-btq
 btm
-buR
+btm
+jmW
 btm
 cXA
 bxo
@@ -86489,30 +85064,30 @@ aak
 aak
 aak
 aak
-aak
-aak
-aQK
+aOz
+aPm
+aEd
 aWL
 aIT
-crU
-aZQ
-bbc
-bco
-bdo
-beI
-beJ
+bdK
+bdK
+bdK
+bdK
+bgi
+bgi
+aXK
 aXH
 cLv
-beO
+cLv
 blN
 bmY
-bov
-bpO
-brl
-blM
-cXv
+cLv
+cLv
+cLv
+bdv
 btm
-buR
+btm
+jmW
 btm
 btm
 bxm
@@ -86741,35 +85316,35 @@ aLj
 aBi
 aEd
 aPC
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
+aEd
+aEd
+aEd
+aEd
+aEd
+aEd
+aEd
+aEd
 bwG
 aIT
-crU
-cnU
-bbd
-crU
-aTM
-beJ
-beJ
+bdK
 beO
+beO
+beO
+bgi
+beJ
 cLv
-beO
-bcm
-box
-bow
-bow
-brm
-blM
+aXH
+cLv
+cLv
+bpU
+cLv
+cLv
+cLv
+cLv
+bgi
 btr
 btm
-buR
+jmW
 btm
 btm
 bxm
@@ -86998,35 +85573,35 @@ bla
 aHx
 kGY
 aNW
-aQK
+aEd
 aHx
 aHx
 aHx
 aHx
 aOs
 aHx
-aHx
-aHx
+aEd
+aRN
 aIT
-crU
-aZS
-bcp
-cnU
+bdK
+beO
+beO
+beO
 bdp
-beO
+cLv
 bgl
-beO
+aYb
 cWw
-cEt
-blO
-bna
-boy
-bow
 bro
-blM
+bro
+bro
+bro
+bbn
+bro
+bgi
 bts
 btm
-buR
+jmW
 btm
 btm
 bxo
@@ -87253,8 +85828,8 @@ aak
 aEd
 aRb
 bbl
-aNc
 bbl
+bvL
 bcJ
 aPW
 bcJ
@@ -87265,25 +85840,25 @@ bbl
 bvL
 bwJ
 aIT
-crU
-baf
-bbq
-bcv
-bdq
-beL
-aVG
-bhz
-cAQ
+bdK
 beO
-blM
-bnb
-bpP
-bow
-bhx
-blM
+beO
+beO
+cAQ
+cAQ
+aVG
+cAQ
+cAQ
+cAQ
+cAQ
+cAQ
+cAQ
+cAQ
+cAQ
+cAQ
 btm
 btm
-buR
+jmW
 btm
 btm
 bxo
@@ -87508,39 +86083,39 @@ aak
 aak
 aak
 aEd
-aLn
-aLp
-aLp
-aLp
-aLp
-aLp
-aRh
+aIT
 aHx
 aHx
-aTS
+csU
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
 aHx
 bla
 aHx
 aXM
-crU
-bag
-bbu
-cnU
-bwd
+bdK
 beO
+beO
+beO
+cAQ
+aXw
 aVP
 bhA
-cLv
+aZb
 bks
-blN
+bac
 bow
-bow
-bow
+cAQ
+bbq
 bhB
-blM
-btt
+bdy
 btm
-buR
+btm
+jmW
 buR
 buR
 bxy
@@ -87761,43 +86336,43 @@ aFZ
 aFM
 aAd
 aak
-aIf
+aaa
+aak
 aEd
+ykc
+aFX
 aEd
-aEd
-bla
-aLp
-aMO
-aNI
-aOt
-aLp
-aQK
+aHx
+csU
+aHx
+bdK
+bdK
 aRR
-aSH
-aSH
-aSH
-aVK
-aSH
-aSH
-aRc
-crU
-crU
-crU
-aTN
+bdK
+bdK
+bdK
+bdK
+bdK
+bdK
+bdK
 beO
 beO
 beO
-bmZ
-beO
-blN
+cFF
+aXC
+cyf
+aYi
+cyf
 bno
-bow
-bow
+cyf
+bno
+bbi
+cyf
 brz
-blM
-btm
-btm
-btm
+bdz
+bdH
+bdH
+beI
 btm
 btm
 bxt
@@ -88018,43 +86593,43 @@ aFZ
 aFM
 aAd
 aak
-aIf
-aIR
-aJy
+aaa
+aak
+aEd
 dJu
-bwJ
-aLp
-aMP
+aIT
+aEd
+aEd
 aNJ
-aOu
-aPt
-csf
+aEd
+bdK
+beO
 aRK
-aSH
-aTI
-aUK
-bvR
-aWP
-aXC
-aYV
-aZW
-bbh
-aZV
-aUF
 beO
 beO
 beO
-cLv
 beO
-blN
-bdP
+beO
+beO
+beO
+beO
+beO
+beO
+cFF
+aXD
+bno
+bfj
+aZc
+bfj
+bfj
+bfj
 beK
 bfj
 bkQ
-blM
+bbi
 btu
 btu
-btu
+beU
 btu
 btu
 bxt
@@ -88275,43 +86850,43 @@ aEQ
 aFN
 aAd
 aak
-aIf
-aIS
+aaa
+aak
 aEd
+aFU
+aHx
+aEd
+aHx
 bla
-aLp
-aLp
-aMQ
-aNK
-aOv
-aPt
-csU
-bYS
-aSH
-aTJ
-aUL
-bvP
-bxi
-aXD
-aYV
-aZX
-bbi
-aZV
-bdt
-bfb
-bwd
-bwd
-blL
+aHx
+bdK
 beO
-bhD
-bhD
-bhD
-bhD
-bhD
-bhD
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+cFF
+bfb
+cyf
+cyf
+blL
+aZS
+bno
+cyf
+bbi
+bbu
+bco
+cAQ
 btn
 btm
-btm
+jmW
 btm
 bws
 bxt
@@ -88532,43 +87107,43 @@ aER
 aFO
 aAd
 aak
-aIf
+aaa
+aak
+aEd
 aIT
-aJz
-bla
-aLp
+aIT
 aMe
-aMR
-aNL
-aOw
-aPu
-cFF
-bmL
-aSH
-aTK
-aUM
-aVN
-aWR
-aXE
-aYV
-aZY
-bbj
-bcs
+aHx
+bla
+aHx
+bdK
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
 cFF
 cyf
-beL
-cFF
+cyf
+aYj
 cNm
-beO
-bhF
-bnf
-bpT
-bpT
-brs
-bhD
+aZV
+bae
+cAQ
+cAQ
+cAQ
+cAQ
+cAQ
 btm
 btm
-btm
+jmW
 btm
 btm
 aVx
@@ -88789,39 +87364,39 @@ aES
 aFP
 aAd
 aak
-aIf
-aIU
+aaa
+aak
 aEd
-bla
-aLp
-aMf
-aMS
+aFV
+xjL
+aEd
+aHx
 aNM
 aOx
 aPt
+aMg
 beO
-cyS
-aSH
-aTL
-aUN
-aVO
-bxi
-aXF
-aYV
-aZX
-bbk
-aZV
-aUG
-cyS
-bgn
-bhD
-bhF
-bhF
-bhD
-bnr
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+cAQ
+aXE
+cFF
+cFF
+cFF
+cFF
+cAQ
+cAQ
 bqo
 bqo
-brD
+bqo
 bhD
 btv
 cJH
@@ -89046,43 +87621,43 @@ aFk
 aGq
 aAd
 aak
-aIf
+aaa
+aak
+aEd
+ykc
 aEd
 aEd
+aHx
 bla
-aLp
-aMy
-aNg
-aNZ
-aOU
-aPt
+aHx
+bdK
+aQN
 beO
-cyS
-aSH
-aTT
-aUW
-bvR
-aXa
-aXN
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
 aYV
-baj
-bbw
-aZV
-pYb
-cyS
-bwd
-bhF
 biP
 bck
 blR
-bnh
+bbc
 bky
 bky
 blQ
 bhD
 esy
 btm
-cVK
+crm
 btm
 btm
 aVx
@@ -89303,32 +87878,32 @@ aAd
 aAd
 aAd
 aak
+aaa
+aak
 aak
 aEd
-aJA
+aLp
+aHx
+aHx
 bla
-aLp
-aLp
-aLp
-aLp
-aLp
-aLp
+bdK
+bdK
 aQN
-aRN
-aSH
-aSH
-aSH
-aVX
-aSH
-aSH
-aSH
-aZV
-aZV
-aZV
-bdv
-cyS
-bwd
-bhF
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+aYY
 bky
 bky
 bky
@@ -89339,7 +87914,7 @@ bru
 bhD
 cpH
 btm
-cVK
+crm
 btm
 adh
 bxr
@@ -89561,42 +88136,42 @@ aak
 aak
 aak
 aak
+aak
+aak
 aEd
-aJB
-aKz
+aFY
+aHO
 aHx
-aHx
+bla
 bdK
-aNP
-aMU
 aPv
-bcb
-bnM
-aSQ
-cFF
-bsO
-bvX
-cFF
-cFF
-bYA
-cFF
-cFF
-aSQ
-cFF
-bha
-bwd
-bhD
-biR
-bkv
+cyS
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+aYZ
+bky
+bky
 bky
 bky
 bky
 bky
 brv
-bhF
+bsh
 cpH
 btm
-cVK
+crm
 btm
 bww
 bxt
@@ -89810,50 +88385,50 @@ axP
 aAN
 avX
 avX
-aCK
-aQC
-aQC
-aQC
-aGr
+aak
+aak
 ahl
+aQC
+aQC
+aQC
+alW
+aqU
 aEd
 aEd
 aEd
 aEd
-aKA
+aIe
 aHx
-aHx
+bla
 bdK
-aNP
-aOz
-beO
+aPv
 cyS
 beO
-ccp
-beO
-aUY
-bwd
-aXh
-aYb
-aZf
 beO
 beO
-bcy
 beO
-cyS
-bwd
-bhD
-biS
-bkv
-blT
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+aYY
 bky
 bky
 bky
 bky
-bhF
+bky
+bky
+bky
+bdA
 cpH
 btm
-cVK
+crm
 btm
 bwx
 aek
@@ -90067,50 +88642,50 @@ azj
 aAO
 avX
 avX
-aQC
-aak
-aak
 aak
 aak
 aQC
-ahn
+aak
+aak
+aak
+aak
+aQC
+aCK
 aHx
 aHx
-aJC
+aGr
+aHx
+aHx
 bla
-aHx
-aHx
 bdK
-aNP
-aOA
+aPv
+cyS
+bta
+bta
+bta
+bta
+bta
+bta
 beO
-cyS
-aWV
-aSK
-aSK
-aUR
-aSK
-aWU
-bdK
-aYY
-ccp
-bdK
-bdK
-cuR
-cyS
-bwd
-bhG
-bky
-bkw
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+bhD
+aZf
 bkv
-bni
+bky
+bky
 bky
 bky
 bky
 bsh
 cpH
 btm
-cVK
+crm
 btm
 bww
 bxu
@@ -90324,6 +88899,8 @@ azm
 azl
 avX
 aCe
+aak
+aak
 aQC
 aak
 ahv
@@ -90334,37 +88911,35 @@ ahv
 ahv
 ahv
 aEd
-aKA
-aMp
-aMp
-aMp
-aMp
-aMp
-beO
+aIe
+aHx
+bla
+bdK
+bdK
 cyS
-aWV
-aSL
-aTO
 bta
-aVT
-bad
-aXJ
-aYZ
+bta
+bta
+bta
+bta
+bta
 beO
-bbm
-bcu
-bdy
-cyS
-sbw
+beO
+beO
+beO
+beO
+beO
+beO
+beO
 bhD
 biU
-bkx
+bkv
 blU
 bnj
 boE
 bky
 bky
-bSF
+bhF
 cpH
 buh
 jdl
@@ -90581,50 +89156,50 @@ axP
 azl
 avX
 avX
-aDd
+aak
+aak
+ahn
 aak
 ahv
-aEU
-aFT
 aGC
 aHy
 bgk
-ahv
+aDd
 aJD
+ahv
+bdL
+aHx
+aHx
 bla
-aMp
-alT
-alW
-aMz
-aMp
+bdK
 cuR
 aQS
-aWV
-aSM
-aTP
+bta
+bta
 bte
-aVU
-aWV
-aXK
+bte
+bte
+aSe
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
 aZa
-bac
-bbn
-bcu
-bdz
-cyS
-aWN
-bhD
-biV
-bkv
+bky
+aZW
 bkv
 cXI
 bky
 bky
 bky
-bsh
+bhF
 cpH
 btm
-buT
+adf
 btm
 bww
 aek
@@ -90838,50 +89413,50 @@ azO
 axp
 avX
 avX
-aDh
-aDH
-ahv
+aak
+aak
+alT
 aEV
-aFU
+ahv
 aGD
 ahU
 aIi
-ahv
+aDh
 aJE
-aRb
-aLs
-aMl
-aOk
-aNV
-aPG
-beO
-cyS
-aWV
-aSN
-aTQ
+ahv
+aTe
+aHx
+aHx
+bla
+bdK
+aKs
+aQT
+bta
+bta
+bte
 cbT
-aVV
-aWV
-aXL
-aZb
+cbT
+aSo
 beO
-cin
-bcu
-bdA
-beU
-bwd
+beO
+beO
+beO
+beO
+beO
+beO
+beO
 bhD
 biW
-bkv
+aZX
+baf
 bky
-mrE
 bky
 bky
 bky
 bhF
 cpH
 btm
-buT
+adf
 btm
 bww
 bxv
@@ -91095,50 +89670,50 @@ avX
 avX
 avX
 avX
-aaa
+aak
+aak
+aak
 aak
 ahv
-aEW
-aFV
 aGE
 aHz
 aIj
+aDH
+aFp
 ahv
 aHx
+aHx
+aHx
 bla
-aMp
-aMm
-bgr
-aOk
-aOB
+bdK
+bdK
+aQT
+bta
+bta
+bte
+cbT
+cbT
+aSo
 beO
-cyS
-aWV
-aSO
-aTR
-aUZ
-aVW
-aWV
-aXK
-aZc
-bae
-cjv
-bcu
-bdz
-cAA
-aXw
-bhH
-bky
-bky
-bky
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+bhD
+aZn
+bkv
+bkv
 mrE
 bky
 bky
-brx
+bky
 bhF
 cpH
 btm
-buT
+adf
 btm
 bww
 bxw
@@ -91352,50 +89927,50 @@ avX
 avX
 avX
 avX
+aak
+aaa
 aaa
 aak
 ahv
-aEX
-aFW
 aGF
 aHA
 aIk
 aIV
 bba
 aOD
-aLu
-aMn
-aNa
+fCC
+aRE
+aRE
 aNU
-aPG
-beO
+aHx
+bdK
 aQT
-aWV
-aSV
-aFR
+bta
+bta
+bte
 cbT
-aWj
-aWV
-aYi
-bYS
-bal
-cjv
-bcu
-bdB
-cAF
-cEt
-bhN
+cbT
+aSD
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+bhD
 xbW
-xbW
-xbW
-hTh
+bkv
+bky
+bky
 bky
 bky
 bry
 bhD
-cpH
+bdI
 btm
-buT
+adf
 btm
 bww
 bxv
@@ -91610,38 +90185,38 @@ aaa
 cXf
 aaa
 aaa
+aaa
+aaa
 aak
 ahv
-aEY
-aFX
 aGG
 ayj
 aIl
-ahv
+aEU
 aJG
-bla
-aMp
-aOk
-aNb
+ahv
+aGJ
+aHx
+aHx
 aNV
-aMp
+aRE
 aMV
-cyS
-aWV
-aSK
-aSK
-aVd
-aSK
-aWU
-bdK
-aZn
-piO
-bdK
-bdK
-bdC
-beX
-bgt
-bhH
+aMl
+bta
+bta
+bte
+bte
+bte
+bte
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+bhW
 bjd
 bky
 bky
@@ -91650,9 +90225,9 @@ bky
 bky
 brE
 bhD
-esy
+cpH
 btm
-buT
+adf
 btm
 bwy
 aek
@@ -91867,45 +90442,45 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
 ahv
-aEZ
-aFY
 aGH
 aHC
 aIm
-ahv
+aEW
 aJH
-bla
-aMp
-aMp
-aMp
-aMp
-aMp
-beO
-cyS
-ccp
-beO
-beO
-aVq
-beO
-aXl
-aYj
-aZo
+ahv
+aHB
+aHx
+aIR
+bwJ
+aHx
+bdK
+aMm
 beO
 beO
-bcE
 beO
-cyS
-bgu
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
+beO
 bhW
-bhW
-bkJ
-bmg
-bns
-bmg
-bkJ
-bhW
+bky
+bky
+bky
+bky
+bky
+bky
+bcp
 bhD
 btn
 cJH
@@ -92124,46 +90699,46 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
 ahv
-aFp
-aHB
 aGI
 aHD
 aIn
+aEX
+aFT
 ahv
-aJH
+aHB
+aHx
 bla
+aHx
+aHx
 bdK
-aMG
-aTz
-aPE
-beO
-beO
 cMH
 aSg
 aSX
-cEt
-btl
-cEt
-cEt
-cEt
+aOA
 bZT
-cEt
-aSX
-aSg
-cEt
-cAQ
-bgv
+bZT
+bZT
+bZT
+bZT
+aVq
+beO
+aXl
+beO
+beO
+beO
 bhK
-biZ
+bhK
 bkC
 blW
-bnq
+bhL
 blW
 bkC
-brA
 bhK
+bdB
 btm
 btm
 adf
@@ -92381,6 +90956,8 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
 ahv
 ahv
@@ -92389,35 +90966,33 @@ ahv
 ahv
 ahv
 ahv
-aJI
+aHE
+aHx
 bla
-bdK
-aPm
-aPB
-beO
-beO
-beO
-aPH
-aRT
-aRT
+aEd
+aEd
+aEd
+aVa
+aVa
+aNZ
 aTU
 aVa
-aTU
-aTU
-aTU
+bte
 aZh
-aTU
-aRT
-aRT
-bdF
-cyS
-bwd
+aZh
+aZh
+aVz
+aXa
+bte
+beO
+beO
+beO
 bhL
-blX
+aZo
 bkD
-blX
+bag
 bnq
-blX
+bag
 bkD
 brB
 bhK
@@ -92638,45 +91213,45 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
 aak
 aak
 aEd
-aGJ
-aHE
-aIo
-aEd
+aIJ
+aEY
 hBv
-aKE
+aEd
 aNG
-aPn
+aHx
 bSp
 cEt
-cEt
-cEt
+aJz
+aKz
 aPI
-aRT
+aMU
 aSS
 aTX
 aVb
-aVY
+bte
 aWX
 aXO
 aZi
-aTX
+aVK
 bbr
-aRT
-bdG
-cyS
-bwd
+bte
+beO
+beO
+beO
 bhM
 blX
 bkE
-blY
-cwF
-boF
-bkE
 blX
+bnq
+blX
+bkE
+bcs
 bhK
 btm
 btm
@@ -92897,43 +91472,43 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
 aEd
-aGJ
-aIe
 aIJ
 aJo
 aKi
 aLb
-aEd
+aPo
 aPo
 aPB
-beO
-beO
-beO
-aQX
-aRT
+aEd
+csU
+aHx
+aVa
+aNb
 aST
 aTW
 aVc
-aTX
+bte
 aWY
-aTX
+aSQ
 aZj
 ape
 bbs
-aqe
-bdH
-cBm
-cEt
+bte
+beO
+beO
+beO
 biX
-ucU
+blX
 ucU
 ogF
 bnu
 boJ
+ucU
 blX
-brF
 bhK
 btm
 btm
@@ -93154,42 +91729,42 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
 aEd
 aHx
 aHx
 aHx
 aEd
-aKs
+aHL
+aHx
 aHx
 aEd
-bSo
-aPB
-beO
-beO
-beO
-aPJ
-aRT
+csU
+aHx
+aVa
+aNc
 aSU
-aTX
-aTX
-aTX
+aOB
+aPn
+bte
 aWZ
-aTX
-aTX
-aTX
+aTz
+aTL
+aVN
 bbt
-aRT
-bdI
-bfb
-bgw
+bte
+beO
+beO
+beO
 bhK
-bjg
-bkP
-bmq
+blX
+blX
+blX
 bnv
-bpg
-bqq
+blX
+blX
 brG
 bhK
 btx
@@ -93411,44 +91986,44 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
 aEd
 aEd
 aEd
 aEd
 aEd
-aQK
-aQK
-aQK
-aQK
-aQK
-aRd
-ccp
-ccp
-aQd
-aRT
+aEd
+aEd
+aEd
+aEd
+csU
+aHx
+aVa
+aNb
 aTb
 aUk
-aTX
-aUk
-aTX
-aUk
-aTX
+aPn
+bte
+aSH
+aTB
+aTM
 bao
 bbH
-aRT
-bdT
+bte
 cBw
-aXz
+cBw
+cBw
 bhK
+aZQ
+aZY
+baj
+blX
+bbj
+bbw
+bcu
 bhK
-aQK
-aQK
-bnt
-aQK
-aQK
-aQK
-aQK
 bty
 btm
 adf
@@ -93668,8 +92243,8 @@ aaa
 aaa
 aaa
 aaa
-aak
-aak
+aaa
+aaa
 aak
 aak
 aak
@@ -93681,34 +92256,34 @@ aak
 aak
 ykc
 csU
-beO
-aPJ
-aRT
-aRT
-aRT
-aRT
-aRT
-aRT
-aRT
-aRT
-aRT
-aRT
-aRT
+aHx
+aVa
+aVa
+aVa
+aVa
+aVa
+bte
+bte
+bte
+bte
+bte
+bte
+bte
 bdK
 bdK
 bdK
-aQK
-aEd
-bkH
-aIT
-bla
-aIT
-aIT
-dJu
-bsY
-bwC
-bwC
-buV
+bhK
+bhK
+bhK
+bhK
+bbd
+bhK
+bhK
+bhK
+bhK
+btm
+btm
+qLZ
 btm
 btm
 bww
@@ -93937,35 +92512,35 @@ aaa
 aaa
 aak
 ykc
-beO
-beO
-blL
+csU
+aHx
+aHx
 aEd
 aTe
-aIT
-aWw
-aIT
-aIT
-aIT
-aIT
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
 bah
 xjL
-bcw
+aHx
 bdL
-aNd
-bgy
-bhO
+bdL
 aEd
+aHx
+aHL
 bkI
-bnG
-qAH
-bnG
-bnG
-brS
-aEd
-btn
-btm
-buW
+bcJ
+kYQ
+bcJ
+bcJ
+bcJ
+bdC
+bdN
+bdF
+pZN
 btm
 btm
 bww
@@ -94194,32 +92769,32 @@ aak
 aak
 aak
 ykc
-beO
-beO
+bgE
+fCC
 fCC
 cXg
 bbl
-bnG
-bnG
-bnG
-aXs
-bnG
-bnG
+fCC
+fCC
+fCC
+fCC
+fCC
+fCC
 bbl
-cjI
-bcw
-bdM
-aHx
-bgz
-bhP
+fCC
+fCC
+fCC
+aXF
 aEd
+aHx
+aHx
 bla
 aHx
-bje
-bje
-bje
-bje
-bje
+aHx
+aHx
+aHx
+bcv
+aEd
 btA
 btm
 buX
@@ -94451,31 +93026,31 @@ aaa
 aaa
 aak
 ykc
-aRd
-aRd
-aRd
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
-aIT
-bwu
-bcw
-bdN
-bfd
-bdM
-bhQ
+aHx
+aHx
+aHx
 aEd
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
+aHx
+csU
+aEd
+aHx
+aHx
 bla
 bmd
 bje
-boK
-bpX
-brH
+bje
+bje
+bje
 bje
 aJu
 btU
@@ -94707,33 +93282,33 @@ aaa
 aaa
 aaa
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aQK
-aIT
-bwu
 aEd
 aEd
 aEd
 aEd
 aEd
 aEd
+aEd
+aEd
+aEd
+aEd
+aEd
+aEd
+aEd
+aEd
+aEd
+aHx
+csU
+aEd
+aHx
+aHx
 bla
 bme
 bje
 boL
 bpY
-brM
-bsj
+bcy
+bje
 btB
 btm
 buY
@@ -94963,33 +93538,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aak
-aQK
-aIT
-cjT
-bcJ
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aEd
+aHx
 bgE
-bgE
-bgE
-bnG
+aXL
+fCC
 bjv
 kYQ
 bmx
 bje
 boM
 cXK
-brJ
+brM
 bsk
 btB
 btm
@@ -95231,22 +93806,22 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 aak
-aQK
-bap
+aEd
+aEd
+aEd
+aEd
+aHx
+aHx
 aIT
-aIT
-aIT
-aIT
-aIT
-bhX
-aIT
-blb
 bmy
 bje
 boN
 bqa
-brM
+bcE
 bsj
 btB
 btm
@@ -95488,23 +94063,23 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 aak
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
-aQK
+aak
+aak
+aak
+aEd
+aEd
 bje
 bje
 bmh
 bje
-brM
+bbk
 bqb
 brK
-bje
+bsk
 btm
 btm
 buT
@@ -95744,13 +94319,13 @@ aaa
 aaa
 aaa
 aaa
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aak
 aak

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -14302,10 +14302,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bfr" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/high/plus,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
 /turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "bfs" = (
 /obj/structure/chair,
 /obj/machinery/camera{
@@ -21871,7 +21873,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bGD" = (
 /turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/area/hallway/primary/central)
 "bGE" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -22172,35 +22174,41 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "bHM" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"bHN" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"bHO" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engineering/gravity_generator";
-	dir = 1;
-	name = "Gravity Generator APC";
-	pixel_y = 25
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"bHP" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
-/area/engineering/gravity_generator)
-"bHS" = (
-/obj/machinery/light/directional/north,
+/area/maintenance/department/engine)
+"bHN" = (
+/obj/structure/lattice,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 30
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"bHO" = (
+/obj/structure/rack,
+/obj/item/electronics/airalarm,
+/obj/item/electronics/airalarm,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
+"bHP" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/machinery/camera{
+	c_tag = "Tech Storage NW";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"bHS" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/requests_console/directional/north{
+	department = "Tech storage";
+	name = "Tech Storage RD"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "bHT" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -22567,39 +22575,59 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bJi" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "bJj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/item/toy/mecha/clarke,
+/obj/machinery/firealarm/directional/north,
+/obj/machinery/button/door/directional/west{
+	desc = "A remote control switch for the engineering security doors.";
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_y = -6;
+	req_access_txt = "10"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_y = 6;
+	req_access_txt = "24"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "engstorage";
+	name = "Engineering Secure Storage Control";
+	pixel_x = -36;
+	req_access_txt = "11"
+	},
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bJk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/computer/apc_control,
+/obj/machinery/keycard_auth{
+	pixel_x = 5;
+	pixel_y = 25
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/light_switch/directional/north{
+	pixel_x = -8
+	},
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bJl" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/modular_computer/console/preset/id,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bJm" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/computer/station_alert,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bJn" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bJo" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/cafeteria,
@@ -22895,56 +22923,46 @@
 /turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "bKv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/structure/rack,
+/obj/item/wirecutters,
+/obj/item/screwdriver,
+/obj/item/crowbar/red,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bKw" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Room";
-	req_access_txt = "19;23"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/engineering,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bKx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/multitool,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bKy" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bKz" = (
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"bKA" = (
 /obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"bKA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/turf/open/floor/plating,
+/area/tcommsat/computer)
 "bKC" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -23294,35 +23312,42 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bMq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/ai,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bMr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/tile/circuit{
+	amount = 10
 	},
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bMs" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 10
+/obj/structure/table,
+/obj/item/stack/sheet/plasmarglass{
+	amount = 15
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bMt" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/trimline/blue/line,
+/obj/structure/rack,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bMu" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
-	},
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/t_scanner,
+/obj/item/clothing/glasses/meson,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bMv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -23561,7 +23586,7 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bNY" = (
-/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bOd" = (
@@ -23668,11 +23693,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bOE" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 8;
-	name = "Gravity Camera";
-	network = list("ss13","engineer")
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
@@ -23763,24 +23785,14 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bPA" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/plating,
+/area/command/heads_quarters/ce)
 "bPB" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -24115,25 +24127,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "bRi" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
+/obj/effect/landmark/start/chief_engineer,
+/obj/structure/chair/comfy/brown{
+	color = "#EFB341"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bRj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bRm" = (
 /obj/structure/toilet,
 /obj/machinery/light/small/directional/west,
@@ -24151,15 +24157,9 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bRv" = (
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bRw" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -24169,9 +24169,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bRx" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/obj/structure/rack,
+/obj/item/electronics/firelock,
+/obj/item/electronics/firelock,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "bRy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -24316,25 +24319,18 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bSG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "bSH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/flashlight,
+/obj/item/assembly/flash/handheld,
+/obj/item/assembly/flash/handheld,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bSJ" = (
 /turf/closed/wall,
 /area/maintenance/department/electrical)
@@ -24437,15 +24433,10 @@
 /turf/open/floor/plating,
 /area/space)
 "bTl" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Antechamber";
-	dir = 8;
-	name = "Gravity Camera";
-	network = list("ss13","engineer")
-	},
-/obj/machinery/airalarm/directional/east,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/rnd,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bTm" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/telecomms,
@@ -24472,37 +24463,27 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bTw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "bTx" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bTy" = (
-/obj/structure/closet/radiation,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bTz" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/directional/south,
+/obj/structure/rack,
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bTB" = (
 /obj/structure/cable,
 /obj/machinery/mech_bay_recharge_port{
@@ -24577,14 +24558,9 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bTQ" = (
-/obj/structure/table,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/gloves/color/latex,
-/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "bTR" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
@@ -24954,19 +24930,15 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "bVD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "bVE" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy,
@@ -25153,19 +25125,14 @@
 /area/science/test_area)
 "bWo" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/storage/tech";
-	name = "Technology Storage APC";
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "bWp" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -25217,10 +25184,9 @@
 /obj/structure/sign/directions/supply{
 	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bWw" = (
@@ -25399,14 +25365,18 @@
 /area/engineering/lobby)
 "bXt" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance";
-	req_one_access_txt = "10; 24"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/maintenance/department/engine)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_access_txt = "19;23"
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "bXu" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -25471,9 +25441,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/science/server)
 "bXK" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plating,
-/area/engineering/lobby)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "bXM" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -25619,9 +25591,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bYw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "bYx" = (
 /obj/machinery/announcement_system,
 /turf/open/floor/circuit,
@@ -25645,15 +25619,11 @@
 /area/tcommsat/computer)
 "bYB" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/engine";
-	dir = 8;
-	name = "Engineering Maint APC";
-	pixel_x = -25;
-	pixel_y = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "bYC" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -25669,29 +25639,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bYN" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 30
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"bYO" = (
-/obj/structure/rack,
-/obj/item/electronics/airalarm,
-/obj/item/electronics/airalarm,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"bYP" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/camera{
-	c_tag = "Tech Storage NW";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"bYQ" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
@@ -25701,18 +25648,17 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"bYR" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/requests_console/directional/north{
-	department = "Tech storage";
-	name = "Tech Storage RD"
-	},
-/turf/open/floor/iron,
+"bYP" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/multitool,
+/turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bYT" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "bYU" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -25757,13 +25703,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"bZb" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/multitool,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "bZc" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -25885,22 +25824,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "bZZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/storage/tech)
-"caa" = (
 /obj/structure/rack,
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cac" = (
-/obj/structure/rack,
-/obj/item/wirecutters,
-/obj/item/screwdriver,
-/obj/item/crowbar/red,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cad" = (
@@ -25912,10 +25839,11 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "cae" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/engineering,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "caf" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -25978,14 +25906,6 @@
 	},
 /turf/open/floor/grass,
 /area/science/genetics)
-"cat" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/multitool,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "cau" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
@@ -26069,20 +25989,16 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
 "caP" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/command/heads_quarters/ce";
-	name = "CE Office APC";
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/command,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "caQ" = (
-/obj/structure/closet/crate{
-	name = "Spare Toner Cartridges"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "caU" = (
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -26098,46 +26014,25 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"caY" = (
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/tile/circuit{
-	amount = 10
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "caZ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/plasmarglass{
-	amount = 15
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cba" = (
-/obj/structure/rack,
-/obj/item/electronics/apc,
-/obj/item/electronics/apc,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cbb" = (
-/obj/structure/rack,
-/obj/item/weldingtool,
-/obj/item/wrench,
-/obj/item/crowbar/red,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cbc" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"cbc" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cbd" = (
-/obj/structure/closet/cardboard,
-/obj/item/toy/plush/lizard_plushie,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/button/door/directional/east{
+	id = "celock";
+	name = "CE Office Lockdown Button";
+	req_access_txt = "56"
+	},
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "cbf" = (
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
@@ -26152,14 +26047,14 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "cbi" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/t_scanner,
-/obj/item/clothing/glasses/meson,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 8;
+	name = "Gravity Camera";
+	network = list("ss13","engineer")
+	},
 /turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "cbj" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
@@ -26298,41 +26193,27 @@
 /turf/open/floor/plating,
 /area/tcommsat/server)
 "ccf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/lobby)
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cch" = (
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cci" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cck" = (
 /obj/structure/rack,
-/obj/item/electronics/firelock,
-/obj/item/electronics/firelock,
-/obj/machinery/status_display/ai/directional/west,
+/obj/item/weldingtool,
+/obj/item/wrench,
+/obj/item/crowbar/red,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "ccl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
-"ccm" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/flashlight,
-/obj/item/assembly/flash/handheld,
-/obj/item/assembly/flash/handheld,
+/obj/structure/table,
+/obj/item/aicard,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "ccn" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "cco" = (
 /obj/machinery/door/airlock/command{
 	name = "Telecomms Control Room";
@@ -26340,6 +26221,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/tcommsat/computer)
 "ccr" = (
@@ -26364,11 +26246,6 @@
 /obj/item/analyzer,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"cct" = (
-/obj/structure/table,
-/obj/item/aicard,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "ccu" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -26574,49 +26451,31 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cdB" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/item/toy/mecha/clarke,
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/button/door/directional/west{
-	desc = "A remote control switch for the engineering security doors.";
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_y = -6;
-	req_access_txt = "10"
-	},
-/obj/machinery/button/door/directional/west{
-	id = "atmos";
-	name = "Atmospherics Lockdown";
-	pixel_y = 6;
-	req_access_txt = "24"
-	},
-/obj/machinery/button/door/directional/west{
-	id = "engstorage";
-	name = "Engineering Secure Storage Control";
-	pixel_x = -36;
-	req_access_txt = "11"
-	},
+/obj/structure/table,
+/obj/item/rcl/pre_loaded,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cdC" = (
-/obj/machinery/computer/apc_control,
-/obj/machinery/keycard_auth{
-	pixel_x = 5;
-	pixel_y = 25
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch/directional/north{
-	pixel_x = -8
-	},
+/obj/structure/table,
+/obj/item/cartridge/atmos,
+/obj/item/cartridge/engineering,
+/obj/item/cartridge/engineering,
+/obj/item/cartridge/engineering,
+/obj/item/lighter,
+/obj/item/toy/figure/ce,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cdD" = (
-/obj/machinery/modular_computer/console/preset/id,
-/obj/machinery/airalarm/directional/north,
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/stamp/ce,
+/obj/item/stamp/denied,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cdE" = (
-/obj/machinery/computer/station_alert,
+/obj/structure/table,
+/obj/item/paper_bin/carbon,
+/obj/item/paper/monitorkey,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cdF" = (
@@ -26637,60 +26496,6 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "cdK" = (
-/obj/structure/rack,
-/obj/structure/cable,
-/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cdL" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cdM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cdN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cdO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage";
-	req_access_txt = "19;23"
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cdP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
-"cdR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -26698,7 +26503,17 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
-"cdS" = (
+"cdL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
+"cdM" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -26709,18 +26524,32 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
-"cdT" = (
+"cdO" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"cdT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cdU" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cdV" = (
-/obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/obj/structure/rack,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cdX" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -26867,22 +26696,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"ceB" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access_txt = "23"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
 "ceC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -27002,53 +26815,40 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cfh" = (
-/obj/effect/landmark/start/chief_engineer,
-/obj/structure/chair/comfy/brown{
-	color = "#EFB341"
-	},
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cfi" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"cfp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cfq" = (
-/obj/structure/rack,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "cfr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/table,
+/obj/item/analyzer,
+/obj/item/analyzer,
+/obj/machinery/camera{
+	c_tag = "Tech Storage SE";
+	dir = 8;
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
 	},
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
-"cfs" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cfu" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cfv" = (
-/obj/machinery/vending/assist,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room";
+	req_access_txt = "19;23"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "cfw" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Control";
@@ -27134,18 +26934,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"cfT" = (
-/obj/structure/table,
-/obj/item/analyzer,
-/obj/item/analyzer,
-/obj/machinery/camera{
-	c_tag = "Tech Storage SE";
-	dir = 8;
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "cfU" = (
 /obj/structure/chair,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -27234,36 +27022,33 @@
 /turf/open/floor/iron/white,
 /area/science)
 "cgx" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/rcl/pre_loaded,
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 5;
+	name = "Chief Engineer's RC"
+	},
 /obj/structure/cable,
+/obj/structure/rack,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cgy" = (
-/obj/structure/table,
-/obj/item/cartridge/atmos,
-/obj/item/cartridge/engineering,
-/obj/item/cartridge/engineering,
-/obj/item/cartridge/engineering,
-/obj/item/lighter,
-/obj/item/toy/figure/ce,
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/obj/structure/rack,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cgz" = (
-/obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/stamp/ce,
-/obj/item/stamp/denied,
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/security,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cgA" = (
-/obj/structure/table,
-/obj/item/paper_bin/carbon,
-/obj/item/paper/monitorkey,
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/obj/machinery/vending/assist,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cgB" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
@@ -27287,45 +27072,20 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "cgG" = (
-/obj/structure/table,
-/obj/item/stack/sheet/mineral/titanium/fifty,
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/machinery/camera{
-	c_tag = "Secure Tech Storage";
-	dir = 1;
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/engineering/storage/tech)
 "cgH" = (
-/obj/structure/table,
-/obj/item/stack/sheet/rglass{
-	amount = 25
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cgI" = (
-/obj/structure/rack,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cgJ" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cgK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/service,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"cgK" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cgL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -27346,8 +27106,8 @@
 	name = "CE Office Camera";
 	network = list("ss13","engineering")
 	},
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cgP" = (
@@ -27363,12 +27123,15 @@
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
 "cgS" = (
+/obj/machinery/power/apc/auto_name/east,
 /obj/structure/table,
-/obj/item/stack/sticky_tape,
-/obj/item/healthanalyzer,
-/obj/item/healthanalyzer,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/geiger_counter,
+/obj/item/geiger_counter,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "cgV" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
@@ -27523,13 +27286,14 @@
 "chH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "chI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "chJ" = (
@@ -27543,10 +27307,10 @@
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "chK" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "chL" = (
@@ -27566,37 +27330,21 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "chN" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/table,
+/obj/item/stack/sheet/mineral/titanium/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/camera{
+	c_tag = "Secure Tech Storage";
+	dir = 1;
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "chO" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"chP" = (
-/obj/structure/rack,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"chQ" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"chR" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/tcomms,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "chS" = (
 /obj/structure/closet/firecloset,
 /obj/item/radio/off,
@@ -27612,9 +27360,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "chU" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/ai/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "chV" = (
@@ -27625,23 +27373,19 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "chX" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=2";
-	freq = 1400;
-	location = "Engineering";
-	name = "Delivery Beacon - Engineering"
-	},
-/obj/effect/turf_decal/bot,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/engineering/lobby)
-"chY" = (
-/obj/structure/table,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"chY" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cie" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac/directional/east,
@@ -27897,25 +27641,13 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cjt" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/closet/cardboard,
+/obj/item/toy/plush/lizard_plushie,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cju" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/structure/cable,
 /mob/living/simple_animal/parrot/poly,
-/obj/machinery/requests_console/directional/west{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 5;
-	name = "Chief Engineer's RC"
-	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "cjw" = (
@@ -27939,22 +27671,18 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "cjz" = (
-/obj/machinery/modular_computer/console/preset/civilian,
-/obj/structure/window{
-	dir = 1
+/obj/structure/table,
+/obj/item/stack/sheet/rglass{
+	amount = 25
 	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cjA" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cjB" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Power Storage";
@@ -27978,43 +27706,49 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cjD" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = -30
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/rack,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cjE" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cjF" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cjG" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"cjJ" = (
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
-"cjK" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"cjF" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/plus,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"cjG" = (
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
+"cjJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Antechamber";
+	dir = 1;
+	name = "Gravity Camera";
+	network = list("ss13","engineer")
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
+"cjK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cjL" = (
 /obj/structure/closet/emcloset,
 /obj/item/radio/off,
@@ -28028,16 +27762,12 @@
 /area/tcommsat/computer)
 "cjM" = (
 /obj/structure/rack,
-/obj/item/storage/firstaid/regular,
-/obj/item/clothing/glasses/meson/engine,
-/obj/structure/cable,
-/obj/machinery/button/door/directional/east{
-	id = "celock";
-	name = "CE Office Lockdown Button";
-	req_access_txt = "56"
-	},
-/turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cjN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28187,19 +27917,19 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
 "ckp" = (
-/obj/machinery/modular_computer/console/preset/cargochat/engineering,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/rack,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "ckq" = (
-/obj/machinery/computer/cargo/request,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -30
 	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ckr" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/crossing,
@@ -28245,23 +27975,18 @@
 /area/engineering/storage_shared)
 "cky" = (
 /obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access_txt = "23"
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/navbeacon/wayfinding,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "ckz" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -28670,9 +28395,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "clL" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
@@ -28684,8 +28406,15 @@
 /area/engineering/lobby)
 "clN" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "clR" = (
@@ -28852,8 +28581,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -29297,9 +29026,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "coc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cod" = (
@@ -30386,9 +30119,12 @@
 /turf/closed/wall,
 /area/science/mixing)
 "csu" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/engineering/engine_smes)
+/obj/structure/table,
+/obj/item/stack/sticky_tape,
+/obj/item/healthanalyzer,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "csv" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
@@ -30453,6 +30189,12 @@
 	color = "#FFD700";
 	dir = 8;
 	name = "Engineering yellow corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -30761,19 +30503,17 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "ctB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
-"ctC" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/camera{
-	c_tag = "Engine Locker Room";
-	dir = 8;
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
+"ctC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "ctD" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -30900,11 +30640,14 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cuf" = (
-/obj/structure/curtain,
-/obj/item/soap/nanotrasen,
-/obj/machinery/shower,
-/turf/open/floor/iron/white,
-/area/engineering/engine_smes)
+/obj/structure/rack,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cug" = (
 /turf/closed/wall/r_wall,
 /area/engineering/transit_tube)
@@ -31043,9 +30786,15 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cuH" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/engineering/engine_smes)
+/obj/structure/rack,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cuI" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -31083,47 +30832,40 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cuS" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Locker Room";
-	req_one_access_txt = "10;24"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/tcomms,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cuU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
+/obj/structure/table,
+/obj/item/plant_analyzer,
+/obj/item/plant_analyzer,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cuV" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cuW" = (
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cuX" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "hand decontamination sink";
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/engineering/engine_smes)
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cvb" = (
 /turf/closed/wall,
 /area/engineering/atmos)
@@ -31154,12 +30896,24 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cvg" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
+/obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cvh" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -31304,17 +31058,32 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cvH" = (
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/hallway/primary/aft)
 "cvJ" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/hallway/primary/aft)
 "cvK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -31884,12 +31653,16 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cxC" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=2";
+	freq = 1400;
+	location = "Engineering";
+	name = "Delivery Beacon - Engineering"
 	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/engineering/engine_smes)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cxI" = (
 /obj/item/wrench,
 /turf/open/floor/iron,
@@ -33367,6 +33140,7 @@
 	network = list("ss13","engineering","engine")
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
 "cDI" = (
@@ -37305,12 +37079,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
 "cSm" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/engineering/engine_smes)
+/obj/structure/rack,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cSn" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -38611,29 +38387,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "cWa" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator Anteroom";
-	req_access_txt = "11"
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "cWb" = (
 /obj/machinery/door/airlock/external{
 	name = "Common Mining Shuttle Bay"
@@ -38646,12 +38403,10 @@
 /area/hallway/secondary/entry)
 "cWc" = (
 /obj/machinery/navbeacon/wayfinding,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cWd" = (
@@ -39673,9 +39428,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "etz" = (
-/obj/structure/closet/toolcloset,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/engineering/storage/tech)
 "eud" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase,
@@ -39716,9 +39471,11 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
 "eFy" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/closet/crate{
+	name = "Spare Toner Cartridges"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "eHp" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255
@@ -40002,12 +39759,6 @@
 /area/medical/medbay/central)
 "fCp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "fCC" = (
@@ -40025,8 +39776,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "fEF" = (
-/turf/open/floor/iron/white,
-/area/engineering/engine_smes)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "fET" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40347,9 +40101,9 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gxs" = (
-/obj/machinery/light/directional/east,
+/obj/structure/cable/multilayer/multiz,
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/command/heads_quarters/ce)
 "gzW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -40406,9 +40160,10 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "gTq" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/white,
-/area/engineering/engine_smes)
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/command/heads_quarters/ce)
 "gXc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -40503,9 +40258,9 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "hjq" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/stairs/north,
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/engineering/lobby)
 "hkj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/red{
@@ -40723,17 +40478,18 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "icD" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 3
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Engineering Delivery";
+	req_one_access_txt = "10;24"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/engineering/lobby)
 "idi" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -40773,15 +40529,21 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ijl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access_txt = "23"
 	},
-/obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/engineering/storage/tech)
 "inh" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/dark,
@@ -40952,10 +40714,17 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "iSy" = (
-/obj/structure/cable,
-/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/engineering/lobby)
 "iUc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/crew_quarters/dorms";
@@ -41004,9 +40773,18 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "jbv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/engineering/lobby)
 "jcz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -41695,9 +41473,7 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "lpq" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/ai,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/engineering/storage/tech)
 "lrs" = (
 /obj/structure/closet/secure_closet/miner,
@@ -42163,10 +41939,9 @@
 /area/hallway/primary/starboard)
 "mOS" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "mPo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42421,9 +42196,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "nBG" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/command,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
 /area/engineering/storage/tech)
 "nBH" = (
 /obj/effect/turf_decal/tile/blue{
@@ -43048,10 +42824,13 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
 "qji" = (
-/obj/structure/closet/firecloset,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/engineering/engine_smes)
+/area/engineering/lobby)
 "qlV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -43874,15 +43653,17 @@
 /turf/open/floor/iron,
 /area/space)
 "ttD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "ttL" = (
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
 /obj/machinery/light/directional/north,
@@ -44090,7 +43871,7 @@
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
-/area/engineering/engine_smes)
+/area/engineering/main)
 "ucU" = (
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
@@ -44195,8 +43976,8 @@
 /turf/open/floor/iron/white,
 /area/science)
 "uys" = (
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "uAc" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -44266,11 +44047,17 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
 "uMD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "uNo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -44665,9 +44452,18 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vZX" = (
-/obj/machinery/holopad/secure,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/command/heads_quarters/ce)
+/area/engineering/lobby)
 "wbs" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -45030,8 +44826,11 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "xur" = (
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/solars/port/aft)
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -45043,11 +44842,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xyD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/engineering/main)
+/area/maintenance/solars/port/aft)
 "xyS" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -60565,7 +60364,7 @@ ctp
 cuD
 cCR
 cuD
-cyo
+ctp
 cyo
 nCr
 cCl
@@ -60822,10 +60621,10 @@ ctp
 cuE
 xhv
 cxm
-cAU
-xyD
-iSu
-qqq
+xur
+cIl
+oop
+cAW
 cAW
 cAW
 cFQ
@@ -61079,7 +60878,7 @@ ctp
 xKA
 cwx
 cxY
-pMG
+xyD
 cIm
 cAW
 cAW
@@ -61336,7 +61135,7 @@ ctp
 cvh
 xhv
 cya
-pMG
+xyD
 cIm
 cAW
 cXq
@@ -63899,8 +63698,8 @@ qTJ
 cmU
 lJc
 bXs
-cuf
-cSm
+aaa
+aaa
 coT
 ctx
 haR
@@ -64156,8 +63955,8 @@ qTJ
 cmU
 cnT
 bXs
-cuX
-fEF
+aaa
+aaa
 coT
 ctz
 haR
@@ -64413,8 +64212,8 @@ tnq
 cmU
 nlF
 bXs
-coT
-gTq
+aaa
+aaa
 coT
 ctz
 haR
@@ -64670,12 +64469,12 @@ qTJ
 cmU
 caU
 bXs
-cvg
-cuW
-csu
-cuH
+aaa
+aaa
 coT
-cuS
+coT
+coT
+coT
 coT
 nIR
 cCz
@@ -64927,13 +64726,13 @@ clB
 cmV
 caU
 bXs
-cvH
-cuW
-etz
-iSy
-iSy
-cwc
-qji
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 cyX
 cLC
 cBi
@@ -65184,13 +64983,13 @@ qTJ
 cmU
 cmU
 bXs
-cvJ
-cuW
-jbv
-ctB
-cuU
-ijl
-cxB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 xjp
 cAm
 cBj
@@ -65441,13 +65240,13 @@ clR
 cmW
 caU
 bXs
-cvH
-gxs
-hjq
-ctC
-cuV
-gxs
-cxC
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 ubI
 cNV
 cBA
@@ -65698,14 +65497,14 @@ qTJ
 cmU
 caU
 bXs
-coT
-coT
-coT
-coT
-coT
-coT
-coT
-coT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 cBG
 cyt
@@ -68514,7 +68313,7 @@ bXq
 bYy
 bZR
 caM
-bYw
+djJ
 cdy
 cfc
 cgu
@@ -69028,7 +68827,7 @@ bXq
 bYD
 caf
 caV
-bYw
+djJ
 cdU
 cfw
 cgL
@@ -69284,15 +69083,15 @@ hse
 bXq
 bXq
 bXq
-bXq
-cbY
-cbY
+bKA
+bPA
+bPA
 cdG
 cbY
 cbY
 cbY
 cbY
-qTJ
+iSy
 cmU
 caU
 coW
@@ -69538,13 +69337,13 @@ atr
 bwU
 bUM
 hse
-bNm
-bYB
-bNm
-caP
+bHM
 cbY
+bJj
+cfg
+cfg
 cdB
-cfJ
+bYB
 cgx
 chH
 cju
@@ -69795,14 +69594,14 @@ vQK
 bLX
 bUN
 hse
-bxJ
 bHm
-bEA
-bEA
 cbY
+bJk
+cfg
+cfg
 cdC
 cfg
-cgy
+cfg
 chI
 cfg
 cdG
@@ -70052,14 +69851,14 @@ vkV
 bLX
 bHm
 hse
-bxJ
-bHn
 bHm
-caQ
 cbY
+bJl
+cfg
+bRi
 cdD
 cfh
-cgz
+cfg
 chJ
 cjw
 ckt
@@ -70309,17 +70108,17 @@ vkV
 bLX
 bHm
 hse
-bxJ
-bYM
-bHm
 bHm
 cbY
-cdE
-vZX
-cgA
-chK
+bJm
 cfg
-cdG
+bRj
+cdE
+cfg
+cfg
+chK
+cbY
+cbY
 clL
 cmZ
 cnY
@@ -70566,18 +70365,18 @@ vkV
 bLX
 bHm
 hse
-bxJ
-bYU
 bHm
-cbd
 cbY
-cdV
+bJn
+cbd
+cfg
+cfg
 cfJ
 cgO
 chU
-cjM
-cdG
-qTJ
+cbY
+gxs
+jbv
 cmU
 cnZ
 coW
@@ -70823,18 +70622,18 @@ vkV
 bLX
 bHm
 hse
-bXs
-bXs
-bXs
-bXs
-cbY
-cdG
-cdG
+bHm
 cbY
 cbY
 cbY
+bPA
+bPA
+bPA
 cbY
-clB
+cbY
+cbY
+gTq
+qji
 cmY
 cnX
 hcM
@@ -71079,19 +70878,19 @@ bQQ
 vkV
 bLX
 bHm
-iKK
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
+hse
+bHm
+bHm
+bHm
+bHm
+bHm
+cjA
+bHn
+bHm
 eFy
-caU
-caU
-clS
+bXs
+hjq
+ttD
 cmU
 nlF
 coW
@@ -71336,18 +71135,18 @@ bQQ
 vkV
 bLX
 bHm
-ttD
-bXt
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
+bWc
+bNm
+bNm
+bNm
+bNm
+bNm
+cjA
+bYM
+bHm
 cjt
-caU
-caU
+bXs
+hjq
 clN
 cmU
 lJc
@@ -71594,18 +71393,18 @@ vkV
 bLX
 bHm
 hse
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
-cjz
-caU
-caU
-clR
+bHm
+bHm
+bHm
+bHm
+bHm
+bNm
+bYU
+bHm
+bHm
+cxC
+icD
+uMD
 cmW
 caU
 coW
@@ -71851,17 +71650,17 @@ auL
 bLX
 bHm
 hse
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
+bOQ
+bOQ
 cjA
-caU
-caU
+cjA
+cjA
+cjA
+cjA
+cjA
+cjA
+bXs
+bXs
 clS
 cmU
 caU
@@ -72108,17 +71907,17 @@ auL
 bLX
 bHm
 hse
+bOQ
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
 bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
-chN
-caU
-caU
 clB
 cmV
 caU
@@ -72365,17 +72164,17 @@ bLX
 bLX
 bHm
 hse
+bOQ
+aak
+chX
+chX
+chX
+chX
+chX
+chX
+chX
+aak
 bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
-bXs
-bXs
-caU
 clS
 cmU
 caU
@@ -72622,17 +72421,17 @@ bLX
 bHm
 bHm
 hse
+bOQ
+aak
+chX
+bMq
+bMq
+bTz
+caP
+caP
+chX
+aak
 bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
-ckp
-caU
 clS
 cmU
 caU
@@ -72879,17 +72678,17 @@ bLX
 bHm
 bHm
 iKK
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bXs
+bOQ
+bHN
+chX
+ccf
+ccf
+bTQ
+ccf
+ccf
+chX
 ckq
-caU
+bXs
 qTJ
 cmU
 caU
@@ -73136,17 +72935,17 @@ bLX
 bHm
 bHm
 hse
-bXK
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bOQ
+aak
 chX
-caU
-caU
+bMr
+bRv
+bVD
+caQ
+chN
+chX
+aak
+bXs
 clS
 cmU
 caU
@@ -73393,16 +73192,16 @@ bLX
 bLX
 bLX
 hse
-bXs
-bXs
-bXs
-bXs
+bOQ
+aak
+bXv
+bMs
 ccf
+bWo
 ccf
-ccf
-bXs
-bXs
-bXs
+cjz
+bXv
+aak
 bXs
 clT
 cmX
@@ -73650,16 +73449,16 @@ bSr
 axc
 bLX
 hse
-bOQ
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+bXv
+bXv
+bXv
+bXv
+bXv
+bXt
+bXv
+bXv
+bXv
+bXv
 bXs
 qTJ
 cmU
@@ -73907,16 +73706,16 @@ bSs
 ayC
 bLX
 hse
-bOQ
-aak
+bXv
+bHO
 bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-aak
+bMt
+bRx
+cdL
+cdV
+cjM
+cuf
+cSm
 bXs
 qTJ
 cmU
@@ -74164,16 +73963,16 @@ dpR
 fxn
 bLX
 lkO
-bOQ
-aak
-bZZ
+bXv
+bHP
 lpq
 lpq
+bSG
 cdK
 nBG
-nBG
-bZZ
-aak
+lpq
+lpq
+cWa
 bXs
 clB
 cmV
@@ -74421,15 +74220,15 @@ vkV
 bLX
 bLX
 hse
-bOQ
+ckK
 bYN
-bZZ
+bKv
 cch
-cch
+bSH
 cdL
-cch
-cch
-bZZ
+cgy
+ckp
+cuH
 cjD
 bXs
 clU
@@ -74678,16 +74477,16 @@ vkV
 bLX
 bHm
 hse
-bOQ
-aak
-bZZ
-caY
-cci
+bXv
+bHS
+lpq
+lpq
+lpq
 cdM
-cfp
 cgG
-bZZ
-aak
+cgG
+cgG
+cgG
 bXs
 clR
 cmW
@@ -74935,17 +74734,17 @@ vkV
 bLX
 bHm
 hse
-bOQ
-aak
 bXv
+lpq
+bKw
 caZ
-cch
-cdN
-cch
+bTl
+lpq
+cgz
 cgH
-bXv
-aak
-bXs
+cuS
+lpq
+ijl
 qTJ
 cmU
 caU
@@ -75193,16 +74992,16 @@ bLX
 aza
 hse
 bXv
-bXv
-bXv
-bXv
-bXv
+bJi
+bKw
+caZ
+bTl
 cdO
-bXv
-bXv
-bXv
-bXv
-bXv
+cgA
+cgz
+cgH
+etz
+bXs
 qTJ
 cmU
 lJc
@@ -75450,16 +75249,16 @@ bLX
 bHm
 hse
 bXv
-bYO
-caa
-cba
-cck
-cdP
-cfq
-cgI
-chP
+lpq
+lpq
+lpq
+lpq
+lpq
+lpq
+lpq
+lpq
 cjE
-bXv
+bXs
 clF
 cmU
 caU
@@ -75708,15 +75507,15 @@ bHm
 iKK
 bXv
 bYP
-uys
-uys
+bKx
+bMu
 ccl
-cdR
+lpq
 cfr
-uys
-uys
+csu
+cuU
 cjF
-bXv
+bXs
 clH
 cmU
 caU
@@ -75963,17 +75762,17 @@ vkV
 bLX
 bHm
 hse
-bXv
-bYQ
-cac
-cbb
-ccm
-cdP
-cfs
-cgJ
-chQ
 cjG
-bXv
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
 clV
 tcQ
 cnS
@@ -76220,18 +76019,18 @@ vkV
 bLX
 bHm
 hse
-bXv
-bYR
+cjG
 uys
 uys
 uys
-cdS
+uys
+uys
 mOS
-mOS
-mOS
-mOS
+ctB
+cuV
+fCp
 cky
-cnS
+cmU
 coc
 caU
 caU
@@ -76476,18 +76275,18 @@ bRn
 vkV
 bLX
 bHm
-bWo
-bXv
+hse
+cjG
 uys
 cae
 cbc
 ccn
-uys
-cfu
+bXK
+mOS
 cgK
-chR
 uys
-bXv
+fEF
+cjG
 bXs
 coH
 bXs
@@ -76734,17 +76533,17 @@ vkV
 bLX
 bHm
 iKK
-bXv
+cjG
 bYT
-cae
-cbc
-ccn
+bKy
+bNY
+bTw
 cdT
 cfv
-cfu
-cgK
+ctC
+cuX
 cjJ
-bXv
+cjG
 clX
 qTJ
 coe
@@ -76991,17 +76790,17 @@ vkV
 bLX
 bHm
 hse
-ckK
+cjG
 uys
-uys
-uys
-uys
-uys
-uys
-uys
-uys
+bKz
+bOE
+bTy
+bYw
+mOS
+cgK
+chY
 cjK
-bXv
+cjG
 clY
 cWc
 cof
@@ -77248,19 +77047,19 @@ vkV
 bLX
 bHm
 hse
-bXv
-bZb
-cat
-cbi
-cct
+cjG
 uys
-cfT
+uys
+cbi
+uys
+uys
+mOS
 cgS
 chY
 bfr
-bXv
+cjG
 vpX
-vpX
+vZX
 vpX
 bXs
 ejT
@@ -77505,17 +77304,17 @@ bLX
 bLX
 bxJ
 bWT
-bXv
-bXv
-bXv
-bXv
-bXv
-ceB
-bXv
-bXv
-bXv
-bXv
-bXv
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+cvg
+cjG
+cjG
 bXs
 cvC
 bXs
@@ -77770,7 +77569,7 @@ rOd
 rOd
 rOd
 bJe
-bJe
+cvH
 lUI
 ckA
 cma
@@ -78027,11 +77826,11 @@ bJe
 bJe
 bJe
 cgM
-bJe
+cvH
 bXy
 bJe
 bJe
-bJe
+cvH
 bJe
 bJe
 bJe
@@ -78284,11 +78083,11 @@ cph
 cph
 cph
 chT
-qwu
+cvJ
 jpH
 qwu
 qwu
-qwu
+cvJ
 qwu
 cph
 cph
@@ -78785,9 +78584,9 @@ cXC
 bMM
 bOA
 bPY
-icD
-bTw
-bVD
+bJe
+bJe
+bJe
 bWv
 cmp
 bXO
@@ -79038,14 +78837,14 @@ rkl
 bGD
 bGD
 bGD
-bGD
-bGD
-bGD
-bGD
-bGD
-cWa
-bGD
-bGD
+cqv
+cqv
+cqv
+cqv
+cqv
+cqv
+cqv
+cqv
 bWx
 bXA
 bYX
@@ -79291,19 +79090,19 @@ byG
 bAr
 bBQ
 bxk
-aak
-bGD
-bHM
-xur
-xur
-xur
-bNY
-bGD
-bRi
-bSG
-bTy
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bXA
 bYY
 cag
@@ -79548,19 +79347,19 @@ byH
 bjW
 khA
 bxk
-aak
-bGD
-bHN
-bJi
-bSH
-uMD
-uMD
-bPA
-bRj
-fCp
-bTz
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bXA
 bYZ
 cah
@@ -79805,19 +79604,19 @@ byI
 bAs
 bBR
 bxk
-aak
-bGD
-bHO
-bJj
-bKv
-bMq
-xur
-bGD
-bRv
-bTl
-bTQ
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bXA
 bZa
 cai
@@ -80062,19 +79861,19 @@ byJ
 bxk
 bxk
 bxk
-aak
-bGD
-bHP
-bHP
-bKw
-bHP
-bHP
-bGD
-bRx
-bGD
-bGD
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bXA
 bZp
 cau
@@ -80319,19 +80118,19 @@ kaW
 bAt
 bBS
 bxk
-aak
-bGD
-xur
-bJk
-bKx
-bMr
-xur
-bGD
-aak
-aak
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bXA
 bXA
 bXA
@@ -80576,15 +80375,15 @@ bwl
 bAu
 bBT
 bxk
-aak
-bGD
-xur
-bJl
-bKy
-bMs
-xur
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bSJ
 bSJ
 bSJ
@@ -80833,15 +80632,15 @@ vOj
 fym
 bBU
 bxk
-aak
-bGD
-bHS
-bJm
-bKz
-bMt
-xur
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bSJ
 bTB
 bVh
@@ -81090,20 +80889,20 @@ byK
 bxl
 bxl
 bxk
-aak
-bGD
-xur
-bJn
-bKA
-bMu
-xur
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bSJ
 bTC
 bVi
 bWz
-aaa
+bSJ
 aaa
 bJp
 cem
@@ -81347,20 +81146,20 @@ mtB
 bAv
 bBV
 bxk
-aak
-bGD
-xur
-xur
-xur
-xur
-bOE
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bSJ
 bTD
 bVj
 bWA
-aaa
+bSJ
 aaa
 bJp
 xmX
@@ -81604,20 +81403,20 @@ fVq
 xcr
 bBW
 bxk
-aak
-bGD
-bGD
-bGD
-bGD
-bGD
-bGD
-bGD
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bSJ
 bTE
 bVk
 bWB
-aaa
+bSJ
 aaa
 bJp
 xmX
@@ -81861,20 +81660,20 @@ byZ
 bAK
 bCn
 bxk
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bSJ
 bTV
 bVJ
 bXb
-aaa
+bSJ
 aaa
 bJp
 heL
@@ -82131,7 +81930,7 @@ bSJ
 bSJ
 bVK
 bSJ
-aaa
+bSJ
 aaa
 bJp
 ckD

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -39357,6 +39357,12 @@
 /obj/machinery/bluespace_vendor/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"dzV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "dBV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39401,28 +39407,12 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/central)
-"dHd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "dIW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"dJo" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "dJu" = (
 /obj/machinery/power/smes{
 	charge = 500000
@@ -39442,6 +39432,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"dMx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "dMF" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -39495,11 +39491,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"dVM" = (
-/obj/effect/landmark/start/paramedic,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "dWI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 5
@@ -39615,10 +39606,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"epy" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "eqU" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/space/basic,
@@ -39690,6 +39677,11 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"eGi" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "eHp" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255
@@ -39737,12 +39729,17 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"eWa" = (
+"eYu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "eYF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -39921,12 +39918,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"ftl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+"fwh" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "fwU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/directional/east,
@@ -39952,10 +39951,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"fyn" = (
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "fyz" = (
 /obj/structure/table,
 /obj/item/stack/rods/ten,
@@ -40019,6 +40014,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fEY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
+"fGc" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -40372,30 +40377,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"gSu" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -5
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "gTq" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/engineering/engine_smes)
-"gTR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "gXc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -40576,6 +40561,13 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"hsU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "hxc" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40796,9 +40788,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ivL" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "ivN" = (
@@ -40839,12 +40829,6 @@
 /obj/item/toy/plush/nukeplushie,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"iCb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "iCe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -40917,9 +40901,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"iOn" = (
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
+"iQu" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40995,14 +40980,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"jei" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "jes" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -41024,17 +41001,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/space)
-"jhs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "jhG" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -41044,9 +41010,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"jiJ" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
 "jiN" = (
 /obj/structure/chair{
 	dir = 8;
@@ -41265,6 +41228,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/transit_tube)
+"jOx" = (
+/obj/effect/landmark/start/paramedic,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "jOz" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -41287,14 +41255,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"jPm" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "jPq" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/space)
+"jRV" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "jUc" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -41524,10 +41492,6 @@
 /obj/machinery/modular_computer/console/preset/cargochat/service,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"kVb" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "kWd" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
@@ -41631,6 +41595,17 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
+"lfj" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Freezer";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/coldroom)
 "lht" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -41737,10 +41712,6 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
 /area/space)
-"lCr" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "lET" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -41793,6 +41764,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"lPO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "lQl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -41839,17 +41821,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"lXz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "maq" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
@@ -41885,6 +41856,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
+"mgt" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "mhQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -42045,10 +42020,6 @@
 /obj/structure/stairs/south,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"mzT" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "mAr" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Hall - Morgue";
@@ -42129,6 +42100,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mMj" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/bounty_board/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "mON" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42186,6 +42162,17 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"nfp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ngu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -42342,12 +42329,27 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"nwj" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
 /obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/space)
+"nzo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "nzM" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -42419,16 +42421,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library)
-"nDz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "nDG" = (
 /obj/structure/sink{
 	dir = 4;
@@ -42494,6 +42486,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
+"nRZ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "nSk" = (
 /obj/structure/chair{
 	dir = 1
@@ -42516,6 +42512,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
+"nTZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "nZK" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -42616,6 +42620,19 @@
 "osl" = (
 /turf/open/floor/white,
 /area/service/library)
+"ovO" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
+	},
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Medical Delivery";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "owj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42629,6 +42646,18 @@
 	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"oxq" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay";
+	name = "Delivery Beacon - Medbay"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/medical/medbay/central)
 "oEh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -42761,10 +42790,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/white,
 /area/science)
-"oZp" = (
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "oZx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -42783,12 +42808,18 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"pfv" = (
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "pgs" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"phA" = (
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
 "phC" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Medbay";
@@ -42931,6 +42962,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pWv" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "pXf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -43082,6 +43117,10 @@
 /obj/item/pen,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"qJW" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "qKh" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
@@ -43680,6 +43719,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
+"sUj" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "sWI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43928,6 +43971,16 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"tIW" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "tJd" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -44026,13 +44079,6 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"ues" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "ueZ" = (
 /obj/structure/table,
 /obj/item/key/security,
@@ -44124,6 +44170,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/space)
+"uAD" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "uAJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -44184,15 +44234,6 @@
 /obj/item/food/popsicle/creamsicle_orange,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
-"uMz" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/camera{
-	c_tag = "Medbay Cold Storage";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "uMD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44239,14 +44280,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uPk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uPA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/gloves,
@@ -44274,18 +44307,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uTS" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay";
-	name = "Delivery Beacon - Medbay"
+"uUW" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/camera{
+	c_tag = "Medbay Cold Storage";
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "uWr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -44425,6 +44455,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"vnM" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "vpK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 4
@@ -44474,22 +44509,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"vBs" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "vCx" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"vDG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vFP" = (
 /obj/machinery/light_switch/directional/west,
 /turf/closed/wall,
@@ -44514,6 +44546,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars)
+"vLT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vNP" = (
 /obj/structure/rack,
 /obj/item/gun/grenadelauncher,
@@ -44616,11 +44655,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wil" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "wlG" = (
 /obj/structure/reflector/single,
 /turf/open/floor/engine,
@@ -44835,10 +44869,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"xfF" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "xfK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -45093,17 +45123,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"xZi" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Freezer";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/coldroom)
 "xZB" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -86156,7 +86175,7 @@ bgi
 bgi
 aYV
 aXH
-lCr
+jRV
 cLv
 blN
 bmY
@@ -86919,8 +86938,8 @@ bbl
 bvL
 bwJ
 lXd
-uTS
-gSu
+oxq
+ovO
 aQT
 beO
 cAQ
@@ -87179,7 +87198,7 @@ aXM
 aXM
 vls
 aQT
-beO
+iQu
 cAQ
 aXN
 aVP
@@ -87681,8 +87700,8 @@ aEd
 aIR
 aRR
 gjU
-jPm
-xfF
+mgt
+uAD
 aRK
 aXM
 fjL
@@ -87938,8 +87957,8 @@ aEd
 bla
 aRR
 uKb
-iOn
-ftl
+pfv
+fEY
 aRK
 aXM
 iro
@@ -87949,7 +87968,7 @@ omY
 gEA
 uOh
 lOx
-lXz
+nzo
 beO
 cFF
 bfb
@@ -88194,10 +88213,10 @@ aIT
 aMe
 bla
 aRR
-jei
-iOn
-eWa
-nDz
+vBs
+pfv
+dzV
+tIW
 aXM
 qay
 hhz
@@ -88206,7 +88225,7 @@ omY
 uZi
 uOh
 lOx
-jhs
+nfp
 beO
 cFF
 uNo
@@ -88454,7 +88473,7 @@ aRR
 aOx
 aPt
 aMl
-iCb
+dMx
 aXM
 vdZ
 yck
@@ -88708,10 +88727,10 @@ aEd
 aEd
 bla
 aRR
-uMz
-dJo
-fyn
-gTR
+uUW
+eGi
+nRZ
+hsU
 aXM
 aXM
 aXM
@@ -88968,8 +88987,8 @@ aRR
 aRR
 aRR
 aRR
-xZi
-jiJ
+lfj
+phA
 beO
 beO
 aQT
@@ -89225,7 +89244,7 @@ aHx
 bdK
 aPv
 cyS
-uPk
+nTZ
 nsd
 bnh
 snX
@@ -89238,7 +89257,7 @@ pZH
 iyE
 iyE
 iKA
-ues
+vLT
 aZo
 xoz
 xoz
@@ -89494,7 +89513,7 @@ mkE
 nGc
 aSo
 aSD
-vDG
+eYu
 beO
 aZn
 bky
@@ -89741,7 +89760,7 @@ aPv
 aQN
 bta
 bta
-kVb
+qJW
 bta
 bta
 aSD
@@ -89751,12 +89770,12 @@ eKn
 xZB
 ivN
 aSD
-vDG
+eYu
 beO
 bhD
 aZW
 uYP
-oZp
+sUj
 bky
 iMA
 bky
@@ -90006,9 +90025,9 @@ ivL
 rrF
 gvV
 xZB
-epy
+fGc
 aSD
-vDG
+eYu
 beO
 bhD
 biU
@@ -90017,7 +90036,7 @@ blU
 bnj
 boE
 bky
-mzT
+pWv
 bhF
 cpH
 buh
@@ -90262,7 +90281,7 @@ aSo
 tYg
 ptC
 eKn
-wil
+vnM
 ptC
 dqs
 aQT
@@ -90274,7 +90293,7 @@ bkv
 cXI
 keH
 bky
-mzT
+pWv
 bhF
 cpH
 btm
@@ -90514,11 +90533,11 @@ bte
 xly
 xly
 cbT
-bta
+nwj
 aSo
 pAu
 xZB
-dHd
+lPO
 xZB
 xZB
 nGc
@@ -90531,7 +90550,7 @@ bbc
 bky
 keH
 bky
-dVM
+jOx
 bhF
 cpH
 btm
@@ -90777,10 +90796,10 @@ wQS
 tYa
 miW
 ptC
-epy
+fGc
 aSD
-vDG
-beO
+eYu
+iQu
 bhD
 aZX
 bkv
@@ -90788,7 +90807,7 @@ bkv
 mrE
 ufV
 bky
-mzT
+pWv
 bhF
 cpH
 btm
@@ -91036,7 +91055,7 @@ rzp
 ptC
 oJL
 aSD
-vDG
+eYu
 beO
 bhD
 xbW
@@ -91293,12 +91312,12 @@ nkR
 dqs
 aSo
 aSD
-vDG
+eYu
 beO
 bhW
 bjd
 bky
-oZp
+sUj
 bky
 bky
 bky
@@ -91553,7 +91572,7 @@ beO
 aQT
 beO
 bhW
-bck
+mMj
 bky
 bky
 bky
@@ -92064,7 +92083,7 @@ aWN
 aXE
 bte
 beO
-jhs
+nfp
 beO
 bhL
 aZY
@@ -93083,7 +93102,7 @@ aVa
 aNc
 aTb
 aUk
-aPn
+fwh
 bte
 aSJ
 aTI

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -5081,6 +5081,12 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/command/bridge)
+"avk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "avn" = (
 /turf/open/floor/iron,
 /area/security/processing)
@@ -10075,6 +10081,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aMm" = (
@@ -10672,6 +10679,7 @@
 "aOx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "aOy" = (
@@ -10952,6 +10960,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/maintenance/department/medical)
 "aPu" = (
@@ -11189,17 +11198,13 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aQN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aQS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aQT" = (
@@ -11482,10 +11487,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"aSe" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "aSf" = (
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
@@ -11523,14 +11524,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aSo" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
+/turf/closed/wall,
+/area/medical/treatment_center)
 "aSp" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/lootdrop/costume,
@@ -11602,19 +11597,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aSD" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "aSE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -11629,12 +11614,6 @@
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aSH" = (
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "aSI" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -12495,6 +12474,15 @@
 	name = "Medical Security Post Morgue Access";
 	req_access_txt = "63;5"
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
 "aVH" = (
@@ -12614,12 +12602,8 @@
 /area/maintenance/department/crew_quarters/dorms)
 "aWw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aWz" = (
@@ -12935,6 +12919,8 @@
 /obj/structure/sign/departments/medbay/alt{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aXL" = (
@@ -12944,10 +12930,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aXM" = (
-/obj/item/stack/cable_coil/five,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/turf/closed/wall/r_wall,
+/area/medical/surgery)
 "aXN" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron/white,
@@ -13000,7 +12984,13 @@
 	dir = 1;
 	name = "Medical blue corner"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "aYk" = (
@@ -13191,6 +13181,7 @@
 "aZb" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "aZc" = (
@@ -13251,9 +13242,6 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 1;
@@ -13263,6 +13251,8 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "aZp" = (
@@ -13343,7 +13333,6 @@
 	name = "Medbay Lobby Camera";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "aZY" = (
@@ -13568,10 +13557,11 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
 "bbk" = (
-/obj/structure/chair,
 /obj/structure/sign/departments/psychology{
 	pixel_x = -32
 	},
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bbl" = (
@@ -13879,6 +13869,18 @@
 	req_access_txt = "6;5"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bdv" = (
@@ -14530,11 +14532,11 @@
 /area/medical/abandoned)
 "bgl" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -15088,6 +15090,9 @@
 	name = "Pharmacy";
 	req_access_txt = "5; 69"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "bjd" = (
@@ -15760,6 +15765,9 @@
 	req_access_txt = "5"
 	},
 /obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "blM" = (
@@ -16122,9 +16130,18 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bnh" = (
-/obj/structure/chair,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/area/medical/medbay/central)
 "bnj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
@@ -16159,6 +16176,13 @@
 	dir = 4;
 	pixel_x = -11
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "bnw" = (
@@ -16430,6 +16454,12 @@
 /area/science/misc_lab)
 "boE" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "boG" = (
@@ -17134,6 +17164,8 @@
 "brv" = (
 /obj/effect/turf_decal/bot_red,
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bry" = (
@@ -17175,6 +17207,7 @@
 	name = "Chemistry RC";
 	receive_ore_updates = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "brK" = (
@@ -26247,7 +26280,13 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "cbT" = (
-/turf/open/floor/plating/elevatorshaft,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/medical/storage)
 "cbV" = (
 /obj/structure/cable,
@@ -26468,6 +26507,12 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"cde" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "cdk" = (
 /obj/structure/rack,
 /obj/item/clothing/gloves/color/yellow,
@@ -32170,11 +32215,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "cyS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -35879,6 +35928,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cMI" = (
@@ -39232,6 +39282,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"dcM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "ddh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 6
@@ -39281,6 +39341,21 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"dkl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"dlq" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dmw" = (
 /obj/structure/table,
 /obj/item/storage/box/shipping,
@@ -39309,6 +39384,20 @@
 "dqB" = (
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
+"dro" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"drv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "duA" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -39351,6 +39440,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
+"dCp" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dDa" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -39391,6 +39486,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"dLF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "dMF" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -39444,6 +39544,11 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"dWj" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "dWI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 5
@@ -39487,6 +39592,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ehr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "ehC" = (
 /obj/structure/rack,
 /obj/item/radio/off,
@@ -39551,6 +39660,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"eqE" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "eqU" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/space/basic,
@@ -39603,6 +39720,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"eyC" = (
+/obj/machinery/smartfridge/organ,
+/obj/machinery/camera{
+	c_tag = "Surgery A";
+	name = "Surgery Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "eze" = (
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -39641,6 +39767,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"eJa" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "eLa" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -39701,6 +39842,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"fjK" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "fjZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
@@ -39724,6 +39875,15 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"foi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "fpK" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39798,6 +39958,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"fwL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fwU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/directional/east,
@@ -39828,6 +39996,9 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/iron,
 /area/space)
+"fzh" = (
+/turf/open/floor/plating/elevatorshaft,
+/area/medical/storage)
 "fAI" = (
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
@@ -39869,6 +40040,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fJE" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -39948,6 +40123,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"fYy" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "fZf" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/stripes/line,
@@ -40064,6 +40244,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"gof" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
+"gpk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "gqT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -40131,6 +40321,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"gyV" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "gzW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -40147,6 +40345,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gEO" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gGz" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/dark,
@@ -40167,6 +40374,16 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"gQU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "gRT" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -40203,6 +40420,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"gXC" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/optable,
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "haR" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -40249,6 +40472,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"hfi" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Pharmacy";
+	name = "Medbay Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hfS" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -40295,6 +40526,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hmq" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "hob" = (
 /turf/closed/wall,
 /area/security/brig)
@@ -40485,6 +40722,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"iee" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "igc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/neutral{
@@ -40512,6 +40755,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"iiP" = (
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "ijl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40531,11 +40780,25 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"ioI" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "iqJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/service/library)
+"iyo" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "iyV" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/stack/sheet/mineral/sandbags{
@@ -40708,6 +40971,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"jiQ" = (
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/hemostat,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
+"jiU" = (
+/obj/structure/closet/secure_closet/medical2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "jjw" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
@@ -40929,6 +41202,15 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/space)
+"jRf" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"jTz" = (
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "jUc" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -40998,6 +41280,16 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"kke" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "knY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -41093,6 +41385,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
+"kQh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "kQJ" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -41110,6 +41407,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"kRJ" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "kTu" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -41316,6 +41618,26 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"lHQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"lII" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "lIQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -41336,6 +41658,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"lPC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "lUI" = (
 /obj/structure/sign/directions/engineering{
 	pixel_x = -30
@@ -41410,6 +41738,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"mkk" = (
+/obj/structure/table,
+/obj/item/storage/box/masks,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "mkP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -41453,6 +41786,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"mqI" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "mqW" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas,
@@ -41520,6 +41859,12 @@
 /obj/item/target/syndicate,
 /turf/open/floor/iron,
 /area/science/misc_lab/range)
+"mwL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mxv" = (
 /obj/structure/window,
 /obj/machinery/hydroponics/constructable,
@@ -41529,6 +41874,16 @@
 /obj/structure/stairs/south,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"myo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mAK" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41556,6 +41911,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"mII" = (
+/obj/structure/table,
+/obj/item/circular_saw,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "mJP" = (
 /obj/structure/chair{
 	dir = 8
@@ -41595,6 +41955,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"mOb" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "mOS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -41629,6 +41994,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/science/explab)
+"mVS" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "mVT" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -41637,6 +42008,14 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"mXl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "ncQ" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/duct,
@@ -41750,6 +42129,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/robotics)
+"npX" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "nqe" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -41779,12 +42163,35 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"nwB" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
 /obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/space)
+"nyw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "nzM" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -41856,6 +42263,22 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library)
+"nDg" = (
+/obj/structure/table,
+/obj/item/clothing/suit/apron/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/color/latex,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
+"nDv" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "nDG" = (
 /obj/structure/sink{
 	dir = 4;
@@ -41905,6 +42328,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"nNN" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "nOf" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase/lawyer,
@@ -41916,6 +42343,20 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
+"nQv" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/storage)
 "nSk" = (
 /obj/structure/chair{
 	dir = 1
@@ -41979,6 +42420,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"okg" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "omh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -42024,6 +42469,10 @@
 "osl" = (
 /turf/open/floor/white,
 /area/service/library)
+"ouW" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "owj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42037,6 +42486,10 @@
 	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"owo" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "oEh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -42193,11 +42646,22 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"plL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "psH" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"ptO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "pux" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/light/directional/north,
@@ -42238,6 +42702,12 @@
 "pAS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
+"pGu" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "pHZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42307,6 +42777,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"pXZ" = (
+/obj/structure/table,
+/obj/item/cautery,
+/obj/item/retractor,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "pZN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
@@ -42321,6 +42797,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"qaM" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "qdp" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -42346,11 +42832,22 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"qhE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "qji" = (
 /obj/structure/closet/firecloset,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"qkD" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qlV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -42362,10 +42859,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
+"qmD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qna" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
+"qoA" = (
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "qqq" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
@@ -42407,6 +42913,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qyR" = (
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -42569,6 +43081,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
+"rcT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "rdy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42613,6 +43135,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"rri" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/department/medical)
 "rsn" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/turf_decal/siding/wood,
@@ -42654,6 +43190,10 @@
 /obj/item/clothing/gloves/cargo_gauntlet,
 /turf/open/floor/iron,
 /area/space)
+"rEq" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "rGv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42664,6 +43204,17 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"rKt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "rLc" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -42729,6 +43280,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"rOH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"rQT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "rRf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
@@ -42777,6 +43339,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science)
+"rWJ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "rWX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -42806,6 +43374,16 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/space)
+"sao" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "sgD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -42880,6 +43458,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"sAR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "sBD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -42890,6 +43478,15 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"sBX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "sHB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -42936,12 +43533,24 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"sRT" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "sSa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"sTb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "sTr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -42964,6 +43573,30 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"sXo" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "sYV" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/bot,
@@ -42998,6 +43631,11 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
+"tjr" = (
+/obj/structure/table,
+/obj/item/surgicaldrill,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "tjt" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -43025,6 +43663,16 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"toF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "tsg" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43182,6 +43830,16 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"tJE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "tKH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 10
@@ -43204,6 +43862,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/space)
+"tPu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "tRe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -43214,6 +43878,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tWG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "tXD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43308,6 +43980,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/tools)
+"uwz" = (
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uwK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -43327,6 +44003,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/space)
+"uAi" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "uAJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -43355,6 +44035,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"uHu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "uJd" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -43448,6 +44136,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vbm" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "vds" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -43471,6 +44163,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vjw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "vjO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -43503,6 +44205,12 @@
 "vkV" = (
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"vmZ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vnA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43540,6 +44248,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"vvi" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "vwM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -43562,6 +44275,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"vAu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"vCm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vCx" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
@@ -43591,6 +44317,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars)
+"vMe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "vNP" = (
 /obj/structure/rack,
 /obj/item/gun/grenadelauncher,
@@ -43604,6 +44340,12 @@
 /obj/effect/turf_decal/siding/wideplating/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vOq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "vQG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43625,6 +44367,15 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"vQV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "vRn" = (
 /obj/machinery/requests_console/directional/south{
 	department = "Cargo Bay";
@@ -43675,6 +44426,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"wlt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "wlG" = (
 /obj/structure/reflector/single,
 /turf/open/floor/engine,
@@ -43760,6 +44517,14 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"wFP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "mainsurgery";
+	name = "Surgery Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/medical/surgery)
 "wFX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43786,6 +44551,11 @@
 /obj/machinery/bluespace_vendor/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"wLr" = (
+/obj/structure/cable,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "wLO" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -43845,6 +44615,17 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wXA" = (
+/obj/structure/table,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medigel/sterilizine,
+/obj/machinery/button/door/directional/east{
+	id = "mainsurgery";
+	name = "Privacy Button";
+	req_access_txt = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "wZO" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -43872,6 +44653,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library)
+"xfL" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Morgue";
+	name = "Medbay Camera";
+	network = list("ss13","medbay")
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xgL" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck,
@@ -43985,6 +44777,10 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/space)
+"xzL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "xzX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44129,6 +44925,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"yik" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "yjV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44138,6 +44941,16 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/department/medical)
+"ylf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 
 (1,1,1) = {"
 aaa
@@ -84855,7 +85668,7 @@ aQG
 aIT
 aHx
 aHx
-aHx
+fJE
 aYK
 aZO
 aZO
@@ -85368,9 +86181,9 @@ aEd
 bwG
 aIT
 bdK
-beO
-beO
-beO
+uwz
+aQN
+nNN
 bgi
 beJ
 cLv
@@ -85626,10 +86439,10 @@ aRN
 aIT
 bdK
 beO
-beO
-beO
+lHQ
+tPu
 bdp
-cLv
+rWJ
 bgl
 aZa
 cWw
@@ -85880,10 +86693,10 @@ bbl
 bbl
 bvL
 bwJ
-aIT
+wLr
 bdK
 beO
-beO
+aQT
 beO
 cAQ
 cAQ
@@ -86132,15 +86945,15 @@ aHx
 aHx
 aHx
 aHx
-aHx
-aHx
-aHx
-bla
-aHx
 aXM
-bdK
-beO
-beO
+aXM
+aXM
+rri
+aXM
+aXM
+aXM
+dlq
+aQT
 beO
 cAQ
 aXN
@@ -86389,23 +87202,23 @@ aHx
 bdK
 bdK
 aRR
-bdK
-bdK
-bdK
-bdK
-bdK
-bdK
-bdK
-beO
-beO
-beO
+aXM
+jiU
+iiP
+vMe
+nDg
+npX
+wFP
+xfL
+toF
+plL
 cFF
 aYb
-cyf
+foi
 aZb
-cyf
-bno
-cyf
+ehr
+fYy
+avk
 bno
 bbq
 cyf
@@ -86644,21 +87457,21 @@ aEd
 aNJ
 aEd
 bdK
-beO
+aQN
 aRK
-aSH
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+aXM
+eyC
+gof
+tWG
+jTz
+pXZ
+wFP
+dCp
+aQT
 beO
 cFF
 aYi
-bno
+fjK
 bfj
 aZV
 bfj
@@ -86903,20 +87716,20 @@ aHx
 bdK
 beO
 beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+aXM
+gXC
+mOb
+vMe
+jTz
+mII
+wFP
+dCp
+aQT
 beO
 cFF
 bfb
-cyf
-cyf
+rcT
+dLF
 blL
 bae
 bno
@@ -87160,19 +87973,19 @@ aHx
 bdK
 beO
 beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+aXM
+dWj
+xzL
+nDv
+jTz
+jiQ
+wFP
+dCp
+aQT
 beO
 cFF
-cyf
-cyf
+lII
+sAR
 aZc
 cNm
 baf
@@ -87417,16 +88230,16 @@ aOx
 aPt
 aMl
 beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+aXM
+mqI
+vvi
+vMe
+wXA
+tjr
+wFP
+dCp
+sao
+mwL
 cAQ
 aYj
 cFF
@@ -87672,20 +88485,20 @@ aHx
 bla
 aHx
 bdK
-aQN
+aQT
+beO
+aXM
+aXM
+aXM
+sXo
+aXM
+aXM
+aXM
+gEO
+aQT
 beO
 beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+aQT
 beO
 aZf
 biP
@@ -87929,26 +88742,26 @@ aHx
 bla
 bdK
 bdK
-aQN
+aQT
 beO
 beO
 beO
 beO
+aQT
+owo
 beO
 beO
 beO
+aQT
 beO
 beO
-beO
-beO
-beO
-beO
+aQT
 beO
 aZn
 bky
 bky
 bky
-bnh
+bky
 bky
 bky
 bru
@@ -88187,32 +89000,32 @@ bla
 bdK
 aPv
 cyS
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+wlt
+fwL
+wlt
+nyw
+myo
+vCm
+tPu
+tPu
+dkl
+ylf
+dro
+dro
+lPC
+dro
 aZo
-bky
-bky
-bky
-bky
-bky
-bky
+kQh
+kQh
+kQh
+kQh
+sBX
+kQh
 brv
-bsh
-cpH
-btm
-crm
+eJa
+nwB
+ptO
+bgv
 btm
 bww
 bxt
@@ -88443,27 +89256,27 @@ aHx
 bla
 bdK
 aPv
-cyS
+bnh
 beO
+qmD
 beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+vAu
+qkD
+aSD
+aSo
+vbm
+qaM
+sRT
+aSo
+aSD
+aQT
 beO
 aZn
 bky
 bky
 bky
 bky
-bky
+vQV
 bky
 bky
 bdI
@@ -88700,27 +89513,27 @@ aHx
 bla
 bdK
 aPv
-cyS
+bnh
 bta
 bta
 bta
 bta
-bta
-bta
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+okg
+aSD
+iyo
+qoA
+drv
+rEq
+iyo
+aSD
+aQT
 beO
 bhD
 aZW
 bkv
 bky
 bky
-bky
+vQV
 bky
 bky
 bsh
@@ -88957,20 +89770,20 @@ aHx
 bla
 bdK
 bdK
-cyS
+aMu
+gyV
+qyR
+mkk
 bta
-bta
-bta
-bta
-bta
-bta
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+okg
+aSo
+pGu
+qhE
+rOH
+rEq
+qoA
+aSD
+aQT
 beO
 bhD
 biU
@@ -89215,26 +90028,26 @@ bla
 bdK
 cuR
 aQS
+bte
+bte
+bte
+uAi
 bta
-bta
-bte
-bte
-bte
-aSe
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+aSo
+eqE
+qoA
+drv
+rEq
+qoA
+vbm
+aQT
 beO
 aZQ
 bky
 bag
 bkv
 cXI
-bky
+cde
 bky
 bky
 bhF
@@ -89472,26 +90285,26 @@ bla
 bdK
 aKz
 aQT
-bta
-bta
 bte
+fzh
+fzh
 cbT
-cbT
+bta
 aSo
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+hmq
+rEq
+kke
+rEq
+rEq
+sRT
+aQT
 beO
 bhD
 biW
 baj
 bbc
 bky
-bky
+cde
 bky
 bky
 bhF
@@ -89729,26 +90542,26 @@ bla
 bdK
 bdK
 aQT
-bta
-bta
 bte
+fzh
+fzh
 cbT
-cbT
+bta
 aSo
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+ioI
+rQT
+mXl
+qoA
+qoA
+aSD
+aQT
 beO
 bhD
 aZX
 bkv
 bkv
 mrE
-bky
+vOq
 bky
 bky
 bhF
@@ -89986,19 +90799,19 @@ aNU
 aHx
 bdK
 aQT
-bta
-bta
 bte
-cbT
-cbT
+fzh
+fzh
+nQv
+bta
 aSD
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+mVS
+qoA
+kke
+qoA
+jRf
+aSD
+aQT
 beO
 bhD
 xbW
@@ -90240,22 +91053,22 @@ aGJ
 aHx
 aHx
 aNV
-aRE
+fCC
 aMV
 aMm
+bte
+bte
+bte
+bte
 bta
-bta
-bte
-bte
-bte
-bte
-beO
-beO
-beO
-beO
-beO
-beO
-beO
+aSD
+aSo
+vbm
+rKt
+vbm
+aSo
+aSD
+aQT
 beO
 bhW
 bjd
@@ -90505,17 +91318,17 @@ beO
 beO
 beO
 beO
+owo
+beO
+beO
+aQT
 beO
 beO
 beO
-beO
-beO
-beO
-beO
-beO
+aQT
 beO
 bhW
-bky
+bck
 bky
 bky
 bky
@@ -90762,15 +91575,15 @@ aSX
 aOA
 bZT
 bZT
-bZT
+yik
 bZT
 bZT
 aWw
-beO
+dro
 aXK
-beO
-beO
-beO
+dro
+iee
+plL
 bhK
 bhK
 bkC
@@ -91026,7 +91839,7 @@ aWN
 aXE
 bte
 beO
-beO
+aQT
 beO
 bhL
 aZY
@@ -91282,9 +92095,9 @@ aZi
 aWP
 bbr
 bte
-beO
-beO
-beO
+hfi
+sao
+mwL
 bhM
 blX
 bkE
@@ -91540,16 +92353,16 @@ ape
 bbs
 bte
 beO
-beO
-beO
+tJE
+tPu
 biX
-blX
+dcM
 ucU
 ogF
 bnu
 boJ
 ucU
-blX
+kRJ
 bhK
 btm
 btm
@@ -91796,16 +92609,16 @@ aUM
 aWR
 bbt
 bte
-beO
-beO
-beO
+vmZ
+vmZ
+vmZ
 bhK
-blX
-blX
-blX
+gQU
+gpk
+uHu
 bnv
-blX
-blX
+sTb
+ouW
 brG
 bhK
 btx
@@ -92060,7 +92873,7 @@ bhK
 bac
 bal
 bbh
-blX
+vjw
 bbu
 bcv
 bdv

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -14798,11 +14798,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "bhW" = (
@@ -39346,6 +39346,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"dpu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "dpR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
@@ -39737,11 +39743,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "eLa" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -40337,6 +40344,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "gxs" = (
@@ -40359,6 +40367,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gDq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "gEA" = (
 /obj/structure/table,
 /obj/item/circular_saw,
@@ -40384,6 +40396,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"gKF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "gRT" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -41494,7 +41512,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "kQV" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -41938,15 +41955,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mkE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/treatment_center)
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "mkP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -43734,6 +43745,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
+"sTS" = (
+/obj/effect/mapping_helpers/dead_body_placer,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "sWI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -85682,8 +85698,8 @@ cnr
 bfe
 bgi
 bhR
-cLv
-cLv
+mkE
+dpu
 cLv
 cLv
 cLv
@@ -86452,12 +86468,12 @@ giJ
 bgi
 beJ
 cLv
-aXH
-cLv
-cLv
-bpU
-cLv
-cLv
+eKn
+gDq
+gDq
+sTS
+gDq
+gKF
 cLv
 cLv
 bgi
@@ -89530,8 +89546,8 @@ beO
 aSD
 aSo
 dqs
-mkE
-nGc
+nkR
+dqs
 aSo
 aSD
 vEC
@@ -89787,8 +89803,8 @@ bta
 aSD
 ivN
 ptC
-eKn
-xZB
+rzp
+ptC
 ivN
 aSD
 lan
@@ -90045,7 +90061,7 @@ aSo
 ivL
 rrF
 gvV
-xZB
+ptC
 feF
 aSD
 lan
@@ -90301,7 +90317,7 @@ bta
 aSo
 tYg
 ptC
-eKn
+rzp
 kQV
 ptC
 dqs

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -1033,11 +1033,6 @@
 "afm" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
-"afp" = (
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "afq" = (
 /obj/item/stock_parts/cell/potato{
 	name = "\improper Beepsky's emergency battery"
@@ -10315,8 +10310,7 @@
 	pixel_y = 30
 	},
 /obj/machinery/camera{
-	c_tag = "Cryogenics";
-	name = "Cryogenics Camera";
+	c_tag = "Medbay - Cryogenics";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -12718,8 +12712,7 @@
 "aWX" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/camera{
-	c_tag = "Medical Storage";
-	name = "Medical Storage Camera";
+	c_tag = "Medbay - Storage";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -13164,6 +13157,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/camera{
+	c_tag = "Medbay - Morgue";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "aZa" = (
@@ -13281,6 +13278,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"aZL" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "aZO" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -13329,8 +13330,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Lobby NE";
-	name = "Medbay Lobby Camera";
+	c_tag = "Medbay - Lobby E";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -13617,9 +13617,8 @@
 "bbu" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera{
-	c_tag = "Pharmacy";
+	c_tag = "Medbay - Pharmacy";
 	dir = 8;
-	name = "Pharmacy Camera";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -13677,10 +13676,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"bca" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "bcf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -15796,9 +15791,8 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /obj/machinery/camera{
-	c_tag = "Medbay Lobby SW";
+	c_tag = "Medbay - Lobby W";
 	dir = 4;
-	name = "Medbay Lobby Camera";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -16898,10 +16892,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"bqq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "bqr" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/west,
@@ -21270,16 +21260,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"bEy" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "bEz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -35380,6 +35360,7 @@
 /area/engineering/main)
 "cKy" = (
 /obj/machinery/light/blacklight/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "cKz" = (
@@ -36485,10 +36466,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
-"cOZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "cPa" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -39278,12 +39255,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"cYY" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "cZG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -39341,6 +39312,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"diV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "djJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -39382,6 +39361,16 @@
 "dqB" = (
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
+"duv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "duA" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -39396,27 +39385,16 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"dvA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "dzf" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/bluespace_vendor/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"dBo" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/firealarm/directional/east,
+"dAQ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/security/checkpoint/medical)
 "dBV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39444,10 +39422,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/commons/dorms)
-"dEF" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "dEZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -39458,6 +39432,11 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"dFR" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "dGr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -39528,6 +39507,16 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"dSR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dUL" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -39595,6 +39584,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
+"eiT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "eiV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -39631,12 +39627,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"ena" = (
-/obj/machinery/iv_drip,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "ene" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -39683,6 +39673,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"etr" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/medical/medbay/lobby)
 "etz" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
@@ -39702,17 +39697,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"eya" = (
-/obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/reagent_containers/medigel/sterilizine,
-/obj/machinery/button/door/directional/east{
-	id = "mainsurgery";
-	name = "Privacy Button";
-	req_access_txt = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "eze" = (
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -39725,29 +39709,21 @@
 /obj/item/firing_pin/implant/mindshield,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"eDG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"eDM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "eEO" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"eFr" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/camera{
+	c_tag = "Medbay - Elevator";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "eFy" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"eHg" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "eHp" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255
@@ -39767,14 +39743,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"eID" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "eLa" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"eLt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "eNp" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
@@ -39782,25 +39763,18 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"eOZ" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/west,
+"eNA" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera{
+	c_tag = "Medbay - Treatment Center";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"eSd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"eUR" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "eVD" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -39841,17 +39815,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"feJ" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"fhV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "fiV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -39876,13 +39839,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"flE" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "fmk" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -39891,6 +39847,11 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"foM" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/operating,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "fpK" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39942,12 +39903,6 @@
 	},
 /turf/open/floor/plating,
 /area/commons/dorms)
-"fru" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "frR" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
@@ -40021,11 +39976,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"fDA" = (
-/obj/structure/table,
-/obj/item/storage/box/masks,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "fEA" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -40047,16 +39997,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fGX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
+"fGw" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/surgery)
+"fKL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -40095,10 +40048,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"fPL" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "fQS" = (
 /obj/structure/window{
 	dir = 1
@@ -40122,6 +40071,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"fSw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "fTJ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/cleaner,
@@ -40203,6 +40156,12 @@
 /obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"ghC" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ghI" = (
 /obj/structure/railing{
 	dir = 4
@@ -40214,6 +40173,21 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"gjL" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "gkY" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock";
@@ -40225,6 +40199,15 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"gmK" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "gnv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
@@ -40260,12 +40243,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"gsn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "gsC" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -40336,6 +40313,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"gAF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "gCa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -40345,35 +40326,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gEj" = (
-/obj/machinery/disposal/bin,
+"gFN" = (
+/obj/structure/table,
+/obj/item/storage/box/masks,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"gFZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
+/area/medical/storage)
 "gGz" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
-"gIz" = (
-/obj/structure/table,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
 "gJn" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"gKi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "gKm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -40385,16 +40351,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"gQJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "gRT" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -40409,6 +40365,9 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
 /area/engineering/engine_smes)
+"gWy" = (
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "gXc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -40523,28 +40482,9 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hkY" = (
-/obj/structure/table,
-/obj/item/scalpel,
-/obj/item/hemostat,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
-"hmc" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "hob" = (
 /turf/closed/wall,
 /area/security/brig)
-"hok" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hoD" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -40590,6 +40530,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"hwV" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "hxc" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40605,6 +40549,16 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hzm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "hBi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -40640,6 +40594,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"hFE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "hGO" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/closed/wall/r_wall,
@@ -40660,15 +40624,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hKu" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
+"hKJ" = (
+/obj/machinery/smartfridge/organ,
+/obj/machinery/camera{
+	c_tag = "Medbay - Surgery A";
+	network = list("ss13","medbay")
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "hLt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -40678,38 +40641,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hMs" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"hMt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "hME" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"hPl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "hPD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -40719,11 +40656,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hSb" = (
+"hQq" = (
 /obj/structure/table,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/color/latex,
+/obj/machinery/requests_console/directional/west{
+	department = "Surgery";
+	departmentType = 1;
+	name = "Surgery Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "hTK" = (
@@ -40739,10 +40681,28 @@
 /obj/structure/stairs/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"hVO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hVV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"hXk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"hXp" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "hXT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -40811,36 +40771,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"imE" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "inh" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
-"inS" = (
-/obj/structure/closet/secure_closet/medical2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"inT" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"inZ" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/medical/storage)
 "iog" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40851,14 +40785,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"itn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "iyV" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/stack/sheet/mineral/sandbags{
@@ -40878,16 +40804,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"izU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "iAk" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -40915,18 +40831,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron,
 /area/space)
-"iFv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
-"iFD" = (
-/obj/machinery/stasis,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "iGq" = (
 /obj/machinery/camera{
 	c_tag = "Minisat Exterior SE";
@@ -40935,16 +40839,26 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"iKv" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Surgery Maintenance";
+	req_access_txt = "45"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/maintenance/department/medical)
 "iKK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"iQX" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40983,19 +40897,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"iYr" = (
-/obj/structure/table,
-/obj/item/circular_saw,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "iYI" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"jad" = (
-/turf/open/floor/plating/elevatorshaft,
-/area/medical/storage)
 "jbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41010,16 +40916,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"jcp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "jcz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -41088,20 +40984,11 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"jlj" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+"jlz" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
-"jmC" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/security/checkpoint/medical)
 "jmW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -41153,14 +41040,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"jsi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "jtK" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -41184,12 +41063,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/chapel/main)
-"juY" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table/optable,
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "jvH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -41199,6 +41072,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"jwr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "jwD" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -41213,22 +41092,11 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
-"jAB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"jAL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+"jEM" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/surgery,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "jEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41351,6 +41219,30 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"jUK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
+"jVn" = (
+/obj/structure/table,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"jVs" = (
+/obj/machinery/camera{
+	c_tag = "Medbay - Security Post";
+	dir = 8;
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "jVy" = (
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
@@ -41409,6 +41301,16 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"khF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "knY" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -41447,6 +41349,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"kBK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"kBL" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "kBU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/radio/intercom/directional/south,
@@ -41473,14 +41389,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
-"kHU" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "kId" = (
 /turf/open/floor/plating,
 /area/commons/dorms)
+"kJu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "kJX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41576,6 +41493,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"kYs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "kYQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -41605,6 +41531,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
+"ldh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ldq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -41617,12 +41548,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/main)
-"lek" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "leP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/warning/vacuum/external{
@@ -41699,11 +41624,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/commons/dorms)
-"lwV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "lAI" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41763,6 +41683,22 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"lSe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"lTj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "lUI" = (
 /obj/structure/sign/directions/engineering{
 	pixel_x = -30
@@ -41770,6 +41706,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"lVb" = (
+/obj/structure/cable,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/maintenance/department/medical)
 "lVC" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -41794,12 +41735,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"lXC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "mar" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41830,16 +41765,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
-"mhb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "mjr" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -41853,12 +41778,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"mkL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "mkP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -41910,6 +41829,16 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"mra" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mrE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -42005,10 +41934,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"mIL" = (
-/obj/item/kirbyplants/random,
+"mIE" = (
+/obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
-/area/medical/storage)
+/area/security/checkpoint/medical)
+"mJe" = (
+/obj/structure/table,
+/obj/item/surgicaldrill,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "mJP" = (
 /obj/structure/chair{
 	dir = 8
@@ -42090,20 +42030,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"mZV" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "ncQ" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/duct,
@@ -42187,11 +42113,6 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"nnh" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "nnm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -42233,6 +42154,16 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"nrs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "nrA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -42257,6 +42188,11 @@
 /obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/space)
+"nxG" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "nzM" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -42328,12 +42264,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/service/library)
-"nDc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "nDG" = (
 /obj/structure/sink{
 	dir = 4;
@@ -42361,6 +42291,9 @@
 	},
 /turf/open/floor/wood,
 /area/service/library)
+"nKm" = (
+/turf/open/floor/plating/elevatorshaft,
+/area/medical/storage)
 "nLu" = (
 /obj/structure/closet/radiation,
 /obj/effect/spawner/lootdrop/gloves,
@@ -42394,30 +42327,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
-"nSc" = (
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre";
-	req_access_txt = "45"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "nSk" = (
 /obj/structure/chair{
 	dir = 1
@@ -42443,6 +42352,12 @@
 "nZK" = (
 /turf/closed/wall/r_wall,
 /area/space)
+"nZU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "oaI" = (
 /obj/structure/chair{
 	name = "Bailiff"
@@ -42461,6 +42376,10 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"ofJ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "ofP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -42490,14 +42409,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"onj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "onX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 9
@@ -42534,6 +42445,13 @@
 "osl" = (
 /turf/open/floor/white,
 /area/service/library)
+"ovM" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "owj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42547,6 +42465,16 @@
 	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"oxX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "oEh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -42555,6 +42483,12 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"oFK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "oHG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -42562,6 +42496,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oHK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "oIk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -42638,6 +42577,29 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"oTC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"oUy" = (
+/obj/structure/table,
+/obj/item/circular_saw,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
+"oVf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "mainsurgery";
+	name = "Surgery Privacy Door"
+	},
+/turf/open/floor/plating,
+/area/medical/surgery)
 "oVs" = (
 /obj/structure/table,
 /obj/item/toy/eightball,
@@ -42703,6 +42665,16 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"pnv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "psH" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/south,
@@ -42748,6 +42720,16 @@
 "pAS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
+"pBk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "pHZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42791,6 +42773,15 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"pOb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "pQK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -42801,13 +42792,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
-"pSS" = (
+"pRz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 9
 	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
+"pRT" = (
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "pWh" = (
@@ -42819,6 +42817,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pWM" = (
+/obj/structure/table,
+/obj/item/scalpel,
+/obj/item/hemostat,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "pXg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42840,17 +42844,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"qbP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
 "qdp" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -42876,19 +42869,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"qhK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "qji" = (
 /obj/structure/closet/firecloset,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
+"qln" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "qlV" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -42904,41 +42893,14 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/misc_lab)
-"qnr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+"qpN" = (
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
-/area/medical/surgery)
-"qnO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/medical/medbay/central)
 "qqq" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
-"qrp" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"qrA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "quc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -42954,14 +42916,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"qvS" = (
-/obj/structure/table,
-/obj/item/storage/box/gloves,
-/obj/structure/sign/departments/medbay/alt{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "qwp" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics Internal Airlock";
@@ -42984,6 +42938,22 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qBl" = (
+/obj/structure/table,
+/obj/item/surgical_drapes,
+/obj/item/reagent_containers/medigel/sterilizine,
+/obj/machinery/button/door/directional/east{
+	id = "mainsurgery";
+	name = "Privacy Button";
+	req_access_txt = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
+"qCw" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43000,6 +42970,20 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"qHn" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/button/elevator{
+	id = "publicElevator";
+	pixel_x = 25
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/medical/storage)
 "qJs" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -43065,16 +43049,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/dorms)
-"qRU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qTJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 4
@@ -43150,22 +43124,50 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"rbV" = (
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre";
+	req_access_txt = "45"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "rbY" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/space)
-"rct" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/computer/operating,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "rdy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"reW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
+"rjK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "rkl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -43196,21 +43198,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"roQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
-"rpX" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "rqh" = (
 /obj/machinery/holopad,
 /obj/item/beacon,
@@ -43271,6 +43258,21 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"rIm" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "rLc" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
@@ -43336,11 +43338,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"rOL" = (
+"rQV" = (
 /obj/structure/cable,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "rRf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
@@ -43418,6 +43423,15 @@
 /obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/space)
+"sbD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "sgD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -43450,24 +43464,6 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"skd" = (
-/obj/machinery/requests_console/directional/north{
-	department = "Medbay";
-	departmentType = 1;
-	name = "Medbay RC"
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
-"skl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"snW" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/pharmacy)
 "ssn" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -30
@@ -43488,32 +43484,6 @@
 "ste" = (
 /turf/open/space/basic,
 /area/commons/dorms)
-"svy" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Morgue";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
-"swf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "swA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43531,6 +43501,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
+"sxC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "szw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43565,36 +43545,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"sKl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+"sJG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"sMp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/treatment_center)
-"sNH" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "sPg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible/layer2{
 	dir = 1
@@ -43622,17 +43578,20 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
+"sRj" = (
+/obj/structure/table,
+/obj/item/storage/box/gloves,
+/obj/structure/sign/departments/medbay/alt{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "sSa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"sSm" = (
-/obj/structure/table,
-/obj/item/surgicaldrill,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "sTr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -43660,11 +43619,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/space)
-"taA" = (
+"tbA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/structure/cable,
+/obj/machinery/requests_console/directional/east{
+	department = "Morgue";
+	departmentType = 1;
+	name = "Morgue Requests Console"
+	},
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "tcQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -43675,14 +43640,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"teJ" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Hall - Pharmacy";
-	name = "Medbay Camera";
-	network = list("ss13","medbay")
+"teg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/security/checkpoint/medical)
 "teP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -43692,10 +43655,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"tfv" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/department/medical)
 "tiZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -43727,35 +43686,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"tnN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "tnQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"tqA" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Surgery Maintenance";
-	req_access_txt = "45"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/maintenance/department/medical)
 "tsg" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -43821,9 +43757,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"txK" = (
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "tyl" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -43898,6 +43831,12 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/iron,
 /area/space)
+"tHH" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tHO" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -43925,6 +43864,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"tKM" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "tLp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -43933,20 +43876,17 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"tMd" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "tML" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/space)
-"tMS" = (
-/turf/open/floor/iron/white,
-/area/medical/surgery)
-"tOY" = (
-/obj/structure/table,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "tRe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -43957,11 +43897,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"tWy" = (
+"tUw" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"tVv" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tXD" = (
@@ -44026,16 +43971,6 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"ujK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "ujZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -44044,6 +43979,10 @@
 /obj/item/toy/figure/cargotech,
 /turf/open/floor/iron,
 /area/space)
+"umH" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uql" = (
 /obj/structure/cable,
 /obj/effect/loot_site_spawner,
@@ -44059,6 +43998,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"uwf" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/optable,
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "uwq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -44087,6 +44032,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/space)
+"uAI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "uAJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -44097,6 +44048,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uEb" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "uEA" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/directional/south,
@@ -44111,16 +44066,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"uFQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "uGx" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
@@ -44130,6 +44075,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uMe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uMD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44148,16 +44099,10 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"uNZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+"uNQ" = (
+/obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "uPf" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
@@ -44181,6 +44126,11 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"uSU" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uTy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44195,6 +44145,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"uUS" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Morgue";
+	network = list("ss13","medbay")
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uWr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -44209,6 +44169,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uWF" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "uYO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 4
@@ -44251,10 +44215,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"viO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/surgery)
 "vjO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -44324,6 +44284,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"vvG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vwM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -44346,11 +44313,25 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"vCb" = (
+/obj/machinery/iv_drip,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "vCx" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vEi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "vFP" = (
 /obj/machinery/light_switch/directional/west,
 /turf/closed/wall,
@@ -44420,6 +44401,16 @@
 "vSj" = (
 /turf/open/floor/plating,
 /area/engineering/storage_shared)
+"vSN" = (
+/obj/machinery/stasis,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"vUl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/security/checkpoint/medical)
 "vUt" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
@@ -44450,6 +44441,13 @@
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
+"wad" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "wbs" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -44484,6 +44482,17 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/space)
+"wrB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/treatment_center)
 "wrR" = (
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/iron,
@@ -44513,21 +44522,12 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"wvU" = (
-/obj/structure/table,
-/obj/item/cautery,
-/obj/item/retractor,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
-"wyq" = (
-/obj/machinery/smartfridge/organ,
-/obj/machinery/camera{
-	c_tag = "Surgery A";
-	name = "Surgery Camera";
-	network = list("ss13","medbay")
+"wvB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/medical/surgery)
+/area/medical/medbay/central)
 "wys" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -44572,14 +44572,16 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"wJn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "mainsurgery";
-	name = "Surgery Privacy Door"
+"wJx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/medical/surgery)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "wKL" = (
 /obj/structure/table,
 /obj/item/toy/foamblade,
@@ -44593,6 +44595,14 @@
 /obj/machinery/bluespace_vendor/east,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"wKZ" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Hall - Pharmacy";
+	name = "Medbay Camera";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "wLO" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -44614,11 +44624,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wOu" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/surgery,
-/turf/open/floor/iron/dark,
-/area/medical/surgery)
 "wOw" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 30
@@ -44642,6 +44647,19 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"wQr" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
+"wRn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/pharmacy)
 "wRL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -44667,16 +44685,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"xba" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "xbW" = (
 /obj/structure/table,
 /obj/machinery/light/directional/north,
@@ -44688,6 +44696,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xcs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/surgery)
+"xeS" = (
+/obj/structure/table,
+/obj/item/cautery,
+/obj/item/retractor,
+/turf/open/floor/iron/dark,
+/area/medical/surgery)
 "xfK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44711,16 +44733,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xiW" = (
-/obj/effect/landmark/start/depsec/medical,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/security/checkpoint/medical)
 "xjf" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/white,
@@ -44772,6 +44784,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"xop" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "xoT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -44804,22 +44830,9 @@
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
-"xxy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 9
-	},
+"xvF" = (
 /turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"xxW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/area/medical/surgery)
 "xyD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -44833,12 +44846,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/space)
-"xzk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "xzX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -44877,6 +44884,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"xDK" = (
+/obj/machinery/requests_console/directional/north{
+	department = "Medbay";
+	departmentType = 1;
+	name = "Medbay RC"
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "xGE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -44897,6 +44912,15 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"xJu" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/surgery)
 "xKA" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -85709,7 +85733,7 @@ aQG
 aIT
 aHx
 aHx
-tfv
+hwV
 aYK
 aZO
 aZO
@@ -86222,9 +86246,9 @@ aEd
 bwG
 aIT
 bdK
-gEj
+qpN
 aQN
-inT
+aZL
 bgi
 beJ
 cLv
@@ -86480,10 +86504,10 @@ aRN
 aIT
 bdK
 beO
-xba
-nDc
+kBK
+hXk
 bdp
-mkL
+tbA
 bgl
 aZa
 cWw
@@ -86734,7 +86758,7 @@ bbl
 bbl
 bvL
 bwJ
-rOL
+lVb
 bdK
 beO
 aQT
@@ -86989,11 +87013,11 @@ aHx
 aXM
 aXM
 aXM
-tqA
+iKv
 aXM
 aXM
 aXM
-feJ
+uSU
 aQT
 beO
 cAQ
@@ -87244,22 +87268,22 @@ bdK
 bdK
 aRR
 aXM
-inS
-ena
-gQJ
-hSb
-wOu
-wJn
-svy
-uNZ
-skl
+uNQ
+vCb
+nrs
+hQq
+jEM
+oVf
+uUS
+lTj
+uMe
 cFF
 aYb
-roQ
+kYs
 aZb
-eID
-kHU
-fru
+vUl
+jlz
+teg
 bno
 bbq
 cyf
@@ -87501,18 +87525,18 @@ bdK
 aQN
 aRK
 aXM
-wyq
-viO
-qnr
-tMS
-wvU
-wJn
-eUR
+hKJ
+reW
+xcs
+xvF
+xeS
+oVf
+tMd
 aQT
 beO
 cFF
 aYi
-xiW
+mIE
 bfj
 aZV
 bfj
@@ -87758,23 +87782,23 @@ bdK
 beO
 beO
 aXM
-juY
-jmC
-gQJ
-tMS
-iYr
-wJn
-eUR
+uwf
+qCw
+nrs
+xvF
+oUy
+oVf
+tMd
 aQT
 beO
 cFF
 bfb
-fGX
-gFZ
+hzm
+dAQ
 blL
 bae
 bno
-cyf
+jVs
 bbq
 bcu
 bcy
@@ -88015,18 +88039,18 @@ bdK
 beO
 beO
 aXM
-rct
-bca
-jlj
-tMS
-hkY
-wJn
-eUR
+foM
+fSw
+xJu
+xvF
+pWM
+oVf
+tMd
 aQT
 beO
 cFF
-ujK
-hMt
+pBk
+pRz
 aZc
 cNm
 baf
@@ -88272,15 +88296,15 @@ aPt
 aMl
 beO
 aXM
-dBo
-nnh
-gQJ
-eya
-sSm
-wJn
-eUR
-sKl
-gsn
+hXp
+fGw
+nrs
+qBl
+mJe
+oVf
+tMd
+khF
+hVO
 cAQ
 aYj
 cFF
@@ -88531,11 +88555,11 @@ beO
 aXM
 aXM
 aXM
-nSc
+rbV
 aXM
 aXM
 aXM
-hKu
+gmK
 aQT
 beO
 beO
@@ -88789,7 +88813,7 @@ beO
 beO
 beO
 aQT
-fPL
+umH
 beO
 beO
 beO
@@ -89041,31 +89065,31 @@ bla
 bdK
 aPv
 cyS
-eDM
-onj
-eDM
-jsi
-xxW
-hok
-nDc
-nDc
-qRU
-jcp
-taA
-taA
-fhV
-nDc
+tVv
+fKL
+tVv
+rQV
+sxC
+vvG
+hXk
+hXk
+mra
+dSR
+ldh
+ldh
+oFK
+hXk
 aZo
-lXC
-lXC
-lwV
-lwV
-tnN
-lwV
+kJu
+kJu
+rjK
+rjK
+eLt
+rjK
 brv
-swf
-sNH
-qnO
+gjL
+rIm
+oHK
 bgv
 btm
 bww
@@ -89299,29 +89323,29 @@ bdK
 aPv
 bnh
 beO
-gKi
+wvB
 beO
-eDG
-flE
+lSe
+ovM
 aSD
 aSo
-dEF
-bEy
-sMp
+uWF
+pnv
+dFR
 aSo
 aSD
 aQT
 beO
 aZn
 bky
-iQX
-iQX
-iQX
-uFQ
-iQX
-iQX
+uEb
+uEb
+uEb
+wJx
+uEb
+uEb
 bdI
-mZV
+xop
 buR
 crm
 btm
@@ -89559,22 +89583,22 @@ bta
 bta
 bta
 bta
-imE
+kBL
 aSD
-eOZ
-txK
-pSS
-eHg
-eOZ
+tHH
+gWy
+pOb
+tKM
+tHH
 aSD
 aQT
 beO
 bhD
 aZW
-gIz
+etr
 bky
 bky
-jAB
+sbD
 bky
 bky
 bsh
@@ -89812,23 +89836,23 @@ bla
 bdK
 bdK
 aMu
-qvS
-tOY
-fDA
+sRj
+jVn
+gFN
 bta
-imE
+kBL
 aSo
-hmc
-cOZ
-jAL
-eHg
-txK
+wQr
+gAF
+wad
+tKM
+gWy
 aSD
 aQT
 beO
 bhD
 biU
-gIz
+etr
 blU
 bnj
 boE
@@ -90072,15 +90096,15 @@ aQS
 bte
 bte
 bte
-mIL
+eFr
 bta
 aSo
-qrp
-txK
-pSS
-eHg
-txK
-dEF
+eNA
+gWy
+pOb
+tKM
+gWy
+uWF
 aQT
 beO
 aZQ
@@ -90088,7 +90112,7 @@ bky
 bag
 bkv
 cXI
-lek
+jwr
 bky
 bky
 bhF
@@ -90327,17 +90351,17 @@ bdK
 aKz
 aQT
 bte
-jad
-jad
+nKm
+nKm
 cbT
 bta
 aSo
-cYY
-eHg
-hPl
-eHg
-eHg
-sMp
+tUw
+tKM
+hFE
+tKM
+tKM
+dFR
 aQT
 beO
 bhD
@@ -90345,7 +90369,7 @@ biW
 baj
 bbc
 bky
-lek
+jwr
 bky
 bky
 bhF
@@ -90584,16 +90608,16 @@ bdK
 bdK
 aQT
 bte
-jad
-jad
+nKm
+nKm
 cbT
 bta
 aSo
-skd
-bqq
-qhK
-txK
-txK
+xDK
+qln
+diV
+gWy
+gWy
 aSD
 aQT
 beO
@@ -90602,7 +90626,7 @@ aZX
 bkv
 bkv
 mrE
-xxy
+uAI
 bky
 bky
 bhF
@@ -90841,16 +90865,16 @@ aHx
 bdK
 aQT
 bte
-jad
-jad
-inZ
+nKm
+nKm
+qHn
 bta
 aSD
-iFD
-txK
-hPl
-txK
-hMs
+vSN
+gWy
+hFE
+gWy
+pRT
 aSD
 aQT
 beO
@@ -91104,9 +91128,9 @@ bte
 bta
 aSD
 aSo
-dEF
-qbP
-dEF
+uWF
+wrB
+uWF
 aSo
 aSD
 aQT
@@ -91359,7 +91383,7 @@ beO
 beO
 beO
 beO
-fPL
+umH
 beO
 beO
 aQT
@@ -91616,15 +91640,15 @@ aSX
 aOA
 bZT
 bZT
-tWy
+eiT
 bZT
 bZT
 aWw
-taA
+ldh
 aXK
-taA
-xzk
-skl
+ldh
+sJG
+uMe
 bhK
 bhK
 bkC
@@ -92136,9 +92160,9 @@ aZi
 aWP
 bbr
 bte
-teJ
-sKl
-gsn
+wKZ
+khF
+hVO
 bhM
 blX
 bkE
@@ -92394,16 +92418,16 @@ ape
 bbs
 bte
 beO
-qrA
-nDc
+oTC
+hXk
 biX
-izU
+duv
 ucU
 ogF
 bnu
 boJ
 ucU
-afp
+nxG
 bhK
 btm
 btm
@@ -92650,16 +92674,16 @@ aUM
 aWR
 bbt
 bte
-rpX
-rpX
-rpX
+ghC
+ghC
+ghC
 bhK
-mhb
-iFv
-itn
+jUK
+nZU
+vEi
 bnv
-eSd
-snW
+wRn
+ofJ
 brG
 bhK
 btx
@@ -92914,7 +92938,7 @@ bhK
 bac
 bal
 bbh
-dvA
+oxX
 bbu
 bcv
 bdv

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -18018,6 +18018,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"buO" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
+	},
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Medical Delivery";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "buQ" = (
 /obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron,
@@ -39257,17 +39270,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"dcO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "ddh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 6
@@ -39317,6 +39319,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"dkM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "dmw" = (
 /obj/structure/table,
 /obj/item/storage/box/shipping,
@@ -39349,6 +39357,10 @@
 "dqB" = (
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
+"dst" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "duA" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -39425,6 +39437,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"dKJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "dLf" = (
 /obj/structure/table,
 /obj/item/cautery,
@@ -39525,6 +39543,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"eab" = (
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "ebB" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -39533,15 +39554,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"efF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+"efE" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
 "ehC" = (
 /obj/structure/rack,
@@ -39660,6 +39679,10 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
+"eus" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "evc" = (
 /obj/structure/chair{
 	dir = 1
@@ -39667,6 +39690,11 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"ewM" = (
+/obj/effect/landmark/start/paramedic,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "eze" = (
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -39725,10 +39753,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"eQQ" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "eVD" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -39754,10 +39778,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"fag" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "faL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -39767,16 +39787,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
-"faW" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
-"fbs" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/bounty_board/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "fcq" = (
 /obj/structure/reflector/box,
 /turf/open/floor/engine,
@@ -39800,6 +39810,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"feF" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "fhP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -40017,6 +40031,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fKU" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -40370,6 +40394,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"gST" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "gTq" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/white,
@@ -40652,14 +40680,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"hSN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hTK" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -40684,11 +40704,6 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ibv" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "ibG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40776,6 +40791,17 @@
 /obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"iub" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iuS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 6
@@ -40796,14 +40822,6 @@
 /obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"ixS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "iyE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40855,6 +40873,14 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/iron,
 /area/space)
+"iGf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iGq" = (
 /obj/machinery/camera{
 	c_tag = "Minisat Exterior SE";
@@ -40908,10 +40934,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"iPm" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40950,14 +40972,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"iYx" = (
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "iYI" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"jaJ" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/bounty_board/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "jbs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -41303,12 +41327,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"kcy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "kdS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -41475,6 +41493,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"kQV" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "kSq" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/button/elevator{
@@ -41573,6 +41596,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"lan" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "laG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -41626,6 +41660,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lla" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "lmc" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/east,
@@ -41644,13 +41683,6 @@
 /obj/effect/spawner/lootdrop/techstorage/ai,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"lqc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "lrs" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/stack/sheet/mineral/sandbags{
@@ -41698,6 +41730,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/commons/dorms)
+"lzo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "lAI" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
@@ -41715,12 +41754,6 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
 /area/space)
-"lEu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "lET" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -41798,14 +41831,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"lWJ" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "lWR" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -41862,6 +41887,25 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
+"mdq" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay";
+	name = "Delivery Beacon - Medbay"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/medical/medbay/central)
+"mfg" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mhQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -42269,6 +42313,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"noL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "npH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42315,11 +42370,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nwh" = (
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
@@ -42462,15 +42512,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
-"nPm" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/camera{
-	c_tag = "Medbay Cold Storage";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "nSk" = (
 /obj/structure/chair{
 	dir = 1
@@ -42606,10 +42647,10 @@
 	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"owm" = (
-/obj/structure/bed/roller,
+"oCy" = (
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/area/medical/storage)
 "oEh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -42718,9 +42759,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"oVe" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
 "oVs" = (
 /obj/structure/table,
 /obj/item/toy/eightball,
@@ -42763,6 +42801,10 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"pfp" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "pgs" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
@@ -42788,6 +42830,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pjm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pkx" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -42795,19 +42848,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"pqo" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -5
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "psH" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/south,
@@ -42862,6 +42902,12 @@
 "pAS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/cargo)
+"pGs" = (
+/obj/structure/sign/departments/medbay/alt{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pHZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -42966,10 +43012,6 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"qcS" = (
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "qdp" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -42980,17 +43022,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/white,
 /area/security/brig)
-"qgl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qhc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -43030,18 +43061,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
-"qso" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay";
-	name = "Delivery Beacon - Medbay"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
 "quc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -43079,6 +43098,9 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"qAS" = (
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
 "qDr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43137,12 +43159,6 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qNF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "qNT" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -43312,11 +43328,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"rsb" = (
-/obj/effect/landmark/start/paramedic,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "rsn" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/turf_decal/siding/wood,
@@ -43335,13 +43346,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"rxF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "rzp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -43593,6 +43597,10 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"smn" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "snX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -43621,6 +43629,14 @@
 "ste" = (
 /turf/open/space/basic,
 /area/commons/dorms)
+"sva" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "swA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43643,10 +43659,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"sAc" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "sBD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43722,10 +43734,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
-"sUx" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "sWI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43974,6 +43982,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"tIW" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "tJd" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -44072,6 +44085,15 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"uef" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/camera{
+	c_tag = "Medbay Cold Storage";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "ueZ" = (
 /obj/structure/table,
 /obj/item/key/security,
@@ -44086,6 +44108,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"ugt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "ugK" = (
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
@@ -44098,6 +44126,10 @@
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
+"uhZ" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "ujZ" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -44106,17 +44138,6 @@
 /obj/item/toy/figure/cargotech,
 /turf/open/floor/iron,
 /area/space)
-"ukE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "unA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -44234,10 +44255,6 @@
 /obj/item/food/popsicle/creamsicle_orange,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
-"uKs" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "uMD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44254,17 +44271,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
-"uNG" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Freezer";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/coldroom)
 "uNP" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -44322,10 +44328,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uVQ" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uWr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -44519,6 +44521,20 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vEC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/bed/roller,
+/obj/structure/sign/departments/examroom{
+	pixel_y = 30
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vFP" = (
 /obj/machinery/light_switch/directional/west,
 /turf/closed/wall,
@@ -44549,17 +44565,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"vOd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "vOj" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -44656,6 +44661,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"wfh" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Freezer";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/coldroom)
 "wlG" = (
 /obj/structure/reflector/single,
 /turf/open/floor/engine,
@@ -44769,6 +44785,10 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"wGR" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "wKL" = (
 /obj/structure/table,
 /obj/item/toy/foamblade,
@@ -86176,7 +86196,7 @@ bgi
 bgi
 aYV
 aXH
-iPm
+gST
 cLv
 blN
 bmY
@@ -86939,8 +86959,8 @@ bbl
 bvL
 bwJ
 lXd
-qso
-pqo
+mdq
+buO
 aQT
 beO
 cAQ
@@ -87199,7 +87219,7 @@ aXM
 aXM
 vls
 aQT
-uVQ
+smn
 cAQ
 aXN
 aVP
@@ -87701,8 +87721,8 @@ aEd
 aIR
 aRR
 gjU
-sAc
-eQQ
+eus
+pfp
 aRK
 aXM
 fjL
@@ -87958,8 +87978,8 @@ aEd
 bla
 aRR
 uKb
-iYx
-lEu
+eab
+dKJ
 aRK
 aXM
 iro
@@ -87969,7 +87989,7 @@ omY
 gEA
 uOh
 lOx
-qgl
+pjm
 beO
 cFF
 bfb
@@ -88214,10 +88234,10 @@ aIT
 aMe
 bla
 aRR
-lWJ
-iYx
-qNF
-efF
+efE
+eab
+ugt
+fKU
 aXM
 qay
 hhz
@@ -88226,7 +88246,7 @@ omY
 uZi
 uOh
 lOx
-ukE
+iub
 beO
 cFF
 uNo
@@ -88474,7 +88494,7 @@ aRR
 aOx
 aPt
 aMl
-kcy
+dkM
 aXM
 vdZ
 yck
@@ -88728,10 +88748,10 @@ aEd
 aEd
 bla
 aRR
-nPm
-faW
-nwh
-rxF
+uef
+tIW
+lla
+lzo
 aXM
 aXM
 aXM
@@ -88988,9 +89008,9 @@ aRR
 aRR
 aRR
 aRR
-uNG
-oVe
-beO
+wfh
+qAS
+pGs
 beO
 aQT
 bOW
@@ -89245,7 +89265,7 @@ aHx
 bdK
 aPv
 cyS
-hSN
+iGf
 nsd
 bnh
 snX
@@ -89258,7 +89278,7 @@ pZH
 iyE
 iyE
 iKA
-lqc
+mfg
 aZo
 xoz
 xoz
@@ -89514,7 +89534,7 @@ mkE
 nGc
 aSo
 aSD
-dcO
+vEC
 beO
 aZn
 bky
@@ -89761,7 +89781,7 @@ aPv
 aQN
 bta
 bta
-uKs
+wGR
 bta
 bta
 aSD
@@ -89771,12 +89791,12 @@ eKn
 xZB
 ivN
 aSD
-dcO
+lan
 beO
 bhD
 aZW
 uYP
-qcS
+dst
 bky
 iMA
 bky
@@ -90026,9 +90046,9 @@ ivL
 rrF
 gvV
 xZB
-sUx
+feF
 aSD
-dcO
+lan
 beO
 bhD
 biU
@@ -90037,7 +90057,7 @@ blU
 bnj
 boE
 bky
-owm
+uhZ
 bhF
 cpH
 buh
@@ -90282,7 +90302,7 @@ aSo
 tYg
 ptC
 eKn
-ibv
+kQV
 ptC
 dqs
 aQT
@@ -90294,7 +90314,7 @@ bkv
 cXI
 keH
 bky
-owm
+uhZ
 bhF
 cpH
 btm
@@ -90534,11 +90554,11 @@ bte
 xly
 xly
 cbT
-fag
+oCy
 aSo
 pAu
 xZB
-vOd
+noL
 xZB
 xZB
 nGc
@@ -90551,7 +90571,7 @@ bbc
 bky
 keH
 bky
-rsb
+ewM
 bhF
 cpH
 btm
@@ -90797,10 +90817,10 @@ wQS
 tYa
 miW
 ptC
-sUx
+feF
 aSD
-dcO
-uVQ
+lan
+smn
 bhD
 aZX
 bkv
@@ -90808,7 +90828,7 @@ bkv
 mrE
 ufV
 bky
-owm
+uhZ
 bhF
 cpH
 btm
@@ -91056,7 +91076,7 @@ rzp
 ptC
 oJL
 aSD
-dcO
+lan
 beO
 bhD
 xbW
@@ -91313,12 +91333,12 @@ nkR
 dqs
 aSo
 aSD
-dcO
+vEC
 beO
 bhW
 bjd
 bky
-qcS
+dst
 bky
 bky
 bky
@@ -91573,7 +91593,7 @@ beO
 aQT
 beO
 bhW
-fbs
+jaJ
 bky
 bky
 bky
@@ -92084,7 +92104,7 @@ aWN
 aXE
 bte
 beO
-ukE
+iub
 beO
 bhL
 aZY
@@ -93103,7 +93123,7 @@ aVa
 aNc
 aTb
 aUk
-ixS
+sva
 bte
 aSJ
 aTI

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -39257,6 +39257,17 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"dcO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ddh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 6
@@ -39357,12 +39368,6 @@
 /obj/machinery/bluespace_vendor/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"dzV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "dBV" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
@@ -39432,12 +39437,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"dMx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "dMF" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
@@ -39534,6 +39533,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"efF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "ehC" = (
 /obj/structure/rack,
 /obj/item/radio/off,
@@ -39677,11 +39686,6 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"eGi" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "eHp" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255
@@ -39721,6 +39725,10 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"eQQ" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "eVD" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -39729,17 +39737,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"eYu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "eYF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -39757,6 +39754,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"fag" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "faL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -39766,6 +39767,16 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
+"faW" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
+"fbs" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/bounty_board/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "fcq" = (
 /obj/structure/reflector/box,
 /turf/open/floor/engine,
@@ -39918,14 +39929,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"fwh" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "fwU" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/directional/east,
@@ -40014,16 +40017,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fEY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
-"fGc" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "fMx" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -40561,13 +40554,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"hsU" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "hxc" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40666,6 +40652,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hSN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hTK" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -40690,6 +40684,11 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ibv" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "ibG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -40797,6 +40796,14 @@
 /obj/machinery/defibrillator_mount/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"ixS" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "iyE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -40901,10 +40908,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"iQu" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+"iPm" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/dark,
+/area/medical/morgue)
 "iSu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -40943,6 +40950,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"iYx" = (
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "iYI" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -41228,11 +41238,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/transit_tube)
-"jOx" = (
-/obj/effect/landmark/start/paramedic,
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "jOz" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -41259,10 +41264,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/space)
-"jRV" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/medical/morgue)
 "jUc" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -41302,6 +41303,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"kcy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "kdS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -41595,17 +41602,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
-"lfj" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Freezer";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/coldroom)
 "lht" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -41648,6 +41644,13 @@
 /obj/effect/spawner/lootdrop/techstorage/ai,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"lqc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "lrs" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/item/stack/sheet/mineral/sandbags{
@@ -41712,6 +41715,12 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron,
 /area/space)
+"lEu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "lET" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -41764,17 +41773,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"lPO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "lQl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 1
@@ -41800,6 +41798,14 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"lWJ" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/item/reagent_containers/blood/random,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "lWR" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -41856,10 +41862,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/maintenance/port/fore)
-"mgt" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "mhQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
 	dir = 8
@@ -42100,11 +42102,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"mMj" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/bounty_board/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "mON" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -42162,17 +42159,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"nfp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "ngu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -42329,27 +42315,17 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nwj" = (
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/storage)
+"nwh" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "nxf" = (
 /obj/structure/rack,
 /obj/item/shovel,
 /obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/space)
-"nzo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "nzM" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -42486,8 +42462,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
-"nRZ" = (
-/obj/structure/cable,
+"nPm" = (
+/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/camera{
+	c_tag = "Medbay Cold Storage";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
 "nSk" = (
@@ -42512,14 +42493,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
-"nTZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "nZK" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -42620,19 +42593,6 @@
 "osl" = (
 /turf/open/floor/white,
 /area/service/library)
-"ovO" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -5
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Medical Delivery";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "owj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -42646,18 +42606,10 @@
 	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"oxq" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Medbay";
-	name = "Delivery Beacon - Medbay"
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/medical/medbay/central)
+"owm" = (
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "oEh" = (
 /obj/structure/sink{
 	dir = 8;
@@ -42766,6 +42718,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"oVe" = (
+/turf/closed/wall/r_wall,
+/area/medical/medbay/central)
 "oVs" = (
 /obj/structure/table,
 /obj/item/toy/eightball,
@@ -42808,18 +42763,12 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"pfv" = (
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "pgs" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"phA" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/central)
 "phC" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Medbay";
@@ -42846,6 +42795,19 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"pqo" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -5
+	},
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Medical Delivery";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "psH" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/south,
@@ -42962,10 +42924,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pWv" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "pXf" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -43008,6 +42966,10 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"qcS" = (
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "qdp" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -43018,6 +42980,17 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron/white,
 /area/security/brig)
+"qgl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qhc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 5
@@ -43057,6 +43030,18 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
+"qso" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Medbay";
+	name = "Delivery Beacon - Medbay"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/medical/medbay/central)
 "quc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/hidden/layer4{
@@ -43117,10 +43102,6 @@
 /obj/item/pen,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"qJW" = (
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "qKh" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
@@ -43156,6 +43137,12 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qNF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen_coldroom,
+/area/medical/coldroom)
 "qNT" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -43325,6 +43312,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"rsb" = (
+/obj/effect/landmark/start/paramedic,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "rsn" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/turf_decal/siding/wood,
@@ -43343,6 +43335,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"rxF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "rzp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
 	dir = 4
@@ -43644,6 +43643,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"sAc" = (
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/medical/coldroom)
 "sBD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
@@ -43719,10 +43722,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
-"sUj" = (
-/obj/effect/landmark/start/paramedic,
+"sUx" = (
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/area/medical/treatment_center)
 "sWI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
@@ -43971,16 +43974,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"tIW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/medical/coldroom)
 "tJd" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -44113,6 +44106,17 @@
 /obj/item/toy/figure/cargotech,
 /turf/open/floor/iron,
 /area/space)
+"ukE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "unA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
@@ -44170,10 +44174,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/space)
-"uAD" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "uAJ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -44234,6 +44234,10 @@
 /obj/item/food/popsicle/creamsicle_orange,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
+"uKs" = (
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "uMD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
@@ -44250,6 +44254,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
+"uNG" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Freezer";
+	req_access_txt = "5"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/coldroom)
 "uNP" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -44307,15 +44322,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uUW" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/effect/turf_decal/siding/white,
-/obj/machinery/camera{
-	c_tag = "Medbay Cold Storage";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
+"uVQ" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "uWr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/hidden/layer2{
@@ -44455,11 +44465,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"vnM" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "vpK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 4
@@ -44509,14 +44514,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"vBs" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/item/reagent_containers/blood/random,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/kitchen_coldroom,
-/area/medical/coldroom)
 "vCx" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/west,
@@ -44546,19 +44543,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars)
-"vLT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "vNP" = (
 /obj/structure/rack,
 /obj/item/gun/grenadelauncher,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"vOd" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "vOj" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -86175,7 +86176,7 @@ bgi
 bgi
 aYV
 aXH
-jRV
+iPm
 cLv
 blN
 bmY
@@ -86938,8 +86939,8 @@ bbl
 bvL
 bwJ
 lXd
-oxq
-ovO
+qso
+pqo
 aQT
 beO
 cAQ
@@ -87198,7 +87199,7 @@ aXM
 aXM
 vls
 aQT
-iQu
+uVQ
 cAQ
 aXN
 aVP
@@ -87700,8 +87701,8 @@ aEd
 aIR
 aRR
 gjU
-mgt
-uAD
+sAc
+eQQ
 aRK
 aXM
 fjL
@@ -87957,8 +87958,8 @@ aEd
 bla
 aRR
 uKb
-pfv
-fEY
+iYx
+lEu
 aRK
 aXM
 iro
@@ -87968,7 +87969,7 @@ omY
 gEA
 uOh
 lOx
-nzo
+qgl
 beO
 cFF
 bfb
@@ -88213,10 +88214,10 @@ aIT
 aMe
 bla
 aRR
-vBs
-pfv
-dzV
-tIW
+lWJ
+iYx
+qNF
+efF
 aXM
 qay
 hhz
@@ -88225,7 +88226,7 @@ omY
 uZi
 uOh
 lOx
-nfp
+ukE
 beO
 cFF
 uNo
@@ -88473,7 +88474,7 @@ aRR
 aOx
 aPt
 aMl
-dMx
+kcy
 aXM
 vdZ
 yck
@@ -88727,10 +88728,10 @@ aEd
 aEd
 bla
 aRR
-uUW
-eGi
-nRZ
-hsU
+nPm
+faW
+nwh
+rxF
 aXM
 aXM
 aXM
@@ -88987,8 +88988,8 @@ aRR
 aRR
 aRR
 aRR
-lfj
-phA
+uNG
+oVe
 beO
 beO
 aQT
@@ -89244,7 +89245,7 @@ aHx
 bdK
 aPv
 cyS
-nTZ
+hSN
 nsd
 bnh
 snX
@@ -89257,7 +89258,7 @@ pZH
 iyE
 iyE
 iKA
-vLT
+lqc
 aZo
 xoz
 xoz
@@ -89513,7 +89514,7 @@ mkE
 nGc
 aSo
 aSD
-eYu
+dcO
 beO
 aZn
 bky
@@ -89760,7 +89761,7 @@ aPv
 aQN
 bta
 bta
-qJW
+uKs
 bta
 bta
 aSD
@@ -89770,12 +89771,12 @@ eKn
 xZB
 ivN
 aSD
-eYu
+dcO
 beO
 bhD
 aZW
 uYP
-sUj
+qcS
 bky
 iMA
 bky
@@ -90025,9 +90026,9 @@ ivL
 rrF
 gvV
 xZB
-fGc
+sUx
 aSD
-eYu
+dcO
 beO
 bhD
 biU
@@ -90036,7 +90037,7 @@ blU
 bnj
 boE
 bky
-pWv
+owm
 bhF
 cpH
 buh
@@ -90281,7 +90282,7 @@ aSo
 tYg
 ptC
 eKn
-vnM
+ibv
 ptC
 dqs
 aQT
@@ -90293,7 +90294,7 @@ bkv
 cXI
 keH
 bky
-pWv
+owm
 bhF
 cpH
 btm
@@ -90533,11 +90534,11 @@ bte
 xly
 xly
 cbT
-nwj
+fag
 aSo
 pAu
 xZB
-lPO
+vOd
 xZB
 xZB
 nGc
@@ -90550,7 +90551,7 @@ bbc
 bky
 keH
 bky
-jOx
+rsb
 bhF
 cpH
 btm
@@ -90796,10 +90797,10 @@ wQS
 tYa
 miW
 ptC
-fGc
+sUx
 aSD
-eYu
-iQu
+dcO
+uVQ
 bhD
 aZX
 bkv
@@ -90807,7 +90808,7 @@ bkv
 mrE
 ufV
 bky
-pWv
+owm
 bhF
 cpH
 btm
@@ -91055,7 +91056,7 @@ rzp
 ptC
 oJL
 aSD
-eYu
+dcO
 beO
 bhD
 xbW
@@ -91312,12 +91313,12 @@ nkR
 dqs
 aSo
 aSD
-eYu
+dcO
 beO
 bhW
 bjd
 bky
-sUj
+qcS
 bky
 bky
 bky
@@ -91572,7 +91573,7 @@ beO
 aQT
 beO
 bhW
-mMj
+fbs
 bky
 bky
 bky
@@ -92083,7 +92084,7 @@ aWN
 aXE
 bte
 beO
-nfp
+ukE
 beO
 bhL
 aZY
@@ -93102,7 +93103,7 @@ aVa
 aNc
 aTb
 aUk
-fwh
+ixS
 bte
 aSJ
 aTI


### PR DESCRIPTION
Medical:
Re-does medbay, pushes CMO office, Surgery B and half of Storage to the second floor.
Adds an elevator
Moves rage cage to Medbay maints and makes it cool 😎 
Standardizes all Medical cameras
Makes the map slightly smaller
Moves stairs to actually fit where they connect.
Medical sec post now has stairs
Adds a Medical coldroom (Mostly copied from Metastation) - Not seen in the screenshot
Makes a better SSD room

First floor:
![heliomed](https://user-images.githubusercontent.com/53777086/127729779-3e538f84-f470-4570-b102-fafd4e4109c2.png)

Second floor:
![heliomedUPPER](https://user-images.githubusercontent.com/53777086/127729778-a9b62e09-4cf5-4227-8713-26bdfd61a53b.png)

Engineering:
Moves Gear room to the second floor
Puts stairs to Engineering foyer
Adds support for multi-Z pipes/power on the bottom left area of the second floor by putting multi-Z layer hubs in Engineering Foyer (the next closest is Xenobiology, which is across the map and has to go through Cargo to even reach.)
Moves Gravity Generator to Engineering entrance, allowing us to put something else in its place (Maybe expanding Commissary?)
Expands CE's office
Moves things in the top floor's maints around Engineering to not be uneedlessly large with nothing in it.

First floor:
![helioengieLOWER](https://user-images.githubusercontent.com/53777086/127758855-3ce8ad1e-1ee5-47cd-a306-470f86e64518.png)

Second floor:
![helioengieUPPER](https://user-images.githubusercontent.com/53777086/127758860-77adecf5-1b96-4144-b227-193092ada0ae.png)