### PR TITLE
arrivals rework, roofs, small maint fixes, elevator fixes

### DIFF
--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -33,6 +33,18 @@
 /obj/item/instrument/banjo,
 /turf/open/floor/iron,
 /area/security/prison)
+"adi" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "adq" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron,
@@ -104,6 +116,33 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/department/security/upper)
+"agY" = (
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "aho" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/blue{
@@ -114,9 +153,8 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "ahP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/white,
+/obj/machinery/smartfridge/chemistry/virology/preloaded,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "aim" = (
 /obj/structure/table,
@@ -187,14 +225,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "akj" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "akM" = (
+/obj/structure/closet/l3closet/virology,
 /turf/open/floor/plating,
 /area/medical/virology)
 "amf" = (
@@ -226,8 +261,12 @@
 	pixel_y = 30
 	},
 /obj/item/stack/spacecash/c1,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
+"anz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "anU" = (
 /obj/machinery/button/ticket_machine{
 	pixel_x = 24;
@@ -274,8 +313,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "aor" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/command/storage/eva)
+/obj/machinery/computer/secure_data,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "apt" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_white"
@@ -478,7 +518,7 @@
 /area/security/prison/workout)
 "axW" = (
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
 "aza" = (
 /obj/machinery/computer/secure_data{
@@ -519,7 +559,6 @@
 /area/service/bar)
 "aAR" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/l3closet/virology,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aBj" = (
@@ -579,10 +618,11 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "aCh" = (
-/obj/structure/chair{
-	dir = 1
+/obj/structure/bed/dogbed/cayenne{
+	name = "Lia's bed"
 	},
-/turf/open/floor/plating/asteroid/basalt,
+/mob/living/simple_animal/hostile/carp/lia,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "aCl" = (
 /obj/item/kirbyplants/random,
@@ -627,10 +667,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "aDw" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/machinery/computer/security/hos,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "aDJ" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -723,6 +762,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/closet/l3closet/virology,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aKx" = (
@@ -763,7 +803,7 @@
 /area/medical/break_room)
 "aLK" = (
 /obj/item/stack/spacecash/c1,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
 "aMN" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -789,13 +829,13 @@
 /turf/open/floor/engine/hull,
 /area/space)
 "aQd" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Isolation A";
-	network = list("ss13","medbay")
+/obj/structure/cable,
+/obj/structure/table/wood{
+	color = "#101010"
 	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/item/toy/figure/hos,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "aQj" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -819,11 +859,8 @@
 /obj/structure/table/wood{
 	color = "#101010"
 	},
-/obj/item/paper_bin/carbon,
-/obj/item/pen/red,
-/obj/item/stamp/hos,
-/obj/item/stamp/denied,
-/turf/open/floor/plating/asteroid/basalt,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "aRK" = (
 /obj/machinery/door/firedoor,
@@ -912,10 +949,15 @@
 /turf/open/floor/iron/white,
 /area/security/prison/work)
 "aWA" = (
-/obj/structure/table,
-/obj/item/toy/figure/virologist,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/cable,
+/obj/structure/table/wood{
+	color = "#101010"
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "aWO" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
@@ -924,8 +966,10 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "aXA" = (
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/machinery/light_switch/directional/south,
+/obj/structure/table/glass,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "aXD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -1088,12 +1132,16 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "beo" = (
 /obj/machinery/jukebox/disco,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
 "bew" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"beH" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "bfa" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -1133,25 +1181,46 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "bhw" = (
-/obj/structure/sign/poster/official/space_cops{
-	pixel_y = 30
+/obj/structure/closet/secure_closet/hos,
+/obj/item/storage/box/seccarts,
+/obj/machinery/keycard_auth{
+	pixel_x = 7;
+	pixel_y = 25
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig - HoS Office";
+	name = "HoS Camera";
+	network = list("ss13","security")
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/office)
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/light_switch/directional/north{
+	pixel_y = 36
+	},
+/obj/machinery/button/door/directional/north{
+	id = "hoslock";
+	name = "Office Lockdown Button";
+	pixel_x = -7;
+	req_access_txt = "58"
+	},
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "bhD" = (
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "63"
+/obj/structure/table/wood{
+	color = "#101010"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/security/office)
+/obj/machinery/recharger,
+/turf/open/floor/plating/asteroid/basalt,
+/area/command/heads_quarters/hos)
 "bhS" = (
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"biH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "biM" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -1180,11 +1249,13 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
 "bkG" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/obj/item/storage/secure/safe/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/table/wood{
+	color = "#101010"
+	},
+/obj/item/clipboard,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/plating/asteroid/basalt,
+/area/command/heads_quarters/hos)
 "bkN" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -1245,6 +1316,12 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/medical/abandoned)
+"bmS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "bnc" = (
 /obj/structure/railing{
 	dir = 8
@@ -1292,10 +1369,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"bqz" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "bqJ" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/happy,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
 "bqP" = (
 /obj/structure/chair/wood{
@@ -1353,12 +1439,12 @@
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "buR" = (
-/obj/effect/turf_decal/siding/wideplating,
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 1
+/obj/structure/table/wood{
+	color = "#101010"
 	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plating/asteroid/basalt,
+/area/command/heads_quarters/hos)
 "bwV" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentyfour_twentyfour,
@@ -1400,7 +1486,7 @@
 /obj/structure/table,
 /obj/item/storage/pill_bottle/lsd,
 /obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
 "byn" = (
 /obj/effect/turf_decal/siding/blue{
@@ -1470,11 +1556,17 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "bBI" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 30
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plating/asteroid/basalt,
+/area/command/heads_quarters/hos)
+"bBK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "bBN" = (
 /obj/structure/sign/warning/gasmask{
 	pixel_x = -32
@@ -1510,7 +1602,7 @@
 /obj/item/food/grown/cannabis,
 /obj/item/food/grown/cannabis,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
 "bCZ" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -1538,19 +1630,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/server)
-"bFX" = (
-/obj/structure/table/wood{
-	color = "#101010"
-	},
-/obj/structure/fluff/beach_umbrella/security,
-/turf/open/floor/plating/asteroid/basalt,
-/area/command/heads_quarters/hos)
 "bGw" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"bGR" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "bHe" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/light/directional/north,
@@ -1598,6 +1687,24 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
+"bLM" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "bLQ" = (
 /obj/structure/dresser,
 /obj/structure/sign/poster/contraband/random{
@@ -1679,6 +1786,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"bRE" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;48"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "bTr" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -1746,12 +1860,19 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"bVX" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "bWb" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/virologist,
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/south,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "bWn" = (
 /obj/structure/table,
@@ -1802,11 +1923,11 @@
 /turf/open/floor/carpet/black,
 /area/command/meeting_room)
 "caL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/turf/open/floor/plating/asteroid/basalt,
+/area/command/heads_quarters/hos)
 "caU" = (
 /obj/structure/chair{
 	dir = 8
@@ -1858,6 +1979,21 @@
 /obj/structure/bedsheetbin,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"ceu" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "ceE" = (
 /obj/machinery/light/dim/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -1889,10 +2025,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/server)
-"cfZ" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
 "cgJ" = (
 /obj/structure/window/reinforced/tinted{
 	pixel_y = -4
@@ -1932,17 +2064,30 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "chZ" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/turf/open/floor/iron/white,
-/area/medical/virology)
-"ciy" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/plating/asteroid/basalt,
+/area/command/heads_quarters/hos)
+"ciy" = (
+/obj/machinery/door_buttons/airlock_controller{
+	idExterior = "virology_airlock_exterior";
+	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Console";
+	pixel_x = -25;
+	pixel_y = -4;
+	req_access_txt = "39"
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Virology";
+	name = "Virology Shutters";
+	pixel_y = 6;
+	req_access_txt = "39"
+	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/infections,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "ciI" = (
 /obj/machinery/vending/tool,
@@ -2089,17 +2234,10 @@
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
 "cmT" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "viro-passthrough"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "cmX" = (
@@ -2125,7 +2263,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/iron/white,
-/area/maintenance/department/medical)
+/area/medical/break_room)
 "cnQ" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -2262,10 +2400,10 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "cwt" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/oxygen,
+/obj/machinery/atmospherics/components/binary/valve/digital/on{
+	dir = 4;
+	name = "Virology air supply valve"
+	},
 /turf/open/floor/plating,
 /area/medical/virology)
 "cya" = (
@@ -2432,14 +2570,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"cFh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Virology";
-	name = "Virology Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/virology)
 "cFI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -2487,6 +2617,9 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"cJU" = (
+/turf/closed/wall/r_wall,
+/area/cargo/miningoffice)
 "cKh" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
@@ -2512,9 +2645,10 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "cKE" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/security/office)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/command/heads_quarters/hos)
 "cLB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
@@ -2556,7 +2690,22 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "cPr" = (
 /obj/item/radio/intercom/directional/west,
@@ -2580,6 +2729,12 @@
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
+"cPT" = (
+/obj/structure/rack,
+/obj/item/tank/jetpack,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "cQc" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 8
@@ -2785,10 +2940,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"cXD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
-/turf/open/floor/plating,
-/area/medical/virology)
+"cXP" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/space)
 "cYg" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -2955,6 +3113,9 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"dgx" = (
+/turf/open/openspace,
+/area/cargo/miningoffice)
 "dhv" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
@@ -3016,10 +3177,9 @@
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
 "dls" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/security/office)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "dlv" = (
 /obj/machinery/door/airlock{
 	name = "Toilet F"
@@ -3070,13 +3230,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"dnT" = (
-/obj/machinery/atmospherics/components/binary/valve/digital/on{
-	dir = 4;
-	name = "Virology air supply valve"
-	},
-/turf/open/floor/plating,
-/area/medical/virology)
 "doF" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -3130,6 +3283,14 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
+"dqL" = (
+/obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/space)
 "dqM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3337,6 +3498,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"dBH" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "dBX" = (
 /obj/structure/ladder,
 /turf/open/floor/iron,
@@ -3461,11 +3630,13 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "dIV" = (
-/obj/machinery/computer/prisoner/management{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "63"
 	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
+/area/security/office)
 "dJn" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -3488,6 +3659,13 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"dKv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "dKM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3868,7 +4046,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/break_room)
 "edF" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/red,
@@ -3879,6 +4057,12 @@
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"eeA" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "eeF" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office";
@@ -3986,11 +4170,12 @@
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/cmo)
 "ejZ" = (
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/safe,
+/obj/item/circuitboard/computer/arcade/amputation,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "ekD" = (
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
@@ -4139,14 +4324,22 @@
 /turf/open/openspace,
 /area/hallway/primary/upper)
 "epd" = (
-/obj/machinery/disposal/bin,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"epl" = (
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 1;
+	name = "dark corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/service/theater)
 "epw" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -4202,6 +4395,16 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/security/prison)
+"erQ" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "erX" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/tile{
@@ -4232,10 +4435,13 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "etK" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 6
+/obj/machinery/door/airlock{
+	name = "Emergency Storage"
 	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "etL" = (
@@ -4245,10 +4451,9 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "etR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "eue" = (
 /obj/structure/railing{
@@ -4558,6 +4763,13 @@
 "eJE" = (
 /turf/closed/wall,
 /area/service/bar)
+"eKH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "eMv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile{
@@ -4602,9 +4814,11 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "eQd" = (
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/hos)
 "eQh" = (
 /turf/open/openspace,
 /area/science/breakroom)
@@ -4630,6 +4844,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
+"eQM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "eQT" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -4660,10 +4881,23 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "eSt" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Head of Security";
+	req_access_txt = "58"
+	},
 /obj/structure/cable,
-/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/medical/virology)
+/area/command/heads_quarters/hos)
 "eSD" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -4770,6 +5004,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
+"eXa" = (
+/turf/closed/wall,
+/area/cargo/miningoffice)
 "eXb" = (
 /obj/structure/sink{
 	pixel_y = 25
@@ -4945,6 +5182,18 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"fgG" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 5;
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/delta;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "fhE" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
@@ -5064,6 +5313,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fmO" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/space)
 "fno" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -5112,10 +5369,12 @@
 /area/security/prison/work)
 "foa" = (
 /obj/structure/cable,
-/obj/machinery/light/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plating/airless,
+/area/security/office)
 "foB" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
@@ -5140,6 +5399,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"fpm" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "fpE" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -5235,8 +5502,12 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "fuD" = (
-/obj/structure/flora/grass/green,
-/turf/open/floor/grass,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Virology";
+	name = "Virology Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/virology)
 "fuN" = (
 /obj/structure/industrial_lift/tram{
@@ -5276,6 +5547,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "fvW" = (
@@ -5358,6 +5630,12 @@
 "fyK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/chapel)
+"fzb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "fzu" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/iron,
@@ -5384,9 +5662,15 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/cargo/qm)
+"fAJ" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "fBj" = (
 /obj/structure/training_machine,
 /obj/item/target/clown,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "fBO" = (
@@ -5434,10 +5718,6 @@
 /turf/open/floor/iron,
 /area/security/office)
 "fDq" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Storage";
-	req_access_txt = "8"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
 	dir = 8;
@@ -5450,6 +5730,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Storage";
+	req_access_txt = "71"
+	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "fDG" = (
@@ -5506,6 +5790,10 @@
 /obj/structure/displaycase/labcage,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"fGs" = (
+/obj/structure/closet/bombcloset,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "fGt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple{
@@ -5546,6 +5834,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"fJK" = (
+/obj/structure/sign/warning/docking{
+	pixel_x = -30
+	},
+/turf/open/space/basic,
+/area/space)
 "fKF" = (
 /obj/structure/window,
 /obj/machinery/conveyor{
@@ -5569,6 +5863,10 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"fMl" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/theater)
 "fMq" = (
 /obj/structure/railing,
 /obj/structure/chair/stool/bar/directional/west,
@@ -5619,26 +5917,31 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "fNs" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/computer/department_orders/security,
 /turf/open/floor/iron,
 /area/security/office)
 "fNw" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig - Security Office W";
+	name = "Security Camera";
+	network = list("ss13","security")
 	},
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/item/toy/beach_ball/holoball,
-/obj/item/toy/beach_ball/holoball,
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/obj/effect/spawner/random/contraband/prison,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/security/prison/workout)
+/turf/open/floor/iron,
+/area/security/office)
 "fND" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "prisonsecofficelockdown";
+	name = "Prison Blast door"
+	},
 /turf/open/floor/plating,
 /area/security/prison)
 "fNR" = (
@@ -5724,9 +6027,13 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "fSK" = (
-/obj/effect/spawner/random/vending/colavend,
+/obj/machinery/camera/directional/north{
+	c_tag = "Brig - Security Office E";
+	name = "Security Camera";
+	network = list("ss13","security")
+	},
 /turf/open/floor/iron,
-/area/security/prison/workout)
+/area/security/office)
 "fTw" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -5738,6 +6045,17 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"fUi" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "fUr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -5861,13 +6179,8 @@
 /area/cargo/warehouse)
 "geX" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Entrance";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "gfh" = (
@@ -6253,6 +6566,17 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"gym" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Entrance";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "gyp" = (
 /obj/machinery/power/apc{
 	areastring = "/area/service/chapel/office";
@@ -6269,10 +6593,6 @@
 /turf/closed/wall/r_wall,
 /area/science/storage)
 "gzk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 9
-	},
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/medical/virology)
 "gzw" = (
@@ -6286,6 +6606,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/holodeck/rec_center)
+"gDn" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "gDD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -6331,14 +6655,16 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "gGk" = (
-/obj/structure/closet/firecloset,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 9
+/obj/machinery/button/door/directional/north{
+	id = "prisonsecofficelockdown";
+	name = "Office Lockdown Button";
+	pixel_x = -7;
+	pixel_y = 0;
+	req_access_txt = "63"
 	},
-/obj/effect/landmark/start/hangover/closet,
+/obj/structure/table,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/area/security/office)
 "gHG" = (
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "panic";
@@ -6417,7 +6743,7 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "gLH" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/cargo/qm)
 "gMy" = (
 /obj/structure/table/glass,
@@ -6436,9 +6762,18 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "gMz" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron,
-/area/security/prison/workout)
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/item/toy/beach_ball/holoball,
+/obj/item/toy/beach_ball/holoball,
+/obj/item/toy/beach_ball/holoball/dodgeball,
+/obj/effect/spawner/random/contraband/prison,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "gMD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance";
@@ -6449,6 +6784,7 @@
 /area/maintenance/department/science/xenobiology)
 "gMF" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/theater)
 "gNn" = (
@@ -6485,6 +6821,19 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"gPg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -30
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"gPm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "gPn" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -6522,24 +6871,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"gQC" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Head of Security";
-	req_access_txt = "58"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
 "gQH" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot_red,
@@ -6833,9 +7164,9 @@
 /turf/open/floor/plating,
 /area/security/prison/visit)
 "hkC" = (
-/obj/machinery/computer/security/hos,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/security/prison/workout)
 "hlk" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -6893,12 +7224,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "hoR" = (
-/obj/machinery/door/airlock/virology{
-	name = "Virology Access";
-	req_one_access_txt = "5;39;12"
+/obj/structure/noticeboard/directional/north{
+	dir = 2
 	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/office)
 "hqa" = (
 /obj/machinery/recharger{
 	pixel_x = -6;
@@ -6954,23 +7285,14 @@
 /turf/open/floor/iron,
 /area/security/prison/visit)
 "hqO" = (
-/obj/machinery/door_buttons/airlock_controller{
-	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Console";
-	pixel_x = -25;
-	pixel_y = -4;
-	req_access_txt = "39"
-	},
-/obj/machinery/button/door/directional/west{
-	id = "Virology";
-	name = "Virology Shutters";
-	pixel_y = 6;
-	req_access_txt = "39"
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/security/prison/workout)
+"hrz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/pinpointer_dispenser,
+/turf/open/floor/plating,
+/area/space)
 "hrN" = (
 /obj/machinery/teleport/station,
 /obj/machinery/airalarm/directional/north,
@@ -7234,6 +7556,24 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/space)
+"hHw" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 25;
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "hIa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -7249,16 +7589,9 @@
 /turf/open/openspace,
 /area/commons/dorms)
 "hIo" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation B";
-	req_access_txt = "39"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/security/office)
 "hIs" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
@@ -7267,6 +7600,42 @@
 "hIJ" = (
 /turf/closed/wall,
 /area/service/chapel/office)
+"hJp" = (
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"hJG" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Emergency Oxygen Supply"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "hKj" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
@@ -7313,6 +7682,19 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"hLZ" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Shuttle";
+	req_one_access_txt = "48"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "hNc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -7358,6 +7740,7 @@
 /obj/structure/sign/warning/explosives/alt{
 	pixel_y = 30
 	},
+/obj/structure/closet/bombcloset,
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "hQM" = (
@@ -7435,6 +7818,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"hUY" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "hVh" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -7459,12 +7847,11 @@
 	pixel_x = -2;
 	pixel_y = 9
 	},
-/obj/item/folder/white,
 /obj/item/folder/white{
 	pixel_y = 2
 	},
 /obj/item/pen/red,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "hWX" = (
 /turf/open/floor/plating/airless,
@@ -7491,11 +7878,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "hZf" = (
-/obj/machinery/airalarm/directional/west,
-/obj/machinery/light/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison/workout)
 "hZx" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -7564,6 +7950,15 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/iron,
 /area/security/prison)
+"icH" = (
+/obj/machinery/door/airlock/command{
+	name = "Auxiliary E.V.A. Storage";
+	req_access_txt = "18"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "ied" = (
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table,
@@ -7645,27 +8040,14 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "iip" = (
-/obj/machinery/modular_computer/console/preset/cargochat/security,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
 /area/security/office)
 "iiC" = (
-/obj/structure/cable,
-/obj/structure/table/wood{
-	color = "#101010"
-	},
-/obj/item/toy/figure/hos,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/security/office)
 "iiR" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/beer{
@@ -7678,7 +8060,10 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "iiY" = (
-/turf/open/floor/plating/airless,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/security/office)
 "ija" = (
 /turf/closed/wall,
@@ -7793,6 +8178,12 @@
 /obj/machinery/computer/cargo,
 /turf/open/floor/wood,
 /area/cargo/qm)
+"iow" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "iqJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -7829,6 +8220,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"isM" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/space)
 "itf" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -7862,16 +8260,14 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "iwh" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/machinery/requests_console/directional/south{
-	department = "Virology";
-	departmentType = 2;
-	name = "Virology Requests Console"
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "prisonsecofficelockdown";
+	name = "Prison Blast door"
 	},
-/turf/open/floor/iron/dark,
-/area/medical/virology)
+/turf/open/floor/plating,
+/area/security/prison)
 "iwu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/general/visible{
 	dir = 10
@@ -7994,6 +8390,13 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"iHl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "iHA" = (
 /obj/structure/table/wood,
 /obj/item/canvas/nineteen_nineteen,
@@ -8209,6 +8612,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"iSx" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "iSG" = (
 /obj/structure/window{
 	dir = 4
@@ -8258,6 +8665,10 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"iVM" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "iVY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8336,22 +8747,30 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "iYY" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
+/turf/closed/wall/r_wall,
+/area/ai_monitored/command/storage/eva)
+"iZj" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
+"iZv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "iZV" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -8575,6 +8994,13 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
+"jnk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "jnK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8659,6 +9085,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/server)
+"jrk" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "jrP" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -8797,8 +9229,12 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "jwq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/grass,
+/obj/machinery/requests_console/directional/east{
+	department = "Virology";
+	departmentType = 2;
+	name = "Virology Requests Console"
+	},
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "jwz" = (
 /obj/effect/landmark/blobstart,
@@ -8884,7 +9320,7 @@
 	req_access_txt = "2"
 	},
 /turf/open/floor/iron/white,
-/area/maintenance/department/medical)
+/area/medical/break_room)
 "jBC" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -8920,9 +9356,10 @@
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "jEh" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron/white,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/medical/virology)
 "jFd" = (
 /obj/effect/turf_decal/tile{
@@ -9053,6 +9490,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "jIY" = (
@@ -9072,6 +9510,16 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/command/bridge)
+"jJC" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "jJP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -9121,6 +9569,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"jMD" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "jME" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -9145,6 +9598,15 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/medical/abandoned)
+"jNZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "jOx" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
@@ -9357,8 +9819,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "jZU" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/grass,
+/obj/machinery/vending/wardrobe/viro_wardrobe,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "kaa" = (
 /obj/effect/landmark/start/prisoner,
@@ -9426,6 +9888,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"keK" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "kfu" = (
 /obj/structure/cable,
 /turf/open/floor/vault,
@@ -9519,19 +9989,8 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "kjA" = (
-/obj/machinery/suit_storage_unit/hos,
-/obj/item/storage/secure/safe/hos{
-	pixel_x = -25
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/requests_console/directional/north{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC"
-	},
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/turf/open/floor/eighties/red,
+/area/maintenance/department/chapel)
 "kjW" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 1
@@ -9672,11 +10131,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"krg" = (
+/obj/structure/rack,
+/obj/item/tank/jetpack,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"krH" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "krT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "ksi" = (
 /obj/machinery/door/poddoor/shutters{
@@ -9780,10 +10250,13 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "kys" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Virology";
+	name = "Virology Privacy Shutters"
+	},
 /turf/open/floor/plating,
-/area/security/prison/workout)
+/area/medical/virology)
 "kzi" = (
 /obj/item/target,
 /turf/open/floor/plating,
@@ -9794,6 +10267,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"kzx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "kAk" = (
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
@@ -9815,8 +10294,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "kBM" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible,
 /turf/open/floor/plating,
 /area/medical/virology)
 "kBO" = (
@@ -9994,6 +10472,16 @@
 "kLx" = (
 /turf/open/openspace,
 /area/maintenance/department/science)
+"kLE" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "kOm" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -10384,15 +10872,7 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "llH" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/computer/department_orders/security,
-/turf/open/floor/iron,
+/turf/open/floor/plating/airless,
 /area/security/office)
 "lml" = (
 /obj/structure/reagent_dispensers/cooking_oil,
@@ -10607,11 +11087,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "lCb" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/healthanalyzer,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "lCp" = (
 /obj/machinery/door/window/northleft{
@@ -10731,12 +11208,10 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lHx" = (
-/obj/structure/table/wood{
-	color = "#101010"
-	},
-/obj/machinery/recharger,
-/turf/open/floor/plating/asteroid/basalt,
-/area/command/heads_quarters/hos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "lIj" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
@@ -10903,11 +11378,7 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
 "lPS" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Monkey Pen";
-	network = list("ss13","medbay")
-	},
-/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
 "lQh" = (
@@ -10915,8 +11386,9 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "lQl" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/grass,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/closet/secure_closet/medical1,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "lQM" = (
 /obj/structure/cable,
@@ -11124,6 +11596,14 @@
 "mde" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"meo" = (
+/obj/machinery/power/shieldwallgen,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "meW" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
@@ -11223,6 +11703,13 @@
 "miy" = (
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"miU" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;48"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "mjd" = (
 /turf/open/openspace,
 /area/ai_monitored/command/storage/eva)
@@ -11253,6 +11740,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "viro-passthrough"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mkL" = (
@@ -11345,7 +11833,10 @@
 /obj/structure/table/wood{
 	color = "#101010"
 	},
-/obj/item/storage/fancy/donut_box,
+/obj/item/paper_bin/carbon,
+/obj/item/pen/red,
+/obj/item/stamp/hos,
+/obj/item/stamp/denied,
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
 "mpP" = (
@@ -11628,6 +12119,10 @@
 	},
 /turf/open/floor/plating,
 /area/medical/surgery/room_b)
+"mGh" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "mGO" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -11647,12 +12142,12 @@
 /turf/open/floor/iron,
 /area/security/office)
 "mIC" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Isolation A";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "mJg" = (
 /obj/structure/window/reinforced{
@@ -11712,6 +12207,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"mLI" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "mLM" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -11776,10 +12276,13 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/bridge)
 "mQa" = (
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Isolation B";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "mQh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -11835,6 +12338,13 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"mTr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "mTI" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 1
@@ -11882,14 +12392,13 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "mUI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = -11
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mUL" = (
@@ -11982,8 +12491,9 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "mZf" = (
-/obj/machinery/computer/pandemic,
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/virologist,
+/obj/structure/chair/office/light,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "nai" = (
 /obj/effect/turf_decal/tile{
@@ -12153,11 +12663,11 @@
 	},
 /area/service/abandoned_gambling_den)
 "ngU" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_one_access_txt = "5;12"
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Isolation C";
+	network = list("ss13","medbay")
 	},
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nhr" = (
@@ -12291,16 +12801,12 @@
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "npm" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "npn" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/dropper,
+/obj/structure/table,
+/obj/item/toy/figure/virologist,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "npR" = (
@@ -12318,7 +12824,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "npV" = (
 /turf/open/openspace,
@@ -12416,6 +12936,21 @@
 /obj/item/assembly/timer,
 /turf/open/floor/iron,
 /area/security/office)
+"ntH" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "viro-passthrough"
+	},
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "nui" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/airalarm/directional/north,
@@ -12469,6 +13004,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"nyx" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/effect/turf_decal/siding/wideplating/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "nyE" = (
 /obj/structure/bed,
 /obj/machinery/camera/directional/north{
@@ -12516,6 +13058,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"nBY" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "nCu" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -12656,6 +13202,7 @@
 	dir = 1;
 	name = "Command blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "nKA" = (
@@ -12730,6 +13277,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"nQo" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "nQy" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/tile/green,
@@ -12781,12 +13335,11 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "nTv" = (
-/obj/structure/table/wood{
-	color = "#101010"
-	},
-/obj/item/clipboard,
-/turf/open/floor/plating/asteroid/basalt,
-/area/command/heads_quarters/hos)
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/orangejuice,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "nTw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -12891,10 +13444,10 @@
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
 "obd" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "ocr" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -12922,6 +13475,12 @@
 /obj/structure/railing,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"odz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "odE" = (
 /obj/machinery/door/airlock/public{
 	id_tag = "Perma Bathroom 3";
@@ -13056,6 +13615,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ojL" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12;31"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "ojN" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/east,
@@ -13094,7 +13660,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "okp" = (
-/obj/effect/landmark/blobstart,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "okw" = (
@@ -13212,15 +13779,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "opf" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/machinery/firealarm/directional/east,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/grass,
 /area/medical/virology)
 "opu" = (
 /obj/machinery/button/door/directional/north{
@@ -13244,8 +13804,8 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "oqS" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/plating/asteroid/basalt,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "ora" = (
 /obj/structure/table/wood,
@@ -13328,15 +13888,9 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "ozo" = (
-/obj/structure/cable,
-/obj/structure/table/wood{
-	color = "#101010"
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/grass,
+/area/medical/virology)
 "oAm" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/prisoner,
@@ -13360,6 +13914,24 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"oAX" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Access";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "oBZ" = (
 /obj/structure/window{
 	dir = 1
@@ -13367,6 +13939,19 @@
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"oCM" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "oDa" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/structure/window/reinforced{
@@ -13384,29 +13969,12 @@
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "oFu" = (
-/obj/structure/closet/secure_closet/hos,
-/obj/item/storage/box/seccarts,
-/obj/machinery/keycard_auth{
-	pixel_x = 7;
-	pixel_y = 25
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	color = "#DE3A3A"
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Brig - HoS Office";
-	name = "HoS Camera";
-	network = list("ss13","security")
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/firealarm/directional/east,
-/obj/machinery/light_switch/directional/north{
-	pixel_y = 36
-	},
-/obj/machinery/button/door/directional/north{
-	id = "hoslock";
-	name = "Office Lockdown Button";
-	pixel_x = -7;
-	req_access_txt = "58"
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
 "oFK" = (
 /obj/machinery/button/door/directional/south{
@@ -13432,10 +14000,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oHQ" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/machinery/light/directional/south,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A";
+	req_access_txt = "39"
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "oIa" = (
@@ -13545,12 +14117,22 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/vault,
 /area/command/heads_quarters/captain)
+"oNa" = (
+/obj/structure/closet/l3closet,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "oNj" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Brig - Security Office W";
-	name = "Security Camera";
-	network = list("ss13","security")
+/obj/machinery/modular_computer/console/preset/cargochat/security,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/security/office)
 "oOs" = (
@@ -13653,10 +14235,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"oSH" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/virology)
 "oSR" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -13897,12 +14475,6 @@
 /obj/structure/bookcase/random/adult,
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
-"peO" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "pfd" = (
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
@@ -13948,7 +14520,14 @@
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "piX" = (
-/obj/structure/table,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation B";
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "pjp" = (
@@ -13960,10 +14539,23 @@
 "pjH" = (
 /turf/open/openspace,
 /area/engineering/storage_shared)
+"pjN" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "pkG" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"pll" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "pmB" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
@@ -14018,6 +14610,16 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
+"pqj" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "pqv" = (
 /obj/structure/dresser,
 /obj/machinery/light_switch/directional/north,
@@ -14060,10 +14662,12 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "ptx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/firstaid/regular,
+/obj/structure/reagent_dispensers/virusfood/directional/south,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "ptC" = (
 /turf/closed/wall/r_wall,
@@ -14086,6 +14690,13 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
+"pwy" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/rglass,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "pwO" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -14139,12 +14750,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "pzv" = (
-/obj/structure/bed/dogbed/cayenne{
-	name = "Lia's bed"
-	},
-/mob/living/simple_animal/hostile/carp/lia,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/hos)
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
+/area/medical/virology)
 "pAh" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -14359,6 +14967,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pMi" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "pMz" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -14367,6 +14979,11 @@
 "pNt" = (
 /turf/closed/wall,
 /area/holodeck/rec_center)
+"pOC" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "pOT" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -14405,6 +15022,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"pQE" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/department/science)
 "pRa" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -14541,11 +15163,41 @@
 "pZC" = (
 /turf/open/openspace,
 /area/medical/chemistry)
+"qae" = (
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "qaP" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/security/prison)
+"qbj" = (
+/obj/machinery/computer/shuttle/mining{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
+"qbu" = (
+/obj/structure/closet/firecloset,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "qcb" = (
 /obj/machinery/gibber,
 /obj/structure/railing,
@@ -14843,11 +15495,7 @@
 /area/maintenance/department/science)
 "qsx" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/department/science)
 "qth" = (
 /obj/item/radio/intercom/directional/east,
@@ -14930,7 +15578,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "qvq" = (
-/obj/machinery/holopad,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - North";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qvG" = (
@@ -14945,6 +15597,20 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"qvS" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "qwk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -14988,6 +15654,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/service/theater)
+"qyt" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron,
+/area/space)
 "qyS" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -15000,8 +15672,8 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "qzQ" = (
-/obj/machinery/smartfridge/chemistry/virology/preloaded,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "qzY" = (
 /obj/structure/window/reinforced{
@@ -15017,6 +15689,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"qAb" = (
+/obj/structure/rack,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "qAL" = (
 /obj/machinery/bluespace_vendor/directional/west,
 /obj/effect/turf_decal/loading_area{
@@ -15232,13 +15919,12 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "qMq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Emergency Oxygen Supply"
+/obj/structure/flora/grass/green,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Monkey Pen";
+	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/grass,
 /area/medical/virology)
 "qME" = (
 /obj/structure/fluff/fokoff_sign,
@@ -15320,8 +16006,9 @@
 /turf/open/openspace,
 /area/maintenance/starboard)
 "qSc" = (
-/obj/item/bedsheet/qm,
-/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/kirbyplants{
+	icon_state = "plant-10"
+	},
 /turf/open/floor/wood,
 /area/cargo/qm)
 "qSC" = (
@@ -15497,6 +16184,10 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/space)
+"rbG" = (
+/obj/machinery/computer/pandemic,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "rci" = (
 /turf/open/openspace,
 /area/medical/medbay/central)
@@ -15952,8 +16643,8 @@
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
 "rwS" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/floor/grass,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/medical/virology)
 "rwV" = (
 /obj/machinery/computer/security/mining,
@@ -15970,6 +16661,10 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/command/bridge)
+"rxb" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "rxS" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -15977,6 +16672,10 @@
 /obj/item/paper_bin,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"rxT" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "rxZ" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -16055,6 +16754,10 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"rCT" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "rDh" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
@@ -16075,7 +16778,8 @@
 /turf/open/floor/iron,
 /area/maintenance/department/science)
 "rEo" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/modular_computer/console/preset/id,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "rEt" = (
 /turf/closed/wall,
@@ -16369,12 +17073,6 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/machinery/button/door/directional/north{
-	id = "secofficelock";
-	name = "Office Lockdown Button";
-	pixel_x = -7;
-	req_access_txt = "58"
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -16557,7 +17255,9 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "saw" = (
-/obj/structure/closet/secure_closet/medical1,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "saU" = (
@@ -16652,16 +17352,10 @@
 /turf/open/floor/plating,
 /area/science/breakroom)
 "shb" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Security External Airlock";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/security/office)
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
+/area/medical/virology)
 "shA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -16777,6 +17471,7 @@
 	name = "Maintenance Access";
 	req_one_access_txt = "5;12"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "sln" = (
@@ -16813,10 +17508,16 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
+"soC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "soN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
-	req_access_txt = "31"
+	req_one_access_txt = "12;31"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -16835,6 +17536,12 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/upper)
+"spS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "spU" = (
 /turf/closed/wall,
 /area/maintenance/department/cargo)
@@ -16842,6 +17549,21 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/medical/virology)
+"ssv" = (
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 1;
+	name = "dark corner"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/service/theater)
 "ssy" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/structure/reagent_dispensers/peppertank/directional/south,
@@ -16863,8 +17585,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ssP" = (
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/white,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
 /area/medical/virology)
 "stN" = (
 /obj/structure/table/reinforced,
@@ -16951,8 +17673,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"syu" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "syC" = (
 /turf/closed/wall,
 /area/security/prison/garden)
@@ -16999,14 +17728,8 @@
 /turf/open/openspace,
 /area/service/library/printer)
 "sCJ" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Monkey Pen";
-	req_access_txt = "39"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "sDh" = (
@@ -17084,10 +17807,9 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "sGB" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/virologist,
+/obj/item/bedsheet/green,
+/obj/structure/bed,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "sGZ" = (
@@ -17210,12 +17932,25 @@
 "sOD" = (
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
-"sPg" = (
-/obj/structure/chair{
-	dir = 4
+"sOI" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/turf/open/floor/iron,
-/area/security/office)
+/turf/open/floor/plating,
+/area/maintenance/department/science)
+"sPg" = (
+/obj/machinery/door/airlock/virology/glass{
+	name = "Monkey Pen";
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "sPl" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -17265,6 +18000,17 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"sQR" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "sRd" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/sign/poster/contraband/random{
@@ -17273,9 +18019,8 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "sRs" = (
-/obj/structure/bed,
-/obj/item/bedsheet/green,
-/turf/open/floor/iron/white,
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/grass,
 /area/medical/virology)
 "sRH" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -17295,6 +18040,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"sVz" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/plating,
+/area/medical/virology)
 "sVF" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -17414,6 +18166,33 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"teW" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
+"tfj" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"tfF" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "tgs" = (
 /obj/structure/railing{
 	dir = 8
@@ -17516,13 +18295,8 @@
 /turf/open/openspace,
 /area/hallway/primary/upper)
 "tna" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Center";
-	network = list("ss13","medbay")
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/white,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
 /area/medical/virology)
 "tnh" = (
 /obj/machinery/light/directional/west,
@@ -17639,8 +18413,12 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/medical/abandoned)
+"tqV" = (
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "tqX" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Dorms";
@@ -17707,6 +18485,13 @@
 "tty" = (
 /turf/open/floor/plating,
 /area/maintenance/department/security/upper)
+"tuh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "tuW" = (
 /obj/item/paicard,
 /obj/item/tape,
@@ -17855,16 +18640,10 @@
 	},
 /area/medical/abandoned)
 "tCf" = (
-/obj/structure/railing{
-	layer = 3.1
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Brig - Security Office E";
-	name = "Security Camera";
-	network = list("ss13","security")
-	},
-/turf/open/floor/iron,
-/area/security/office)
+/obj/machinery/light/directional/west,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "tCj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -17911,9 +18690,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "tEV" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/orangejuice,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "tEX" = (
@@ -17994,6 +18771,11 @@
 "tKH" = (
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
+"tKI" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/medical/virology)
 "tKO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18037,6 +18819,29 @@
 /obj/structure/frame/machine,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
+"tNp" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "tNO" = (
 /obj/structure/chair{
 	dir = 8
@@ -18067,6 +18872,12 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"tPc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "tPp" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -18405,13 +19216,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "ucq" = (
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/storage/firstaid/regular,
-/obj/structure/reagent_dispensers/virusfood/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
 /area/medical/virology)
 "ucW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -18421,9 +19227,9 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "udg" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/office)
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
+/area/medical/virology)
 "udn" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "abandonedmechbay";
@@ -18509,22 +19315,12 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "uhb" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "uhR" = (
 /obj/structure/table,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
@@ -18572,12 +19368,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ukM" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Isolation B";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "ukN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18608,6 +19400,12 @@
 "unr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine)
+"unA" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "uoE" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security Office - Table";
@@ -18653,7 +19451,7 @@
 "uqC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/cargo/warehouse)
+/area/maintenance/department/science/xenobiology)
 "urr" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -18851,6 +19649,12 @@
 "uyn" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/visit)
+"uyx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "uyM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -18943,15 +19747,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uBS" = (
-/obj/machinery/door/airlock/virology{
-	name = "Virology Break Room";
-	req_access_txt = "39"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/west,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "uCf" = (
 /obj/structure/beebox,
@@ -18966,9 +19766,11 @@
 /area/security/prison/workout)
 "uCE" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "uCR" = (
 /obj/machinery/skill_station,
 /obj/machinery/status_display/ai/directional/north,
@@ -19097,6 +19899,7 @@
 	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "uML" = (
@@ -19270,6 +20073,10 @@
 "uTX" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"uUp" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "uUS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical Dormitory Maintenance";
@@ -19333,6 +20140,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/supply)
+"uZl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "vak" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/mech_bay_recharge_port{
@@ -19462,11 +20275,17 @@
 	name = "dark corner"
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/service/theater)
 "vjx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/grass,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
+"vjC" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
 /area/medical/virology)
 "vkO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -19634,27 +20453,14 @@
 /turf/open/floor/iron,
 /area/space)
 "vta" = (
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
-/area/security/office)
+/obj/machinery/computer/pandemic,
+/obj/structure/reagent_dispensers/virusfood/directional/west,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "vtY" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Access";
-	req_access_txt = "5"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/virology)
 "vuD" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/hangover,
@@ -19764,14 +20570,9 @@
 /turf/open/openspace,
 /area/security/prison/visit)
 "vBQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/range)
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "vCb" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -19779,12 +20580,13 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "vCr" = (
-/obj/effect/landmark/start/security_officer,
-/obj/structure/chair{
-	dir = 8
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Break Room";
+	network = list("ss13","medbay")
 	},
-/turf/open/floor/iron,
-/area/security/office)
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "vCA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
@@ -19825,10 +20627,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "vEf" = (
-/obj/structure/table/wood{
-	color = "#101010"
+/obj/machinery/computer/prisoner/management{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "vEl" = (
@@ -19898,6 +20699,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science)
+"vHR" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "vIp" = (
 /obj/structure/sign/warning/docking{
 	pixel_y = -30
@@ -19927,6 +20737,13 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"vII" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "vJO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -19943,15 +20760,16 @@
 /turf/open/openspace,
 /area/space)
 "vLl" = (
-/obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Break Room";
-	network = list("ss13","medbay")
-	},
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vLW" = (
-/obj/machinery/atmospherics/components/tank/air,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/medical/virology)
 "vLZ" = (
@@ -19973,6 +20791,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"vMM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "vNO" = (
 /obj/machinery/restaurant_portal/restaurant/prison,
 /obj/effect/turf_decal/tile{
@@ -20170,10 +20994,11 @@
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
 "vYj" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/office)
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "vYM" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -20354,17 +21179,6 @@
 	},
 /turf/open/floor/iron,
 /area/space)
-"wkG" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A";
-	req_access_txt = "39"
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "wkL" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -20401,6 +21215,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
+"wnE" = (
+/obj/machinery/power/shieldwallgen,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "wnJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -20421,8 +21239,10 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "wpJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "wpL" = (
 /obj/machinery/door/window/northleft{
@@ -20465,7 +21285,11 @@
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
 "wsd" = (
-/turf/open/floor/iron/dark,
+/obj/structure/table/wood{
+	color = "#101010"
+	},
+/obj/structure/fluff/beach_umbrella/security,
+/turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
 "wsj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -20481,7 +21305,9 @@
 /turf/open/floor/glass/reinforced,
 /area/service/bar/atrium)
 "wsw" = (
-/obj/structure/fluff/empty_sleeper,
+/obj/structure/fluff/empty_sleeper{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
 "wte" = (
@@ -20525,12 +21351,18 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "wuQ" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	color = "#DE3A3A"
+/obj/machinery/suit_storage_unit/hos,
+/obj/item/storage/secure/safe/hos{
+	pixel_x = -25
 	},
-/obj/effect/landmark/start/head_of_security,
-/turf/open/floor/plating/asteroid/basalt,
+/obj/machinery/light/directional/west,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security RC"
+	},
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "wvc" = (
 /obj/structure/table/wood,
@@ -20578,11 +21410,13 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "wxE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
 	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/command/heads_quarters/hos)
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "wxJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -20647,17 +21481,7 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "wCv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_x = -25;
-	pixel_y = 25;
-	req_access_txt = "39"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wCy" = (
@@ -20734,8 +21558,11 @@
 /area/maintenance/department/science)
 "wFs" = (
 /obj/machinery/jukebox,
-/turf/open/floor/eighties,
+/turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
+"wFV" = (
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "wGe" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -20807,6 +21634,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"wIX" = (
+/obj/structure/closet/crate,
+/obj/item/stack/ore/glass,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "wJz" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
@@ -20821,11 +21662,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"wLl" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/command/heads_quarters/hos)
 "wLC" = (
 /obj/structure/filingcabinet,
 /obj/structure/reagent_dispensers/peppertank/directional/north,
@@ -21031,8 +21867,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "wTs" = (
-/obj/machinery/modular_computer/console/preset/id,
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/command/heads_quarters/hos)
 "wTP" = (
 /turf/closed/wall,
@@ -21070,16 +21905,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"wWk" = (
-/obj/structure/safe,
-/obj/item/circuitboard/computer/arcade/amputation,
+"wVR" = (
+/obj/structure/closet/l3closet,
+/obj/item/toy/mecha/mauler,
 /turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"wWk" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
 "wZI" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/theater)
 "wZM" = (
@@ -21104,13 +21944,11 @@
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
 "xaE" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/item/storage/secure/safe/directional/east,
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "xaI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -21183,11 +22021,12 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "xhF" = (
-/obj/structure/noticeboard/directional/north{
-	dir = 2
-	},
-/turf/open/floor/iron,
-/area/security/office)
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "xhN" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Dormitories";
@@ -21307,9 +22146,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "xuk" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/security/office)
+/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/science,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "xus" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
@@ -21590,6 +22433,66 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"xJo" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"xJK" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
+"xJR" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "xJZ" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/massdriver_chapel,
@@ -21605,8 +22508,7 @@
 /turf/open/floor/plating,
 /area/science/server)
 "xKX" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/medical/virology)
 "xLm" = (
@@ -21638,6 +22540,19 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
+"xMS" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "xNu" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/purple,
@@ -21652,6 +22567,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"xNC" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "xOd" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
@@ -21713,9 +22632,15 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "xPC" = (
-/obj/structure/table,
-/obj/item/storage/box/monkeycubes,
-/turf/open/floor/grass,
+/obj/machinery/door/airlock/virology{
+	name = "Virology Break Room";
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "xPN" = (
 /obj/structure/mirror/directional/south,
@@ -21770,16 +22695,16 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "xSh" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/effect/landmark/start/virologist,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "xSC" = (
 /obj/machinery/airalarm/directional/west,
-/obj/item/kirbyplants{
-	icon_state = "plant-10"
-	},
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/item/bedsheet/qm,
 /turf/open/floor/wood,
 /area/cargo/qm)
 "xSU" = (
@@ -21804,15 +22729,12 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
 "xTf" = (
-/obj/machinery/door/airlock{
-	name = "Emergency Storage"
+/obj/structure/table,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "xTC" = (
 /obj/structure/industrial_lift{
 	id = "medbayElevator"
@@ -21860,6 +22782,20 @@
 "xYO" = (
 /turf/open/openspace,
 /area/hallway/primary/starboard)
+"xYX" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "xZe" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -21874,12 +22810,17 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "xZY" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Virology - South;
+	network = list("ss13","medbay")
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/machinery/light/directional/west,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "yaI" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/stripes/corner{
@@ -21917,6 +22858,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
+"ybU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "ycm" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -37883,7 +38830,7 @@ pGV
 pGV
 pGV
 pGV
-gPn
+pGV
 dsT
 yin
 dsT
@@ -37911,7 +38858,7 @@ cMd
 cMd
 cMd
 dsT
-dsT
+hrz
 dsT
 cMd
 cMd
@@ -38140,7 +39087,7 @@ pGV
 pGV
 pGV
 pGV
-gPn
+pGV
 dsT
 yin
 dsT
@@ -44781,9 +45728,9 @@ pGV
 pGV
 pGV
 pGV
-dls
-bhD
-dls
+pGV
+pGV
+pGV
 pGV
 gZM
 gQH
@@ -45038,9 +45985,9 @@ pGV
 pGV
 pGV
 pGV
-dls
-iiY
-dls
+pGV
+pGV
+pGV
 pGV
 gZM
 gQH
@@ -45294,11 +46241,11 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
 gZM
-dls
-shb
-dls
-vYj
+gZM
+gZM
 gZM
 gZM
 emm
@@ -45551,11 +46498,11 @@ pGV
 pGV
 pGV
 pGV
-gZM
+iip
+iip
 iip
 gpF
-gpF
-gpF
+hIo
 gpF
 gZM
 gZM
@@ -45801,20 +46748,20 @@ pGV
 pGV
 pGV
 pGV
-bBI
 pGV
 pGV
 pGV
 pGV
 pGV
 pGV
-gZM
+pGV
+dIV
 llH
-gpF
+foa
 jiR
-udg
-sPg
-sPg
+gpF
+gpF
+gpF
 gpF
 gpF
 adq
@@ -46058,16 +47005,16 @@ pGV
 pGV
 pGV
 pGV
-rEo
-rEo
-hiP
-hiP
-hiP
-hiP
-wLl
-rEo
-gZM
-gpF
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+iip
+iip
+iip
 jiR
 tVq
 vVo
@@ -46315,17 +47262,17 @@ pGV
 pGV
 pGV
 pGV
-rEo
-kjA
-oid
-wsd
-wsd
-pzv
-oid
-hZf
-rEo
-xhF
-jiR
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+gZM
+hoR
 tVq
 dud
 pLC
@@ -46572,16 +47519,16 @@ pGV
 pGV
 pGV
 pGV
-hiP
-iiC
-wNB
-wNB
-wNB
-wxE
-wsd
-obd
-rEo
-cKE
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+gZM
+gZM
 jiR
 tVq
 xyS
@@ -46828,16 +47775,16 @@ pGV
 pGV
 pGV
 pGV
-hiP
-hiP
-dIV
-wNB
-aRz
-wNB
-wNB
-wNB
-oid
-hiP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+gZM
 oNj
 jiR
 jnK
@@ -47085,21 +48032,21 @@ pGV
 pGV
 pGV
 pGV
+pGV
+wTs
+wTs
 hiP
-cfZ
-wNB
-wNB
-lHx
-aCh
-wNB
-wNB
-wsd
 hiP
-gpF
+hiP
+cKE
+cKE
+hiP
+wTs
+fNs
 tVc
 dXT
-lsd
-lsd
+gpF
+gpF
 gpF
 gpF
 dUu
@@ -47186,7 +48133,7 @@ xCi
 xCi
 xCi
 xCi
-qoL
+xCi
 qoL
 rue
 lcP
@@ -47342,17 +48289,17 @@ pGV
 pGV
 pGV
 pGV
-hiP
+pGV
 wTs
 wuQ
-wNB
-bFX
+oid
+epd
 aCh
 oqS
-wNB
-wsd
-gQC
-jiR
+epd
+ejZ
+wTs
+fNw
 jiR
 lKv
 vQa
@@ -47369,8 +48316,8 @@ hVj
 etL
 iVq
 gFk
+hVj
 etL
-iVq
 uvQ
 bfR
 tty
@@ -47380,9 +48327,9 @@ tty
 tty
 tty
 bHy
-hCh
-hCh
-hCh
+kjA
+kjA
+kjA
 bqJ
 dim
 wNH
@@ -47599,16 +48546,16 @@ pGV
 pGV
 pGV
 pGV
+pGV
 hiP
-hkC
+aQd
 wNB
 wNB
-nTv
-aCh
 wNB
 wNB
-wsd
-wLl
+epd
+oid
+wTs
 gpF
 tVq
 ied
@@ -47627,7 +48574,7 @@ leG
 usd
 fno
 fBj
-vBQ
+vxz
 uvQ
 bfR
 tty
@@ -47638,8 +48585,8 @@ tty
 tty
 bHy
 wFs
-hCh
-hCh
+kjA
+kjA
 byc
 dim
 wNH
@@ -47861,7 +48808,7 @@ hiP
 vEf
 wNB
 mpI
-wNB
+bBI
 wNB
 wNB
 oid
@@ -47894,8 +48841,8 @@ bHy
 bHy
 ocV
 bHy
-hCh
-hCh
+kjA
+kjA
 aLK
 bCv
 dim
@@ -48113,18 +49060,18 @@ pGV
 pGV
 pGV
 pGV
-pGV
 hiP
-ozo
+aor
 wNB
 wNB
+bhD
+caL
 wNB
-etR
-oid
+wNB
 epd
-rEo
-vta
-vCr
+hiP
+gpF
+dhv
 lsd
 lsd
 vPg
@@ -48152,9 +49099,9 @@ tty
 tty
 bHy
 anp
-hCh
-hCh
-hCh
+kjA
+kjA
+kjA
 cmX
 wNH
 wNH
@@ -48370,17 +49317,17 @@ pGV
 pGV
 pGV
 pGV
-pGV
-rEo
-oFu
-oid
-wsd
-wsd
-wWk
 hiP
 rEo
-rEo
-xuk
+oFu
+wNB
+wsd
+caL
+wWk
+wNB
+epd
+eSt
+gpF
 gpF
 gpF
 gpF
@@ -48408,7 +49355,7 @@ clD
 clD
 clD
 bHy
-hCh
+kjA
 aLK
 beo
 aLK
@@ -48627,22 +49574,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-rEo
-rEo
 hiP
-hiP
-hiP
-hiP
-hiP
-pGV
-gZM
-bhw
+aDw
+wNB
+wNB
+bkG
+caL
+wNB
+wNB
+epd
+cKE
+gpF
 xIY
 ufJ
 ufJ
 azJ
-fNs
+gpF
 tgJ
 uvQ
 hWX
@@ -48665,10 +49612,10 @@ bHy
 bHy
 tty
 bHy
-hCh
-hCh
+kjA
+kjA
 aLK
-hCh
+kjA
 dim
 wNH
 wNH
@@ -48884,22 +49831,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gZM
-gZM
-tCf
+hiP
+hiP
+aRz
+wNB
+buR
+chZ
+wNB
+wNB
+oid
+hiP
+gpF
+pRa
 rTd
 rTd
 yjj
-gZM
+gpF
 gZM
 uvQ
 uvQ
@@ -48923,8 +49870,8 @@ bHy
 tty
 bHy
 axW
-hCh
-hCh
+kjA
+kjA
 aLK
 dim
 wNH
@@ -49142,24 +50089,24 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gZM
+hiP
+aWA
+wNB
+wNB
+wNB
+wNB
+oid
+etR
+wTs
+fSK
 pRa
 rTd
 rTd
 yjj
+iiC
 gZM
-tDG
-tDG
-tDG
+eOq
+eOq
 aPY
 aPY
 aPY
@@ -49399,23 +50346,23 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gZM
+wTs
+bhw
+oid
+epd
+epd
+dls
+oid
+eQd
+wTs
+gGk
 rTu
 mIf
 mIf
 uhS
+iiY
 gZM
-tDG
-tDG
+eOq
 tor
 tor
 tor
@@ -49656,21 +50603,21 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+wTs
+wTs
+hiP
+hiP
+hiP
+spB
+spB
+spB
+ohv
 ohv
 fND
 fND
-ohv
-ohv
 fND
 fND
-fND
-fND
-ohv
+iwh
 ohv
 ohv
 tor
@@ -50261,7 +51208,7 @@ cof
 cof
 cof
 nhr
-jIn
+eeA
 qTM
 qTM
 yaI
@@ -50776,7 +51723,7 @@ vmM
 twb
 nhr
 jIn
-gCq
+fAJ
 jIn
 jIn
 kjW
@@ -51033,7 +51980,7 @@ nhr
 nhr
 rEt
 rEt
-gCq
+fAJ
 jIn
 jIn
 ecG
@@ -51290,7 +52237,7 @@ baJ
 baJ
 gsT
 rEt
-gCq
+fAJ
 jIn
 ecG
 ecG
@@ -51547,7 +52494,7 @@ baJ
 baJ
 gsT
 rEt
-gCq
+fAJ
 jIn
 ecG
 lsZ
@@ -51804,7 +52751,7 @@ kBO
 kBO
 sVX
 rEt
-gCq
+fAJ
 jIn
 lsZ
 lsZ
@@ -52061,7 +53008,7 @@ kGM
 kGM
 kGM
 kjr
-gCq
+fAJ
 jIn
 ecG
 lsZ
@@ -52318,7 +53265,7 @@ wsn
 wsn
 kGM
 rEt
-gCq
+fAJ
 jIn
 hhb
 hhb
@@ -52575,12 +53522,12 @@ iTL
 uAg
 wsn
 rEt
-gCq
+fAJ
 jIn
 hhb
 uav
 vjv
-qKJ
+ssv
 toc
 jPZ
 tKw
@@ -52832,11 +53779,11 @@ rDh
 iTL
 wsn
 rEt
-gCq
+fAJ
 jIn
 hhb
 cwd
-qKJ
+epl
 qKJ
 ime
 dcw
@@ -53089,11 +54036,11 @@ wsn
 wsn
 kGM
 rEt
-gCq
+fAJ
 jIn
 hhb
 qgU
-aNf
+fMl
 fak
 frM
 iqJ
@@ -53346,10 +54293,10 @@ eJE
 eJE
 eJE
 eJE
-gCq
-jIn
+fAJ
+rCT
 wZI
-aNf
+fMl
 gMF
 iWS
 avM
@@ -56454,19 +57401,19 @@ oRz
 juT
 cFI
 tzT
-rXC
+diF
 diF
 vzA
 vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+spU
+spU
+spU
+spU
+spU
+spU
+spU
+spU
 pGV
 pGV
 pGV
@@ -56715,15 +57662,15 @@ aqQ
 diF
 vzA
 vzA
+pyu
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
 pGV
 pGV
 pGV
@@ -56973,14 +57920,14 @@ diF
 vzA
 vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+vzA
+spU
 pGV
 pGV
 pGV
@@ -57232,18 +58179,18 @@ spU
 spU
 spU
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
+spU
+spU
+spU
+spU
+miU
+spU
+cJU
+cJU
+cJU
+cJU
+cJU
+cJU
 pGV
 pGV
 pGV
@@ -57488,19 +58435,19 @@ vzA
 vzA
 vzA
 vzA
+vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
+dgx
+dgx
+iZv
+fzb
+tuh
+bLM
+iZj
+xYX
+xMS
+teW
+cJU
 pGV
 pGV
 pGV
@@ -57745,19 +58692,19 @@ vzA
 vzA
 vzA
 vzA
+vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
+dgx
+dgx
+bmS
+dKv
+hLZ
+xJK
+wFV
+wFV
+wFV
+wIX
+cJU
 pGV
 pGV
 pGV
@@ -57996,25 +58943,25 @@ iuR
 xPR
 rXC
 rXC
-rXC
+diF
 diF
 vzA
 vzA
 vzA
 vzA
+vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
+dgx
+dgx
+bmS
+rxT
+anz
+adi
+wFV
+wFV
+wFV
+pjN
+cJU
 pGV
 pGV
 pGV
@@ -58257,21 +59204,21 @@ soN
 vzA
 vzA
 vzA
-diF
-diF
-gLH
-pVi
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
+spU
+spU
+spU
+spU
+lXP
+lXP
+tPc
+jnk
+eXa
+ceu
+qvS
+erQ
+vII
+qbj
+cJU
 pGV
 pGV
 pGV
@@ -58510,25 +59457,25 @@ wDm
 jRr
 jRr
 cYE
-gLH
-gLH
-gLH
-gLH
-gLH
+spU
+spU
+spU
+spU
+spU
 xSC
 tlv
-pVi
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
+uqC
+rAR
+lXP
+bRE
+lXP
+eXa
+anz
+anz
+fUi
+anz
+cJU
+cJU
 pGV
 pGV
 pGV
@@ -58774,16 +59721,16 @@ ihs
 khh
 ruk
 qSc
-pVi
+uqC
+rAR
+rAR
+rAR
+uqC
 pGV
 pGV
-pGV
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+anz
+tqV
+anz
 pGV
 pGV
 pGV
@@ -59031,16 +59978,16 @@ xbQ
 aim
 bsJ
 rvC
-pVi
+uqC
+rAR
+rAR
+rAR
+uqC
 pGV
 pGV
-pGV
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+anz
+tqV
+anz
 pGV
 pGV
 pGV
@@ -59190,7 +60137,7 @@ fIg
 fIg
 fIg
 qpB
-aor
+mjd
 pKN
 jFr
 jFr
@@ -59288,16 +60235,16 @@ xbQ
 eFn
 ftw
 qSH
-pVi
+uqC
+rAR
+rAR
+rAR
+uqC
 pGV
 pGV
-pGV
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+anz
+sQR
+anz
 pGV
 pGV
 pGV
@@ -59442,12 +60389,12 @@ ohv
 pGV
 pGV
 aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+iYY
+mjd
+mjd
+mjd
+mjd
+mjd
 dbm
 ggJ
 ggJ
@@ -59545,16 +60492,16 @@ xbQ
 sjW
 sjW
 xbQ
-pVi
+uqC
+rAR
+rAR
+uqC
+uqC
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+fJK
+fgG
+fJK
 pGV
 pGV
 pGV
@@ -59688,7 +60635,7 @@ axT
 ncv
 ncv
 mBT
-oJa
+gMz
 aKO
 aKO
 aKO
@@ -59802,10 +60749,10 @@ loV
 xbQ
 xbQ
 xbQ
-pVi
-pGV
-pGV
-pGV
+uqC
+rAR
+rAR
+uqC
 pGV
 pGV
 pGV
@@ -60058,11 +61005,11 @@ gLH
 gcL
 xbQ
 xbQ
-pVi
-pVi
-pGV
-pGV
-pGV
+uqC
+uqC
+rAR
+rAR
+uqC
 pGV
 pGV
 pGV
@@ -60311,15 +61258,15 @@ qoI
 jOF
 oVL
 anY
-pTQ
-pVi
-pVi
-pVi
-pVi
-aPY
-pGV
-pGV
-pGV
+lXP
+uqC
+uqC
+uqC
+uqC
+rAR
+rAR
+rAR
+uqC
 pGV
 pGV
 pGV
@@ -60568,15 +61515,15 @@ geB
 vCQ
 vCQ
 itf
-pTQ
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+ojL
+rAR
+rAR
+rAR
+rAR
+rAR
+rAR
+rAR
+uqC
 pGV
 pGV
 pGV
@@ -60716,7 +61663,7 @@ kTE
 cHn
 xdd
 mBT
-fNw
+tJK
 tJK
 vqw
 bsh
@@ -60825,15 +61772,15 @@ jZk
 emp
 vCQ
 itf
-pTQ
-pTQ
-pTQ
-pTQ
-aPY
-aPY
-pGV
-pGV
-pGV
+lXP
+uqC
+uqC
+uqC
+oSt
+lXP
+lXP
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -61086,9 +62033,9 @@ fsU
 rTA
 tHE
 uqC
-aPY
-aPY
-pGV
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -61343,9 +62290,9 @@ fsU
 hKm
 rws
 uqC
-aPY
-aPY
-pGV
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -61600,10 +62547,10 @@ fsU
 kig
 rws
 uqC
-aPY
-aPY
-pGV
-pGV
+rAR
+rAR
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -61853,14 +62800,14 @@ qiT
 xsj
 cQN
 grC
-pTQ
-pTQ
-pTQ
-pTQ
-aPY
-aPY
-pGV
-pGV
+fsU
+rws
+rws
+lXP
+rAR
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -62001,9 +62948,9 @@ kAk
 ncv
 pbu
 mBT
-tJK
-tJK
-tJK
+hkC
+hqO
+hkC
 mBT
 pGV
 snP
@@ -62110,15 +63057,15 @@ ydA
 nVN
 kcJ
 pTQ
-pTQ
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+fsU
+rws
+rws
+lXP
+rAR
+rAR
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -62258,10 +63205,10 @@ ikj
 ncv
 ncv
 mBT
-gMz
-fSK
-gMz
 mBT
+mBT
+mBT
+hZf
 pGV
 pGV
 pGV
@@ -62372,10 +63319,10 @@ uTX
 uTX
 uTX
 uTX
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -62515,10 +63462,10 @@ bsh
 bsh
 bsh
 bsh
-mBT
-mBT
-mBT
-kys
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -62629,10 +63576,10 @@ wxJ
 aol
 aol
 aol
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -62886,10 +63833,10 @@ vrg
 aol
 hnC
 wof
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -63143,10 +64090,10 @@ xOM
 vNV
 wcV
 aol
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -63400,10 +64347,10 @@ uTX
 uTX
 uTX
 uTX
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -63657,10 +64604,10 @@ wxJ
 aol
 aol
 aol
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -63914,10 +64861,10 @@ uOt
 aol
 aol
 wof
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -64092,7 +65039,7 @@ aPY
 wcJ
 rHj
 ydW
-ydW
+mWM
 mWM
 tck
 enK
@@ -64171,10 +65118,10 @@ dpj
 vNV
 rSr
 aol
-uTX
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -64428,11 +65375,11 @@ uTX
 uTX
 uTX
 uTX
-uTX
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -64685,11 +65632,11 @@ wxJ
 aol
 aol
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -64942,11 +65889,11 @@ fEp
 aol
 aol
 wof
-uTX
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -65122,7 +66069,7 @@ gia
 ydW
 mWM
 mWM
-sfi
+mWM
 edw
 mWM
 eqx
@@ -65199,11 +66146,11 @@ ooI
 vNV
 riU
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -65456,11 +66403,11 @@ uTX
 uTX
 uTX
 uTX
-uTX
-wxJ
-aPY
-aPY
-aPY
+lWu
+uqC
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -65714,10 +66661,10 @@ cod
 tnh
 rtP
 uPp
-wxJ
-aPY
-aPY
-aPY
+uqC
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -65971,10 +66918,10 @@ cod
 cod
 cod
 cod
-wxJ
-aPY
-aPY
-aPY
+uqC
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -66228,10 +67175,10 @@ mCd
 mCd
 wPJ
 cod
-wxJ
-aPY
-aPY
-aPY
+uqC
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -66485,10 +67432,10 @@ cod
 cRr
 cod
 uPp
-wxJ
-aPY
-aPY
-aPY
+uqC
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -66742,10 +67689,10 @@ uTX
 uTX
 uTX
 uTX
-wxJ
-aPY
-aPY
-aPY
+uqC
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -66913,7 +67860,7 @@ kKL
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 bdb
 fin
@@ -66998,18 +67945,18 @@ wxJ
 aol
 aol
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -67170,7 +68117,7 @@ pGV
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 bTr
 rWM
@@ -67255,18 +68202,18 @@ dtz
 aol
 aol
 wof
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -67427,7 +68374,7 @@ pGV
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 dyn
 rWM
@@ -67445,7 +68392,7 @@ qee
 cPN
 oOF
 cOR
-dAu
+dBH
 rRA
 koY
 bxz
@@ -67512,18 +68459,18 @@ quW
 vNV
 jPL
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -67684,7 +68631,7 @@ pGV
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 onP
 rWM
@@ -67701,14 +68648,14 @@ tEX
 tEX
 wzF
 xTC
-cOR
-dAu
+xJR
+wJz
 pBS
 dQY
 dQY
 nJY
-ebz
-ebz
+dQY
+dQY
 wgL
 ydW
 hCc
@@ -67769,18 +68716,18 @@ uTX
 uTX
 uTX
 uTX
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -67941,7 +68888,7 @@ pGV
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 bTr
 rWM
@@ -67952,20 +68899,20 @@ fQt
 hcT
 cQK
 tEX
-kaq
+jZK
 kaq
 kaq
 tEX
 qFs
 uOF
 npR
-iYY
 siS
 siS
 siS
 siS
+oCM
 xgd
-uhb
+siS
 huS
 ydW
 hCc
@@ -68026,21 +68973,21 @@ wxJ
 aol
 aol
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -68198,7 +69145,7 @@ pGV
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 jWj
 rWM
@@ -68209,20 +69156,20 @@ bCo
 mQG
 kiY
 wQS
+jZK
 kaq
 kaq
-kaq
 tEX
 tEX
 tEX
 tEX
 tEX
 tEX
-hoR
-bTE
-bTE
 sfi
-vtY
+sfi
+oAX
+sfi
+sfi
 sfi
 ydW
 hCc
@@ -68283,21 +69230,21 @@ aum
 aol
 aol
 wof
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -68455,7 +69402,7 @@ pGV
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 ckD
 uwi
@@ -68466,20 +69413,20 @@ iZV
 tqU
 dpP
 tEX
-kaq
-kaq
-kaq
-kaq
-kaq
+jZK
+jZK
+jZK
+jZK
+jZK
 kaq
 kaq
 kaq
 tEX
-wAt
-wAt
-bTE
+wJz
 rkj
 vpa
+wJz
+wJz
 wJz
 ydW
 hCc
@@ -68540,21 +69487,21 @@ qug
 vNV
 ukt
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -68712,7 +69659,7 @@ pGV
 pGV
 pGV
 pGV
-aPY
+pGV
 ptC
 ptC
 ptC
@@ -68727,14 +69674,14 @@ tEX
 tEX
 tEX
 tEX
-kaq
-kaq
+jZK
+jZK
 jZK
 jZK
 kGy
-aXA
-aXA
-ngU
+vpa
+vpa
+vpa
 vpa
 vpa
 vpa
@@ -68797,18 +69744,18 @@ uTX
 uTX
 uTX
 uTX
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -68969,30 +69916,30 @@ pGV
 pGV
 pGV
 pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+pGV
+gPn
+kys
+lCb
+npm
+wAt
+oHQ
+wAt
+sCJ
+tCf
+uhb
+uBS
+vta
+xhF
 tEX
 kaq
 kaq
 kaq
 kaq
 hKj
-wAt
-wAt
-bTE
-fNb
+wJz
+vpa
+wJz
+spS
 vpa
 wJz
 ydW
@@ -69054,18 +70001,18 @@ wxJ
 aol
 aol
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -69228,18 +70175,18 @@ pGV
 pGV
 pGV
 gPn
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 rrS
-rrS
-rrS
-rrS
-rrS
+lHx
+wAt
+wAt
+rwS
+wAt
+wCv
+wCv
+wCv
+uCE
+wCv
+xuk
 hKj
 hKj
 hKj
@@ -69311,18 +70258,18 @@ kFD
 aol
 szG
 wof
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+rAR
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -69485,24 +70432,24 @@ pGV
 pGV
 pGV
 gPn
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-cFh
-ahP
-wpJ
-wAt
-wkG
-wAt
+rrS
+mIC
 npn
+okp
+rwS
+wAt
+wAt
+wAt
+wAt
+wAt
+wAt
+wCv
+xZY
+wAt
 hWV
 ciy
-hqO
 rrS
+hHw
 mUI
 jIJ
 jky
@@ -69568,18 +70515,18 @@ eqt
 vNV
 smz
 aol
-uTX
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lWu
+rAR
+rAR
+lXP
+lXP
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -69742,26 +70689,26 @@ pGV
 pGV
 pGV
 gPn
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 rrS
-aQd
-aWA
-aDw
-oSH
+bTE
+bTE
+bTE
+bTE
+qvq
+wAt
+lCb
 wAt
 wAt
-peO
 wAt
-wAt
+wCv
+wCv
+wCv
+wCv
+wCv
+ntH
 cmT
 wCv
-wAt
+wCv
 aAR
 rrS
 vpa
@@ -69822,13 +70769,13 @@ lWu
 gMD
 lWu
 lWu
-uTX
-uTX
-uTX
-uTX
-pGV
-pGV
-pGV
+lWu
+lWu
+lWu
+lWu
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -69999,24 +70946,24 @@ pGV
 pGV
 pGV
 gPn
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-rrS
-bTE
-bTE
-bTE
-bTE
-foa
+kys
+lCb
+npm
+wAt
+piX
+wAt
+wAt
+wAt
+ukM
+vjx
+vtY
+wAt
+wAt
+wAt
+wAt
 aXA
-eSt
-aXA
-ssP
 rrS
+gym
 geX
 aIT
 dqM
@@ -70078,14 +71025,14 @@ rAR
 rAR
 xuA
 rAR
+rAR
+rAR
+rAR
+rAR
+oSt
+rAR
+rAR
 lXP
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 pGV
 pGV
 pGV
@@ -70256,26 +71203,26 @@ gPn
 gPn
 gPn
 gPn
-bMu
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-cFh
+rrS
+lHx
+wAt
+wAt
+rwS
+wAt
+wAt
+wAt
 ahP
 wpJ
+vBQ
 wAt
-hIo
+vMM
+biH
 wAt
-wAt
-lCb
 ptx
-ucq
 rrS
 rrS
-qMq
+hJG
+rrS
 rrS
 rrS
 vpa
@@ -70335,14 +71282,14 @@ xuA
 xuA
 xuA
 rAR
+rAR
+rAR
+rAR
+rAR
 lXP
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+rAR
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -70513,26 +71460,26 @@ huc
 huc
 huc
 huc
-huc
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 rrS
-ukM
-tEV
-aDw
-oSH
+mQa
+nTv
 okp
-qvq
+rwS
+wAt
+wAt
+tEV
+wAt
+wAt
+wAt
+wAt
+wAt
+wAt
 mZf
 bWb
-iwh
 rrS
+sVz
 cwt
-dnT
+gzk
 akM
 bTE
 vpa
@@ -70593,12 +71540,12 @@ lXP
 lXP
 lXP
 lXP
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -70770,26 +71717,26 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 rrS
 bTE
 bTE
 bTE
 bTE
-tna
-wAt
 qzQ
+wAt
+wAt
+wAt
+wAt
+wAt
+wAt
+wAt
+wAt
+wAt
 krT
-mIC
 rrS
+tKI
 kBM
-cXD
+gzk
 vQs
 bTE
 vpa
@@ -70841,16 +71788,16 @@ rAR
 rAR
 lXP
 xuA
+rAR
+rAR
+rAR
+rAR
+rAR
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+rAR
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -71027,24 +71974,24 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-rrS
-xPC
+kys
+lCb
+npm
+wAt
+piX
+wAt
+wAt
+wAt
+wAt
 jwq
-fVO
-sCJ
-eQd
 wAt
 wAt
 wAt
-opf
+rbG
+bVX
+krH
 rrS
+vjC
 vLW
 gzk
 sqj
@@ -71098,16 +72045,16 @@ rAR
 rAR
 lXP
 xuA
+xuA
+xuA
+xuA
+xuA
+xuA
+fpm
+xuA
+rAR
+vHR
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 pGV
 pGV
 pGV
@@ -71284,26 +72231,26 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-cFh
-fuD
-vjx
-rwS
-bTE
-bTE
-oSH
-uBS
-oSH
-bTE
 rrS
+lHx
+wAt
+wAt
 bTE
+fuD
+sPg
+fuD
+fuD
 bTE
+rwS
+xPC
+rwS
+rrS
+rrS
+rrS
+rrS
+rrS
+rrS
+tUp
 tUp
 bTE
 vmQ
@@ -71355,16 +72302,16 @@ xuA
 xuA
 xuA
 xuA
+rAR
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+lXP
+lXP
+lXP
+lXP
+xuA
+xuA
+iVM
+lXP
 pGV
 pGV
 pGV
@@ -71541,27 +72488,27 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-cFh
-xKX
-fVO
-jZU
-bTE
-vLl
-wpJ
-wAt
-caL
-jEh
 rrS
+ngU
+obd
+okp
+fuD
+fVO
+sRs
+ucq
+xKX
+bTE
+jZU
+wAt
+wAt
+nQo
+mLI
+rrS
+jEh
 pGV
 pGV
-xSh
+pGV
+pGV
 yjO
 qBK
 hTm
@@ -71611,17 +72558,17 @@ lWu
 rAR
 rAR
 lXP
+xuA
+xuA
+qxr
+xuA
+rAR
 rAR
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+rAR
+rAR
+rAR
+lXP
 pGV
 pGV
 pGV
@@ -71798,24 +72745,24 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-cFh
+rrS
+fuD
+fuD
+fuD
+fuD
+qMq
 fVO
-rwS
+tna
+fVO
+bTE
 lQl
-oSH
-sRs
+wAt
+wAt
 wAt
 sGB
-wAt
-chZ
 rrS
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -71868,20 +72815,20 @@ lWu
 rAR
 rAR
 lXP
+xuA
 rAR
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+xuA
+rAR
+rAR
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -72055,24 +73002,24 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-rrS
+fuD
+fVO
+fVO
+opf
+pzv
+shb
+fVO
+fVO
 lPS
-fVO
-fVO
 bTE
-bkG
-saw
-piX
+vCr
 wAt
-oHQ
+wAt
+saw
+wAt
 rrS
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -72125,20 +73072,20 @@ lWu
 lWu
 lWu
 lXP
+xuA
 rAR
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+xuA
+rAR
+rAR
+lXP
+tfj
+unA
+cPT
+pwy
+nBY
+xNC
+lXP
 pGV
 pGV
 pGV
@@ -72312,24 +73259,24 @@ pGV
 pGV
 pGV
 pGV
+fuD
+fVO
+fVO
+fVO
+fVO
+fVO
+tna
+udg
+ssP
+bTE
+vLl
+wAt
+wAt
+wAt
+beH
+rrS
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-rrS
-rrS
-rrS
-rrS
-rrS
-rrS
-cFh
-cFh
-cFh
-rrS
-rrS
 pGV
 pGV
 pGV
@@ -72382,20 +73329,20 @@ rKD
 eQh
 lWu
 rAR
+xuA
 rAR
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+xuA
+rAR
+rAR
+lXP
+qae
+odz
+bBK
+bBK
+uyx
+bGR
+lXP
 pGV
 pGV
 pGV
@@ -72569,22 +73516,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+fuD
+fVO
+fVO
+ozo
+fVO
+ssP
+fVO
+fVO
+fVO
+bTE
+vYj
+wAt
+wAt
+iow
+wAt
+rrS
 pGV
 pGV
 pGV
@@ -72639,20 +73586,20 @@ rKD
 eQh
 lWu
 lXP
-oSt
+fpm
 lXP
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+lXP
+xuA
+rAR
+rAR
+uqC
+wVR
+kzx
+aTP
+iSx
+jrk
+mTr
+lXP
 pGV
 pGV
 pGV
@@ -72826,22 +73773,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+rrS
+fuD
+fuD
+fuD
+fuD
+fuD
+fuD
+fuD
+fuD
+rrS
+wxE
+xSh
+wAt
+wAt
+wAt
+rrS
 pGV
 pGV
 pGV
@@ -72896,20 +73843,20 @@ gzg
 gzg
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+fbl
+lXP
+rAR
+xuA
+rAR
+rAR
+uqC
+oNa
+kzx
+aTP
+aTP
+aTP
+gDn
+lXP
 pGV
 pGV
 pGV
@@ -73092,13 +74039,13 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+rrS
+xaE
+xTf
+hUY
+wAt
+mGh
+rrS
 pGV
 pGV
 pGV
@@ -73126,7 +74073,7 @@ vmQ
 vmQ
 mJz
 rDr
-mQa
+rDr
 rDr
 rDr
 rDr
@@ -73153,23 +74100,23 @@ qrf
 rPP
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+fbl
+lXP
+rAR
+xuA
+rAR
+rAR
+lXP
+jNZ
+bqz
+tNp
+xJo
+rxb
+gPg
+gPm
+gPm
+gPm
+gPm
 pGV
 pGV
 pGV
@@ -73349,13 +74296,13 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+rrS
+rrS
+fuD
+fuD
+fuD
+fuD
+rrS
 pGV
 pGV
 pGV
@@ -73382,11 +74329,11 @@ hTm
 hTm
 hTm
 luc
-gaC
-gaC
-xTf
-gaC
-uCE
+dkc
+dkc
+dkc
+dkc
+rDr
 bew
 ctm
 nKH
@@ -73410,23 +74357,23 @@ cbt
 ftK
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+fbl
+lXP
+rAR
+xuA
+xuA
+xuA
+icH
+eQM
+rxb
+qAb
+jMD
+rxb
+gDn
+tfF
+rAR
+rAR
+jJC
 pGV
 pGV
 pGV
@@ -73639,12 +74586,12 @@ hTm
 hTm
 toC
 luc
-gGk
-npm
-buR
-rmT
+dkc
+dkc
+dkc
+rDM
 qsx
-rmT
+rDM
 rmT
 nqs
 nGy
@@ -73667,23 +74614,23 @@ cbt
 ftK
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+fbl
+lXP
+rAR
+rAR
+rAR
+rAR
+lXP
+iHl
+pqj
+agY
+hJp
+rxb
+gPg
+gPm
+gPm
+gPm
+gPm
 pGV
 pGV
 pGV
@@ -73898,10 +74845,10 @@ hTm
 luc
 akj
 dkc
-ejZ
-rmT
-fbl
-iXi
+dkc
+rDM
+qsx
+rDM
 rmT
 ciW
 nGy
@@ -73913,7 +74860,7 @@ gjk
 rmT
 qub
 hQE
-mkX
+fGs
 jdT
 mkX
 mkX
@@ -73924,20 +74871,20 @@ cbt
 kHX
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+fbl
+lXP
+rAR
+rAR
+rAR
+rAR
+uqC
+wnE
+eQM
+aTP
+aTP
+rxb
+aTP
+lXP
 pGV
 pGV
 pGV
@@ -74153,12 +75100,12 @@ hTm
 hTm
 nSN
 luc
-xaE
-xZY
+gaC
+gaC
 etK
 rmT
-fbl
-iXi
+pQE
+rDM
 rmT
 rXt
 elb
@@ -74166,8 +75113,8 @@ fma
 nhY
 rmT
 iXi
-iXi
-iXi
+fbl
+fbl
 vGY
 cFd
 uRg
@@ -74181,20 +75128,20 @@ cbt
 ftK
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+fbl
+lXP
+rAR
+rAR
+rAR
+rAR
+uqC
+wnE
+eQM
+rxb
+rxb
+pOC
+eKH
+lXP
 pGV
 pGV
 pGV
@@ -74410,12 +75357,12 @@ hTm
 hTm
 hTm
 luc
-gaC
-gaC
-gaC
+qbu
+pll
+nyx
 rmT
-fbl
-iXi
+sOI
+rmT
 rmT
 rmT
 tCj
@@ -74423,7 +75370,7 @@ rmT
 rmT
 rmT
 iXi
-iXi
+fbl
 iXi
 qub
 qub
@@ -74438,20 +75385,20 @@ cbt
 ftK
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+fbl
+lXP
+rAR
+rAR
+rAR
+rAR
+lXP
+wnE
+soC
+uZl
+uZl
+ybU
+uUp
+lXP
 pGV
 pGV
 pGV
@@ -74667,9 +75614,9 @@ hTm
 hTm
 hTm
 luc
-aPY
-aPY
-aPY
+fmO
+wlM
+qyt
 rmT
 fbl
 fbl
@@ -74695,20 +75642,20 @@ qub
 qub
 qub
 iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+fbl
+lXP
+rAR
+rAR
+rAR
+rAR
+lXP
+meo
+syu
+krg
+kLE
+pMi
+xNC
+lXP
 pGV
 pGV
 pGV
@@ -74924,9 +75871,9 @@ mtv
 vcf
 hTm
 luc
-aPY
-aPY
-aPY
+dqL
+isM
+cXP
 rmT
 iXi
 iXi
@@ -74938,34 +75885,34 @@ iXi
 iXi
 iXi
 iXi
-iXi
-iXi
-iXi
-iXi
-iXi
-qsj
-iXi
-iXi
-iXi
-iXi
-iXi
-iXi
-iXi
-iXi
-iXi
-rmT
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+fbl
+fbl
+fbl
+fbl
+fbl
+keK
+fbl
+fbl
+fbl
+fbl
+fbl
+fbl
+fbl
+fbl
+fbl
+lXP
+rAR
+rAR
+rAR
+rAR
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -75181,25 +76128,9 @@ luc
 luc
 luc
 luc
-aPY
-aPY
-aPY
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-rmT
-iXi
+tlJ
+tlJ
+tlJ
 rmT
 iXi
 iXi
@@ -75210,12 +76141,28 @@ iXi
 iXi
 iXi
 iXi
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
 rmT
-aPY
-aPY
-aPY
-aPY
-aPY
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
+lXP
+lXP
+lXP
+lXP
+lXP
+lXP
 pGV
 pGV
 pGV
@@ -75441,20 +76388,22 @@ aPY
 aPY
 aPY
 aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
+iXi
 rmT
 rmT
 rmT
@@ -75465,9 +76414,7 @@ rmT
 rmT
 rmT
 rmT
-rmT
-rmT
-rmT
+lXP
 pGV
 pGV
 pGV
@@ -75705,17 +76652,17 @@ pGV
 pGV
 pGV
 pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+rmT
+pGV
 pGV
 pGV
 pGV

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -1,4 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aam" = (
+/obj/machinery/door/airlock/command{
+	name = "Auxiliary E.V.A. Storage";
+	req_access_txt = "18"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "aaD" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
@@ -33,22 +42,17 @@
 /obj/item/instrument/banjo,
 /turf/open/floor/iron,
 /area/security/prison)
-"adi" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "adq" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron,
 /area/security/office)
+"adI" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/space)
 "adV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -116,33 +120,6 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/maintenance/department/security/upper)
-"agY" = (
-/obj/structure/rack,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "aho" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/blue{
@@ -184,6 +161,13 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/cargo/qm)
+"aiq" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Arrivals - East Ferry Dock";
+	name = "Arrivals Camera"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "ajc" = (
 /obj/item/radio/intercom/directional/north{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
@@ -228,6 +212,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"aky" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "akM" = (
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/plating,
@@ -256,6 +244,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"anj" = (
+/obj/structure/rack,
+/obj/item/tank/jetpack,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "anp" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -263,10 +257,6 @@
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
-"anz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/cargo/miningoffice)
 "anU" = (
 /obj/machinery/button/ticket_machine{
 	pixel_x = 24;
@@ -316,6 +306,15 @@
 /obj/machinery/computer/secure_data,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"aoK" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Service Bay";
+	req_access_txt = "65"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "apt" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_white"
@@ -387,7 +386,7 @@
 	},
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "arK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -402,6 +401,12 @@
 /obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"asb" = (
+/obj/structure/table,
+/obj/item/storage/crayons,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "asn" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -676,6 +681,14 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
+"aDO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "aEF" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -734,6 +747,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison/upper)
+"aGG" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "aHH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/instrument/eguitar,
@@ -765,6 +785,21 @@
 /obj/structure/closet/l3closet/virology,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"aJh" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "aKx" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -801,6 +836,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"aLr" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "aLK" = (
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/eighties/red,
@@ -809,9 +851,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/psychology)
+"aNb" = (
+/turf/open/openspace,
+/area/cargo/miningoffice)
 "aNf" = (
 /turf/open/floor/wood,
 /area/service/theater)
+"aNm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/maintenance/solars)
 "aNP" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
@@ -850,6 +900,25 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"aQO" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/multitool,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 35
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
+"aQW" = (
+/obj/structure/closet/firecloset,
+/obj/item/storage/box/lights/mixed,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 9
+	},
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "aRb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -883,6 +952,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/server)
+"aSP" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "aTg" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -894,7 +967,7 @@
 	icon_state = "L8"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "aTP" = (
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
@@ -932,10 +1005,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"aUN" = (
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "aUP" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"aVa" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "aVu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -1138,10 +1220,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"beH" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "bfa" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -1205,6 +1283,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"bhB" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "bhD" = (
 /obj/structure/table/wood{
 	color = "#101010"
@@ -1215,12 +1316,19 @@
 "bhS" = (
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
-"biH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+"bib" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"biu" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Minisat Exterior SWW";
+	name = "Minisat Camera";
+	network = list("minisat")
 	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/turf/open/space/basic,
+/area/space)
 "biM" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -1235,6 +1343,13 @@
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"biY" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "bjf" = (
 /obj/item/radio/intercom/directional/east,
 /obj/structure/closet/firecloset,
@@ -1282,6 +1397,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"blr" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/machinery/light/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "blM" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
@@ -1316,12 +1438,6 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/medical/abandoned)
-"bmS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "bnc" = (
 /obj/structure/railing{
 	dir = 8
@@ -1369,15 +1485,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"bqz" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "bqJ" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/happy,
@@ -1425,6 +1532,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"bue" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "buy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1445,6 +1557,31 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
+"bvo" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Space Access Airlock";
+	req_one_access_txt = "13;65"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/circuit,
+/area/maintenance/solars)
+"bvU" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"bvZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"bwl" = (
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "bwV" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentyfour_twentyfour,
@@ -1467,6 +1604,13 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/cmo)
+"bxA" = (
+/obj/machinery/power/tracker{
+	id = "aisolar"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/maintenance/solars)
 "bxZ" = (
 /obj/structure/railing{
 	dir = 8
@@ -1529,6 +1673,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"bzI" = (
+/obj/structure/cable,
+/obj/structure/table/glass,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/science,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "bzZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim/directional/north,
@@ -1538,6 +1690,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"bBl" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "bBq" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/glass,
@@ -1561,18 +1727,12 @@
 	},
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
-"bBK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "bBN" = (
 /obj/structure/sign/warning/gasmask{
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "bCc" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/requests_console/directional/west{
@@ -1624,6 +1784,12 @@
 "bDk" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"bDu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "bFG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -1636,10 +1802,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
-"bGR" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "bHe" = (
 /obj/machinery/computer/slot_machine,
 /obj/machinery/light/directional/north,
@@ -1660,6 +1822,20 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/purple,
 /area/commons/dorms)
+"bIi" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
+	dir = 1;
+	name = "AI Satellite Service APC";
+	pixel_y = 23
+	},
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "bIm" = (
 /turf/open/openspace,
 /area/maintenance/department/security)
@@ -1687,24 +1863,10 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
-"bLM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/pickaxe,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
+"bLj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "bLQ" = (
 /obj/structure/dresser,
 /obj/structure/sign/poster/contraband/random{
@@ -1712,6 +1874,14 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/commons/dorms)
+"bLZ" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "bMk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1738,17 +1908,41 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/supply)
+"bOY" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"bPe" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "bPp" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+"bPq" = (
+/turf/closed/wall/r_wall,
+/area/cargo/miningoffice)
+"bPy" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "bPC" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "bPG" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -1786,13 +1980,34 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"bRE" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_one_access_txt = "12;48"
+"bRx" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
+"bRL" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"bSh" = (
+/obj/structure/lattice,
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Solars Weak Point E";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bTr" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -1836,12 +2051,16 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bUM" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "bVM" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "bVN" = (
 /obj/machinery/camera{
 	c_tag = "Prison - Court E";
@@ -1860,14 +2079,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"bVX" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe/antiviral,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/stack/sheet/mineral/plasma/five,
-/turf/open/floor/iron/dark,
-/area/medical/virology)
 "bWb" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/south,
@@ -1879,6 +2090,17 @@
 /obj/item/toy/talking/ai,
 /turf/open/floor/iron,
 /area/security/prison)
+"bWs" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "bWR" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -1939,6 +2161,10 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"cbF" = (
+/obj/machinery/teleport/station,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "cbW" = (
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/iron,
@@ -1979,21 +2205,6 @@
 /obj/structure/bedsheetbin,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
-"ceu" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/closet/emcloset,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "ceE" = (
 /obj/machinery/light/dim/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -2182,6 +2393,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/security/upper)
+"clZ" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Arrivals - South";
+	name = "Arrivals camera"
+	},
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cmz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 4
@@ -2304,6 +2526,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"cpI" = (
+/obj/structure/table,
+/obj/item/pen/blue,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "crB" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -2315,6 +2543,9 @@
 "csg" = (
 /turf/closed/wall/r_wall,
 /area/command/teleporter)
+"csi" = (
+/turf/closed/wall,
+/area/cargo/miningoffice)
 "cst" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -2406,6 +2637,11 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"cxU" = (
+/obj/item/kirbyplants/random,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cya" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -2545,6 +2781,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"cEb" = (
+/obj/machinery/recharge_station,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "cEd" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -2575,6 +2816,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
+"cGa" = (
+/obj/machinery/atmospherics/components/tank/air,
+/turf/open/floor/plating,
+/area/medical/virology)
+"cGp" = (
+/turf/closed/wall/r_wall,
+/area/service/chapel)
 "cGG" = (
 /obj/structure/table/glass,
 /obj/item/surgical_drapes,
@@ -2596,6 +2844,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"cIp" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "cIC" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -2603,6 +2855,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"cIM" = (
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
+	name = "AI Foyer turret control";
+	pixel_y = -27
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "cIV" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/machinery/vending/coffee,
@@ -2617,9 +2878,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"cJU" = (
-/turf/closed/wall/r_wall,
-/area/cargo/miningoffice)
 "cKh" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
@@ -2664,7 +2922,7 @@
 /area/command/bridge)
 "cMd" = (
 /turf/closed/wall/r_wall,
-/area/space)
+/area/hallway/secondary/entry)
 "cNb" = (
 /obj/structure/curtain,
 /turf/open/floor/iron/white,
@@ -2729,12 +2987,6 @@
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
-"cPT" = (
-/obj/structure/rack,
-/obj/item/tank/jetpack,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "cQc" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 8
@@ -2790,7 +3042,7 @@
 "cQT" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "cRi" = (
 /obj/item/target/clown,
 /turf/open/floor/iron,
@@ -2813,6 +3065,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/upper)
+"cSJ" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "cSL" = (
 /obj/structure/railing{
 	dir = 1
@@ -2936,17 +3193,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"cXj" = (
+/obj/structure/table,
+/obj/item/trash/cheesie,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cXp" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"cXP" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/space)
 "cYg" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
@@ -2965,6 +3221,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
+"cZm" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "cZu" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -2998,6 +3262,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"cZU" = (
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "Minisat Main Airlock";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "dbd" = (
 /obj/structure/bed,
 /turf/open/floor/iron/white,
@@ -3035,6 +3309,15 @@
 /obj/item/clothing/head/costume_2020/forbidden_cowboy,
 /turf/open/floor/carpet/black,
 /area/command/meeting_room)
+"dbQ" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_one_access_txt = "13;65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "dcf" = (
 /turf/open/floor/plating/airless,
 /area/maintenance/department/crew_quarters/dorms)
@@ -3070,6 +3353,13 @@
 /obj/structure/mirror/directional/south,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"ddb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "deT" = (
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
@@ -3113,9 +3403,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"dgx" = (
-/turf/open/openspace,
-/area/cargo/miningoffice)
 "dhv" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
@@ -3256,10 +3543,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"dpn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "dpt" = (
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 30
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
+"dpB" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "dpE" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -3283,14 +3581,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
-"dqL" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/space)
 "dqM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -3304,6 +3594,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"drH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/transit_tube)
 "dsf" = (
 /obj/structure/table/wood,
 /obj/item/restraints/handcuffs,
@@ -3313,7 +3608,7 @@
 "dsT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/hallway/secondary/entry)
 "dsW" = (
 /obj/structure/lattice,
 /obj/machinery/door/firedoor,
@@ -3408,11 +3703,35 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
+"dvG" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"dww" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "dwY" = (
 /obj/machinery/bounty_board/directional/west,
 /obj/structure/cable,
 /turf/open/floor/carpet/lone/star,
 /area/command/meeting_room)
+"dxL" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "dyn" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue{
@@ -3442,6 +3761,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"dzl" = (
+/mob/living/simple_animal/bot/floorbot,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "dAa" = (
 /obj/effect/turf_decal/box/white{
 	color = "#EFB341"
@@ -3467,6 +3790,16 @@
 /obj/structure/mopbucket,
 /turf/open/floor/iron/checker,
 /area/maintenance/department/chapel)
+"dAC" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
+	dir = 1;
+	name = "AI Satellite Foyer APC";
+	pixel_y = 23
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "dBn" = (
 /obj/machinery/computer/rdconsole{
 	dir = 1
@@ -3498,14 +3831,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"dBH" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "dBX" = (
 /obj/structure/ladder,
 /turf/open/floor/iron,
@@ -3558,6 +3883,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
+"dDt" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "dDJ" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit,
@@ -3580,6 +3917,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"dFe" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Foyer";
+	req_access_txt = "65"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"dFm" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "dFz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -3599,6 +3949,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"dGt" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;48"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "dGZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -3659,13 +4016,18 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"dKv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+"dKI" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Virology - South;
+	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
+/obj/machinery/light/directional/west,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "dKM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -3725,7 +4087,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/hallway/secondary/entry)
 "dNB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -3794,6 +4156,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "dQg" = (
@@ -3893,6 +4256,10 @@
 	dir = 8
 	},
 /turf/open/space/basic,
+/area/hallway/secondary/entry)
+"dUt" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/space/basic,
 /area/space)
 "dUu" = (
 /obj/machinery/camera/directional/south{
@@ -3958,6 +4325,11 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/command/bridge)
+"dZl" = (
+/obj/machinery/power/smes,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "dZr" = (
 /obj/structure/cable,
 /turf/open/floor/carpet,
@@ -4051,18 +4423,16 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"eeo" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/service)
 "ees" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"eeA" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "eeF" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office";
@@ -4087,6 +4457,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"eeZ" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "efC" = (
 /obj/item/clothing/suit/toggle/labcoat/science,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4114,10 +4491,25 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"egz" = (
+/obj/structure/transit_tube,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "egG" = (
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
+"egT" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"ehe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "eht" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4165,10 +4557,17 @@
 	name = "Port Docking Bay 2"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/hallway/secondary/entry)
 "ejy" = (
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/cmo)
+"ejG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "ejZ" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -4179,6 +4578,18 @@
 "ekD" = (
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"ekE" = (
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "Minisat Teleporter";
+	name = "AI motion-sensitive security camera";
+	network = list("ss13","minisat")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ekX" = (
 /obj/structure/railing{
 	dir = 1
@@ -4258,7 +4669,7 @@
 	name = "Port Docking Bay 2"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/hallway/secondary/entry)
 "enp" = (
 /obj/machinery/door/airlock/medical{
 	name = "Break Room";
@@ -4283,6 +4694,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"enN" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "enS" = (
 /obj/structure/chair{
 	dir = 8
@@ -4326,20 +4750,6 @@
 "epd" = (
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
-"epl" = (
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/service/theater)
 "epw" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -4379,6 +4789,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"eqA" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"eqR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "erf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/stairs{
@@ -4395,16 +4815,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/security/prison)
-"erQ" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "erX" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/tile{
@@ -4515,17 +4925,33 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "evE" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "evK" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"evP" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "AI Core";
+	req_access_txt = "65"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"ewb" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/service/theater)
 "ewv" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Medbay";
@@ -4570,12 +4996,31 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
+"eAc" = (
+/obj/machinery/power/solar_control{
+	id = "aisolar";
+	name = "AI Solar Control"
+	},
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
+"eAm" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"eAF" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "eAS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "eAX" = (
 /obj/machinery/computer/mecha,
 /obj/effect/turf_decal/tile/red{
@@ -4608,7 +5053,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "eCu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/stairs{
@@ -4626,7 +5071,7 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "eDb" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -4650,6 +5095,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/carpet,
 /area/service/bar)
+"eEq" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "eEz" = (
 /obj/structure/table,
 /obj/item/food/cakeslice/birthday,
@@ -4733,6 +5182,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"eIk" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "eIA" = (
 /obj/machinery/duct,
 /turf/open/floor/wood,
@@ -4763,13 +5217,11 @@
 "eJE" = (
 /turf/closed/wall,
 /area/service/bar)
-"eKH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+"eMb" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "eMv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile{
@@ -4783,6 +5235,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"eNc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "eNm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -4807,7 +5263,7 @@
 "ePG" = (
 /obj/structure/table,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "ePM" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -4844,13 +5300,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
-"eQM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "eQT" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -5004,9 +5453,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/bridge)
-"eXa" = (
-/turf/closed/wall,
-/area/cargo/miningoffice)
 "eXb" = (
 /obj/structure/sink{
 	pixel_y = 25
@@ -5182,18 +5628,6 @@
 /obj/machinery/computer/med_data/laptop,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"fgG" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/delta;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "fhE" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
@@ -5246,6 +5680,13 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
+"fjO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "fjV" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -5313,14 +5754,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fmO" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron,
-/area/space)
 "fno" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -5375,6 +5808,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/security/office)
+"fox" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "foB" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/structure/cable,
@@ -5399,14 +5839,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"fpm" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "fpE" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -5501,6 +5933,10 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"fuu" = (
+/obj/structure/lattice/catwalk,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai)
 "fuD" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Virology";
@@ -5535,7 +5971,7 @@
 	icon_state = "L3"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "fvI" = (
 /obj/machinery/light/floor,
 /obj/machinery/button/door/directional/north{
@@ -5576,7 +6012,7 @@
 	icon_state = "L5"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "fxt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -5630,12 +6066,10 @@
 "fyK" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/chapel)
-"fzb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
+"fzn" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "fzu" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/iron,
@@ -5650,6 +6084,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"fzB" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "fzC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -5662,11 +6100,6 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/cargo/qm)
-"fAJ" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "fBj" = (
 /obj/structure/training_machine,
 /obj/item/target/clown,
@@ -5687,6 +6120,14 @@
 "fCB" = (
 /turf/closed/wall/r_wall,
 /area/service/library/private)
+"fCC" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/syringe/antiviral,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/stack/sheet/mineral/plasma/five,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "fCJ" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -5765,6 +6206,19 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"fED" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Shuttle";
+	req_one_access_txt = "48"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "fEO" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -5790,10 +6244,6 @@
 /obj/structure/displaycase/labcage,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"fGs" = (
-/obj/structure/closet/bombcloset,
-/turf/open/floor/iron/dark,
-/area/science/storage)
 "fGt" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple{
@@ -5816,6 +6266,14 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
+"fHD" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access_txt = "32;65"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "fHY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -5834,12 +6292,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"fJK" = (
-/obj/structure/sign/warning/docking{
-	pixel_x = -30
-	},
-/turf/open/space/basic,
-/area/space)
 "fKF" = (
 /obj/structure/window,
 /obj/machinery/conveyor{
@@ -5863,10 +6315,6 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"fMl" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/theater)
 "fMq" = (
 /obj/structure/railing,
 /obj/structure/chair/stool/bar/directional/west,
@@ -5964,6 +6412,11 @@
 /obj/item/storage/box/bodybags,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"fPs" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "fPt" = (
 /obj/structure/cable,
 /obj/structure/railing{
@@ -5971,6 +6424,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"fPX" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "fQt" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -5999,6 +6456,14 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"fRD" = (
+/obj/machinery/turretid{
+	control_area = "/area/maintenance/solars";
+	name = "AI solar control turret panel";
+	pixel_y = -27
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "fRE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6008,6 +6473,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"fSk" = (
+/obj/machinery/teleport/hub,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "fSl" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -6045,17 +6514,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"fUi" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/cargo/miningoffice)
 "fUr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -6082,6 +6540,12 @@
 "fVO" = (
 /turf/open/floor/grass,
 /area/medical/virology)
+"fVY" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "fWJ" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -6090,8 +6554,9 @@
 /area/maintenance/department/medical)
 "fXG" = (
 /obj/machinery/light/small/directional/north,
+/obj/machinery/computer/shuttle/mining/common,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "fYa" = (
 /obj/structure/table,
 /obj/item/toy/plush/fly,
@@ -6111,6 +6576,13 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"gag" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "gat" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4169E1";
@@ -6124,6 +6596,13 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"gay" = (
+/obj/machinery/computer/monitor{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "gaC" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -6219,6 +6698,13 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"gfZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "ggm" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -6367,6 +6853,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
+"gmr" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 8
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "gmG" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/grenades,
@@ -6393,6 +6886,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
+"gon" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "goz" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -6403,6 +6900,11 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/wood,
 /area/cargo/qm)
+"goQ" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "gpo" = (
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -6488,6 +6990,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"gsD" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "gsO" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -6513,7 +7022,7 @@
 	icon_state = "L1"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "gvn" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Grenade testing"
@@ -6525,6 +7034,10 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"gvw" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "gvI" = (
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
@@ -6534,6 +7047,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"gwl" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "gwo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6557,7 +7074,7 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "gxK" = (
 /obj/structure/noticeboard/directional/north,
 /turf/open/floor/iron,
@@ -6566,17 +7083,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"gym" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Entrance";
-	network = list("ss13","medbay")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "gyp" = (
 /obj/machinery/power/apc{
 	areastring = "/area/service/chapel/office";
@@ -6595,9 +7101,21 @@
 "gzk" = (
 /turf/open/floor/plating,
 /area/medical/virology)
+"gzp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "gzw" = (
 /turf/open/openspace,
 /area/security/courtroom)
+"gzH" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "gCq" = (
 /obj/machinery/duct,
 /turf/open/floor/wood,
@@ -6606,10 +7124,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/holodeck/rec_center)
-"gDn" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "gDD" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -6717,6 +7231,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"gLp" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Exterior SW";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "gLD" = (
 /obj/machinery/computer/monitor{
 	name = "Bridge Power Monitoring Console"
@@ -6815,25 +7337,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"gOJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/north,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "gOU" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
 	},
 /turf/open/floor/iron,
-/area/space)
-"gPg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -30
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
-"gPm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
+/area/hallway/secondary/entry)
+"gPj" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/aisat_interior)
 "gPn" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -6870,7 +7390,7 @@
 	icon_state = "L14"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "gQH" = (
 /obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot_red,
@@ -6917,6 +7437,17 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"gUD" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_one_access_txt = "13;65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "gVo" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -6972,6 +7503,16 @@
 "gZM" = (
 /turf/closed/wall/r_wall,
 /area/security/office)
+"haa" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "haN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
@@ -7063,6 +7604,21 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
+"hfa" = (
+/obj/structure/rack,
+/obj/item/tank/jetpack,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
+"hfr" = (
+/turf/open/openspace,
+/area/construction/mining/aux_base)
+"hfR" = (
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "hfX" = (
 /obj/item/tank/internals/oxygen/yellow,
 /turf/open/floor/plating/asteroid/airless,
@@ -7167,6 +7723,12 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"hkY" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "hlk" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -7230,6 +7792,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
+"hpa" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 30
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"hpl" = (
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "hqa" = (
 /obj/machinery/recharger{
 	pixel_x = -6;
@@ -7288,11 +7859,11 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/security/prison/workout)
-"hrz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/pinpointer_dispenser,
-/turf/open/floor/plating,
-/area/space)
+"hqQ" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "hrN" = (
 /obj/machinery/teleport/station,
 /obj/machinery/airalarm/directional/north,
@@ -7554,26 +8125,12 @@
 /area/service/chapel/office)
 "hHv" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals - Public Mining";
+	name = "Hallway Camera"
+	},
 /turf/open/floor/iron,
-/area/space)
-"hHw" = (
-/obj/machinery/door_buttons/access_button{
-	idDoor = "virology_airlock_interior";
-	idSelf = "virology_airlock_control";
-	name = "Virology Access Button";
-	pixel_y = 25;
-	req_access_txt = "39"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/area/hallway/secondary/entry)
 "hIa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -7600,45 +8157,18 @@
 "hIJ" = (
 /turf/closed/wall,
 /area/service/chapel/office)
-"hJp" = (
-/obj/structure/rack,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"hJG" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Emergency Oxygen Supply"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "hKj" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/medical/central)
+"hKk" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_one_access_txt = "13;65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/transit_tube)
 "hKm" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -7682,19 +8212,19 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"hLZ" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Shuttle";
-	req_one_access_txt = "48"
+"hLX" = (
+/obj/structure/lattice,
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Solars E";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
+/turf/open/space/basic,
+/area/space/nearstation)
+"hMh" = (
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "hNc" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -7703,6 +8233,13 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"hNV" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "teledoor";
+	name = "MiniSat Teleport Access"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "hOO" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -7758,7 +8295,7 @@
 	icon_state = "L9"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "hTm" = (
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -7818,11 +8355,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"hUY" = (
-/obj/structure/table,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "hVh" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -7903,6 +8435,17 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"hZz" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_one_access_txt = "13;65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "iaH" = (
 /obj/structure/cable,
 /obj/structure/rack,
@@ -7946,19 +8489,30 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/ai_upload)
+"ibQ" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/small/directional/west,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"icm" = (
+/obj/machinery/door/airlock/virology{
+	name = "Virology Break Room";
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "icD" = (
 /obj/structure/bookcase/random,
 /turf/open/floor/iron,
 /area/security/prison)
-"icH" = (
-/obj/machinery/door/airlock/command{
-	name = "Auxiliary E.V.A. Storage";
-	req_access_txt = "18"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+"icF" = (
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ied" = (
 /obj/item/storage/fancy/donut_box,
 /obj/structure/table,
@@ -7990,6 +8544,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"igb" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "igc" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -7997,7 +8556,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/space)
+/area/hallway/secondary/entry)
 "igm" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -8033,6 +8592,15 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/glass/reinforced,
 /area/cargo/qm)
+"ihM" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/camera/directional/south{
+	c_tag = "Arrivals - North Waiting Room";
+	name = "Arrivals Camera"
+	},
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "iib" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
@@ -8074,6 +8642,14 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
+"ijF" = (
+/obj/machinery/camera/xray/directional/east{
+	c_tag = "AI Chamber W";
+	name = "Upgraded AI Camera";
+	network = list("aicore")
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "ijP" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -8127,6 +8703,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"ild" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/iron/white,
+/area/medical/virology)
+"ilg" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "ilh" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#4169E1";
@@ -8168,6 +8759,10 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"imx" = (
+/obj/machinery/computer/pandemic,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "imE" = (
 /obj/machinery/modular_computer/console/preset/cargochat/engineering{
 	dir = 8
@@ -8178,12 +8773,9 @@
 /obj/machinery/computer/cargo,
 /turf/open/floor/wood,
 /area/cargo/qm)
-"iow" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+"ipR" = (
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "iqJ" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -8202,6 +8794,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/service/theater)
+"irc" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Transit Tubes";
+	name = "Tubes Camera";
+	network = list("ss13","minisat")
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "irn" = (
 /obj/structure/railing{
 	dir = 10
@@ -8214,19 +8814,27 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"irA" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "viro-passthrough"
+	},
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "virology_airlock_interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "isg" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"isM" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/space)
 "itf" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -8282,6 +8890,14 @@
 /obj/machinery/photocopier,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"iyX" = (
+/obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/space)
 "izc" = (
 /turf/closed/wall,
 /area/medical/abandoned)
@@ -8290,7 +8906,7 @@
 	icon_state = "L13"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "izF" = (
 /obj/structure/railing{
 	dir = 6
@@ -8373,6 +8989,11 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"iFV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/pinpointer_dispenser,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "iGm" = (
 /obj/machinery/vending/cart,
 /turf/open/floor/wood,
@@ -8390,13 +9011,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
-"iHl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "iHA" = (
 /obj/structure/table/wood,
 /obj/item/canvas/nineteen_nineteen,
@@ -8452,6 +9066,14 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/cmo)
+"iKo" = (
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	name = "AI turret control";
+	pixel_x = 27
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "iKW" = (
 /obj/structure/chair{
 	dir = 8
@@ -8507,6 +9129,15 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"iMX" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Storage";
+	req_access_txt = "65"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "iNb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -8515,6 +9146,13 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
+"iNg" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "iNL" = (
 /obj/structure/chair{
 	dir = 8
@@ -8524,6 +9162,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"iOg" = (
+/obj/structure/closet/emcloset,
+/obj/effect/landmark/start/hangover/closet,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "iOM" = (
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
@@ -8612,10 +9255,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"iSx" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "iSG" = (
 /obj/structure/window{
 	dir = 4
@@ -8665,14 +9304,16 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"iVM" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "iVY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/sorting)
+"iWh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "iWp" = (
 /obj/structure/window,
 /obj/machinery/disposal/delivery_chute{
@@ -8747,30 +9388,14 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "iYY" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/command/storage/eva)
-"iZj" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/pickaxe,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
-"iZv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/command/heads_quarters/hop)
+"iZx" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/solars)
 "iZV" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -8795,6 +9420,16 @@
 /obj/structure/chair/office,
 /turf/open/floor/carpet/orange,
 /area/commons/dorms)
+"jaR" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "jbd" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -8828,6 +9463,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/upper)
+"jdR" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/effect/turf_decal/siding/wideplating/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "jdT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -8894,6 +9536,15 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"jgP" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals - Pod 2 Entrance";
+	name = "Arrivals Camera"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "jho" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "supdoor";
@@ -8960,6 +9611,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"jkj" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "jky" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -8994,13 +9652,6 @@
 /obj/structure/curtain,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
-"jnk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "jnK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -9085,12 +9736,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/server)
+"jri" = (
+/obj/structure/cable,
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "jrk" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "jrP" = (
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
@@ -9216,6 +9873,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
+"jvj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
+"jvo" = (
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "Minisat Foyer";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/structure/table,
+/obj/item/phone,
+/turf/open/floor/iron/grimy,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "jvH" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
@@ -9240,6 +9914,12 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"jxm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "jxn" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
@@ -9247,6 +9927,15 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"jxW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Emergency Oxygen Supply"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "jyF" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -9332,7 +10021,7 @@
 	name = "Maintenance Access";
 	req_access_txt = "12"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/plating,
 /area/maintenance/department/science)
 "jCC" = (
 /obj/machinery/keycard_auth{
@@ -9355,6 +10044,16 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
+"jDF" = (
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/south{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "jEh" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -9404,7 +10103,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/hallway/secondary/entry)
 "jFQ" = (
 /obj/structure/table,
 /obj/item/pen/fountain,
@@ -9427,11 +10126,10 @@
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "jGz" = (
-/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/engine/hull,
 /area/engineering/atmos/upper)
 "jGB" = (
 /turf/open/openspace,
@@ -9510,16 +10208,6 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/command/bridge)
-"jJC" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "jJP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -9569,11 +10257,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"jMD" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "jME" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -9598,14 +10281,11 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/medical/abandoned)
-"jNZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
+"jOn" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/emergency,
+/obj/item/flashlight,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "jOx" = (
 /obj/machinery/vending/medical,
@@ -9644,6 +10324,11 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"jPo" = (
+/obj/structure/closet/l3closet,
+/obj/item/toy/mecha/mauler,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "jPL" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Xenobiology - Pen #10";
@@ -9674,7 +10359,7 @@
 "jRe" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "jRr" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/cargo/office)
@@ -9706,6 +10391,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"jTo" = (
+/obj/effect/landmark/start/ai/secondary,
+/obj/item/radio/intercom/directional/south,
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	name = "Common Channel"
+	},
+/obj/item/radio/intercom/directional/north{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "jTp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -9727,11 +10426,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/department/chapel)
+"jVb" = (
+/obj/structure/transit_tube,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jVo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/breakroom)
+"jVS" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "jWj" = (
 /obj/structure/bed,
 /obj/item/bedsheet/purple,
@@ -9758,6 +10469,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"jWv" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Arrivals - Aux Base Observation";
+	name = "Arrivals Camera"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "jWD" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -30
@@ -9803,6 +10524,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
 /area/maintenance/department/chapel)
+"jYc" = (
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "jZk" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/brown{
@@ -9829,6 +10553,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"kab" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kaq" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
@@ -9845,6 +10573,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"kaE" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_one_access_txt = "13;65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "kaR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -9888,14 +10627,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"keK" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "kfu" = (
 /obj/structure/cable,
 /turf/open/floor/vault,
@@ -9956,6 +10687,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"khJ" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "kig" = (
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/plating,
@@ -9974,6 +10709,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"kiS" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "kiY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/item/wrench{
@@ -9989,8 +10731,8 @@
 /turf/open/floor/wood,
 /area/service/bar/atrium)
 "kjA" = (
-/turf/open/floor/eighties/red,
-/area/maintenance/department/chapel)
+/turf/closed/wall/r_wall,
+/area/ai_monitored/command/storage/eva)
 "kjW" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 1
@@ -10003,6 +10745,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"kko" = (
+/obj/structure/transit_tube/station/reverse/flipped{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kkF" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -10020,7 +10769,7 @@
 	location = "Arrival Shuttle"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/hallway/secondary/entry)
 "kmb" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -10117,6 +10866,13 @@
 /obj/item/modular_computer/laptop,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"kpJ" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/sheet/rglass,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "kqh" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
@@ -10131,16 +10887,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
-"krg" = (
-/obj/structure/rack,
-/obj/item/tank/jetpack,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"krH" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/iron/dark,
-/area/medical/virology)
+"kra" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/space)
 "krT" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper,
@@ -10223,6 +10976,10 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/medical/chemistry)
+"kvH" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kvK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -10245,17 +11002,31 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/cargo/sorting)
+"kyc" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Entrance";
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "kyh" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "kys" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Virology";
-	name = "Virology Privacy Shutters"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/eighties/red,
+/area/maintenance/department/chapel)
+"kyL" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
+"kzg" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "kzi" = (
 /obj/item/target,
@@ -10267,12 +11038,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"kzx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "kAk" = (
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
@@ -10421,6 +11186,9 @@
 "kHm" = (
 /turf/open/openspace,
 /area/service/bar)
+"kHQ" = (
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/service)
 "kHX" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/light/directional/south,
@@ -10472,16 +11240,6 @@
 "kLx" = (
 /turf/open/openspace,
 /area/maintenance/department/science)
-"kLE" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/cable_coil,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "kOm" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -10517,6 +11275,15 @@
 /obj/item/restraints/legcuffs,
 /turf/open/floor/iron,
 /area/security/office)
+"kQS" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Atmospherics";
+	req_access_txt = "65"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "kRd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -10528,6 +11295,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
+"kRG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "kSf" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -10545,6 +11318,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"kSD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kSZ" = (
 /turf/closed/wall,
 /area/security/prison/upper)
@@ -10574,6 +11352,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"kTZ" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "kUr" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
@@ -10604,6 +11387,10 @@
 "kWk" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/port)
+"kWq" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kXm" = (
 /obj/structure/railing{
 	dir = 8
@@ -10630,6 +11417,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"kYE" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/oxygen,
+/turf/open/floor/plating,
+/area/medical/virology)
 "kYP" = (
 /obj/structure/railing{
 	dir = 4
@@ -10679,13 +11473,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
+"kZI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/transit_tube,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/transit_tube)
 "kZU" = (
 /obj/structure/railing/corner,
 /obj/structure/industrial_lift{
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "lan" = (
 /obj/structure/cable,
 /obj/structure/cable,
@@ -10834,6 +11634,17 @@
 /obj/item/toy/figure/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
+"liN" = (
+/obj/structure/cable,
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
+	name = "Atmospherics Turret Control";
+	pixel_x = 27;
+	req_access = null;
+	req_access_txt = "65"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "liQ" = (
 /turf/closed/wall,
 /area/medical/surgery/room_b)
@@ -10878,6 +11689,15 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/service/kitchen/coldroom)
+"lmP" = (
+/obj/structure/lattice,
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Solars Weak Point W";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "lnd" = (
 /obj/structure/chair{
 	dir = 8
@@ -10903,6 +11723,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "loV" = (
@@ -10918,6 +11739,16 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"lpl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/transit_tube_pod,
+/obj/structure/transit_tube/station/reverse{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/transit_tube)
 "lpr" = (
 /obj/structure/table/wood,
 /obj/item/storage/dice,
@@ -10928,6 +11759,15 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"lpK" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/radio/off,
+/obj/item/screwdriver,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "lrr" = (
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
@@ -10988,6 +11828,25 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/cmo)
+"luB" = (
+/obj/structure/cable,
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "Minisat Solars Airlock LOCKED E";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/east,
+/obj/item/radio/intercom/directional/east{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom"
+	},
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "lxF" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/circuit,
@@ -10999,7 +11858,7 @@
 "lxY" = (
 /obj/structure/railing/corner,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "lyl" = (
 /turf/open/openspace,
 /area/medical/psychology)
@@ -11087,8 +11946,12 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "lCb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Virology";
+	name = "Virology Privacy Shutters"
+	},
+/turf/open/floor/plating,
 /area/medical/virology)
 "lCp" = (
 /obj/machinery/door/window/northleft{
@@ -11120,6 +11983,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/department/security/upper)
+"lDi" = (
+/obj/structure/cable,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "lDU" = (
 /obj/structure/table,
 /obj/item/wrench,
@@ -11170,6 +12038,15 @@
 "lGi" = (
 /turf/open/openspace,
 /area/science/robotics/mechbay)
+"lGj" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/solars";
+	dir = 8;
+	pixel_x = -25
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/maintenance/solars)
 "lGy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -11208,10 +12085,23 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lHx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"lHU" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat/service";
+	dir = 1;
+	name = "AI Satellite Service APC";
+	pixel_y = 23
+	},
+/obj/structure/cable,
+/obj/item/storage/toolbox/electrical,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "lIj" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
@@ -11336,6 +12226,13 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
+"lMG" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/virologist,
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "lNp" = (
 /obj/structure/table,
 /obj/item/food/pizzaslice/pineapple,
@@ -11357,6 +12254,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"lOA" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "lOK" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -11397,6 +12305,10 @@
 "lRK" = (
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
+"lRP" = (
+/obj/structure/rack,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "lRT" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/soda_cans/space_mountain_wind,
@@ -11412,7 +12324,13 @@
 "lSm" = (
 /obj/structure/railing,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
+"lSV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "lTi" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -11423,7 +12341,10 @@
 "lTl" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
+"lTC" = (
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "lTD" = (
 /obj/structure/frame/machine,
 /obj/effect/turf_decal/tile/blue{
@@ -11463,6 +12384,11 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"lVd" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/maintenance/department/science)
 "lVl" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/mech_bay_power_console,
@@ -11500,6 +12426,13 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/service/bar)
+"lWR" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "lXu" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -11517,12 +12450,21 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
+"lYV" = (
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "lZd" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"lZf" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "lZp" = (
 /obj/structure/table/glass,
 /obj/item/cartridge/medical,
@@ -11559,6 +12501,13 @@
 /obj/item/flashlight/lamp/bananalamp,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"mcw" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "mcx" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -11596,14 +12545,16 @@
 "mde" = (
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"meo" = (
-/obj/machinery/power/shieldwallgen,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
+"meq" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "Minisat Solar Control";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "meW" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
@@ -11676,6 +12627,14 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"mhn" = (
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "mht" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -11703,16 +12662,13 @@
 "miy" = (
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"miU" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_one_access_txt = "12;48"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/cargo)
 "mjd" = (
 /turf/open/openspace,
 /area/ai_monitored/command/storage/eva)
+"mjt" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "mjY" = (
 /obj/machinery/power/generator,
 /turf/open/floor/plating,
@@ -11743,6 +12699,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"mkE" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "mkL" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -11809,6 +12769,12 @@
 "mnR" = (
 /turf/open/floor/carpet/lone/star,
 /area/command/meeting_room)
+"mnT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "moe" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -11820,7 +12786,7 @@
 	icon_state = "L11"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "moI" = (
 /obj/machinery/door/airlock{
 	name = "Prison Restrooms"
@@ -11866,6 +12832,16 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"mqM" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"mrp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "mrX" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = fnaf2
@@ -11992,9 +12968,19 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"mzy" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/space/basic,
+/area/maintenance/solars)
 "mzC" = (
 /turf/open/openspace,
 /area/medical/medbay/zone2)
+"mzH" = (
+/obj/machinery/power/shieldwallgen,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "mzI" = (
 /obj/structure/chair/sofa{
 	desc = "Made of very expensive furs, probably from an endangered animal.";
@@ -12119,15 +13105,15 @@
 	},
 /turf/open/floor/plating,
 /area/medical/surgery/room_b)
-"mGh" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "mGO" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/command)
+"mGV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "mHT" = (
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet/lone/star,
@@ -12142,11 +13128,8 @@
 /turf/open/floor/iron,
 /area/security/office)
 "mIC" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Isolation A";
-	network = list("ss13","medbay")
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mJg" = (
@@ -12207,11 +13190,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
-"mLI" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "mLM" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -12234,7 +13212,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "mNi" = (
 /obj/structure/chair{
 	dir = 1
@@ -12278,7 +13256,7 @@
 "mQa" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/camera/directional/north{
-	c_tag = "Virology - Isolation B";
+	c_tag = "Virology - Isolation A";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
@@ -12337,14 +13315,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
-"mTr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/area/hallway/secondary/entry)
 "mTI" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 1
@@ -12391,6 +13362,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
+"mUr" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "mUI" = (
 /obj/structure/sink{
 	dir = 4;
@@ -12431,6 +13409,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"mWi" = (
+/obj/structure/cable,
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
+	name = "AI Hallway control";
+	pixel_y = -27
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "mWD" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -12495,6 +13482,33 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"mZR" = (
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "nai" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -12567,6 +13581,18 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/range)
+"nda" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Minisat Exterior SEE";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
+"ndd" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "ndA" = (
 /obj/structure/sign/poster/official/ian{
 	pixel_y = 30
@@ -12663,13 +13689,22 @@
 	},
 /area/service/abandoned_gambling_den)
 "ngU" = (
+/obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/camera/directional/north{
-	c_tag = "Virology - Isolation C";
+	c_tag = "Virology - Isolation B";
 	network = list("ss13","medbay")
 	},
-/obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"nhn" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/obj/machinery/camera/directional/south{
+	c_tag = "Arrivals SE";
+	name = "Hallway Camera"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "nhr" = (
 /turf/closed/wall,
 /area/service/kitchen/coldroom)
@@ -12695,6 +13730,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"njQ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/command/glass{
+	name = "Minisat Access";
+	req_one_access_txt = "13;32;65"
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "njV" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/purple,
@@ -12704,7 +13747,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "nke" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/green,
@@ -12762,6 +13805,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/server)
+"nlZ" = (
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "nme" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door/directional/east{
@@ -12778,6 +13826,18 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
+"nmn" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
+	name = "AI Hallway APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "nmv" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -12801,12 +13861,15 @@
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "npm" = (
-/obj/machinery/light/small/directional/west,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Isolation C";
+	network = list("ss13","medbay")
+	},
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "npn" = (
-/obj/structure/table,
-/obj/item/toy/figure/virologist,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "npR" = (
@@ -12911,6 +13974,17 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"nsG" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Service Bay";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/machinery/recharge_station,
+/obj/machinery/light/directional/west,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "nsK" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
@@ -12936,21 +14010,14 @@
 /obj/item/assembly/timer,
 /turf/open/floor/iron,
 /area/security/office)
-"ntH" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "viro-passthrough"
+"ntg" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
 	},
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "virology_airlock_interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/virology)
+/area/medical/medbay/zone2)
 "nui" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/airalarm/directional/north,
@@ -12983,7 +14050,7 @@
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "nwy" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -12994,6 +14061,32 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
+"nxA" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
+"nxQ" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/transit_tube)
 "nyt" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -13004,13 +14097,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
-"nyx" = (
-/obj/effect/turf_decal/siding/wideplating,
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "nyE" = (
 /obj/structure/bed,
 /obj/machinery/camera/directional/north{
@@ -13034,6 +14120,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"nzY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "nAM" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -13058,10 +14151,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"nBY" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "nCu" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -13099,6 +14188,15 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"nDi" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Teleporter";
+	req_access_txt = "65"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "nDx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -13112,6 +14210,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"nEI" = (
+/turf/open/openspace,
+/area/hallway/secondary/entry)
+"nES" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "nFq" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -30
@@ -13133,7 +14237,11 @@
 "nFw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
+"nFR" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "nGe" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/circuit,
@@ -13164,6 +14272,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"nHh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "nIo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -13277,13 +14392,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"nQo" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+"nPf" = (
+/obj/structure/railing,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "nQy" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/tile/green,
@@ -13297,6 +14410,28 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"nRg" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
 "nRP" = (
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -13336,8 +14471,7 @@
 /area/command/teleporter)
 "nTv" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/bottle/orangejuice,
-/obj/item/reagent_containers/food/drinks/drinkingglass,
+/obj/item/toy/figure/virologist,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nTw" = (
@@ -13349,6 +14483,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
+"nUH" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/turretid{
+	name = "AI Chamber turret control";
+	pixel_x = 5;
+	pixel_y = -24
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "nUX" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/poster/contraband/random{
@@ -13356,6 +14504,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"nVh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "nVN" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/exoscanner{
@@ -13430,6 +14584,11 @@
 	},
 /turf/open/openspace,
 /area/service/library/printer)
+"oaj" = (
+/obj/structure/lattice,
+/obj/structure/transit_tube,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oaW" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Captain's Office";
@@ -13445,7 +14604,8 @@
 /area/command/heads_quarters/captain)
 "obd" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/coffee,
+/obj/item/reagent_containers/food/drinks/bottle/orangejuice,
+/obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ocr" = (
@@ -13475,12 +14635,6 @@
 /obj/structure/railing,
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
-"odz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "odE" = (
 /obj/machinery/door/airlock/public{
 	id_tag = "Perma Bathroom 3";
@@ -13549,7 +14703,7 @@
 "ogI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "ohh" = (
 /obj/structure/railing{
 	dir = 1
@@ -13564,7 +14718,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "ohv" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -13615,13 +14769,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ojL" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12;31"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "ojN" = (
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/east,
@@ -13660,8 +14807,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "okp" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/coffee,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "okw" = (
@@ -13683,11 +14830,46 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"olj" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "oll" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"olY" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Access";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/medical/medbay/zone2)
+"oml" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/structure/ore_box,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "omI" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -13731,7 +14913,7 @@
 	icon_state = "L2"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "onP" = (
 /obj/structure/frame/computer,
 /obj/effect/turf_decal/tile/blue{
@@ -13779,8 +14961,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "opf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/grass,
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "opu" = (
 /obj/machinery/button/door/directional/north{
@@ -13816,7 +14999,10 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
+"orX" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "ott" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
@@ -13832,6 +15018,10 @@
 "otS" = (
 /turf/open/openspace,
 /area/security/interrogation)
+"ouo" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "ouP" = (
 /obj/structure/table,
 /obj/item/toy/cards/deck/cas/black{
@@ -13887,8 +15077,14 @@
 /obj/item/aicard,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"oyP" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "ozo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/grass,
 /area/medical/virology)
 "oAm" = (
@@ -13896,6 +15092,9 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
+"oAC" = (
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "oAE" = (
 /obj/structure/chair{
 	dir = 1
@@ -13914,24 +15113,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"oAX" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Chemistry Access";
-	req_access_txt = "5"
+"oBx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+/area/medical/virology)
 "oBZ" = (
 /obj/structure/window{
 	dir = 1
@@ -13939,19 +15126,6 @@
 /obj/machinery/power/shieldwallgen,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
-"oCM" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "oDa" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/structure/window/reinforced{
@@ -13963,6 +15137,17 @@
 /obj/item/ship_in_a_bottle,
 /turf/open/floor/carpet/black,
 /area/command/meeting_room)
+"oEC" = (
+/obj/structure/cable,
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat/service";
+	name = "Service Bay Turret Control";
+	pixel_x = -27;
+	req_access = null;
+	req_access_txt = "65"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "oEW" = (
 /obj/machinery/light_switch/directional/north,
 /obj/structure/closet/secure_closet/personal/patient,
@@ -14000,15 +15185,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oHQ" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation A";
-	req_access_txt = "39"
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/grass,
 /area/medical/virology)
 "oIa" = (
 /obj/machinery/door/airlock/medical{
@@ -14104,6 +15282,9 @@
 /obj/item/toy/crayon/yellow,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"oMI" = (
+/turf/closed/wall,
+/area/space)
 "oMJ" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Chemistry W";
@@ -14117,10 +15298,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/vault,
 /area/command/heads_quarters/captain)
-"oNa" = (
-/obj/structure/closet/l3closet,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "oNj" = (
 /obj/machinery/modular_computer/console/preset/cargochat/security,
 /obj/effect/turf_decal/tile/brown{
@@ -14141,7 +15318,7 @@
 	safety_mode = 1
 	},
 /turf/open/space/basic,
-/area/space)
+/area/hallway/secondary/entry)
 "oOF" = (
 /obj/structure/railing{
 	dir = 10
@@ -14317,6 +15494,14 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"oUJ" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/mob/living/simple_animal/bot/secbot/pingsky,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "oUQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -14348,6 +15533,24 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"oVJ" = (
+/obj/effect/landmark/start/ai/secondary,
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel"
+	},
+/obj/item/radio/intercom/directional/west{
+	freerange = 1;
+	name = "Common Channel"
+	},
+/obj/item/radio/intercom/directional/north{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "oVL" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser{
@@ -14373,6 +15576,14 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"oVZ" = (
+/obj/machinery/power/shieldwallgen,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "oWh" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office";
@@ -14398,6 +15609,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"oWr" = (
+/obj/item/beacon,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "oXn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -14426,6 +15641,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"oZk" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "oZv" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -14479,6 +15698,18 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"pfm" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
+"pgB" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Air Out"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "pgX" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14520,16 +15751,23 @@
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "piX" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Isolation B";
-	req_access_txt = "39"
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation A";
+	req_access_txt = "39"
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"pjc" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pjp" = (
 /obj/item/storage/secure/safe/caps_spare{
 	pixel_x = -27
@@ -14539,23 +15777,14 @@
 "pjH" = (
 /turf/open/openspace,
 /area/engineering/storage_shared)
-"pjN" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "pkG" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/storage)
-"pll" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
+"pmr" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "pmB" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
@@ -14581,6 +15810,13 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"pnf" = (
+/obj/structure/table,
+/obj/machinery/computer/med_data/laptop{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "pnS" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/iron/white,
@@ -14596,6 +15832,15 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"ppo" = (
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "Minisat Solars Airlock E";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/space/basic,
+/area/space)
 "ppp" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
@@ -14610,16 +15855,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
-"pqj" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "pqv" = (
 /obj/structure/dresser,
 /obj/machinery/light_switch/directional/north,
@@ -14656,6 +15891,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"ptf" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "ptv" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
@@ -14675,7 +15917,7 @@
 "ptR" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "pvR" = (
 /obj/structure/table,
 /obj/item/dest_tagger,
@@ -14690,13 +15932,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
-"pwy" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/rglass,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "pwO" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -14717,6 +15952,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
+"pwV" = (
+/obj/structure/table,
+/obj/item/toy/eightball,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pxy" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -14738,6 +15978,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"pyp" = (
+/obj/structure/transit_tube,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "pyu" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -14750,8 +16000,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "pzv" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/grass,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Isolation B";
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "pAh" = (
 /obj/machinery/door/airlock/maintenance{
@@ -14947,6 +16204,9 @@
 	},
 /turf/closed/wall/mineral/titanium,
 /area/hallway/primary/upper)
+"pLp" = (
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "pLv" = (
 /turf/open/openspace,
 /area/hallway/primary/fore)
@@ -14960,30 +16220,30 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "pLQ" = (
 /obj/structure/sign/warning/docking{
 	pixel_x = 30
 	},
 /turf/open/space/basic,
 /area/space)
-"pMi" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "pMz" = (
 /obj/structure/table,
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/security/prison)
+"pNk" = (
+/obj/structure/lattice,
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Solars W";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pNt" = (
 /turf/closed/wall,
 /area/holodeck/rec_center)
-"pOC" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "pOT" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -15022,11 +16282,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"pQE" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/maintenance/department/science)
 "pRa" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -15055,6 +16310,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"pSN" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pTu" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/mapping_helpers/trapdoor_placer,
@@ -15116,6 +16379,35 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/qm)
+"pVE" = (
+/obj/effect/landmark/start/ai,
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_y = -8
+	},
+/obj/item/radio/intercom/directional/west{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom";
+	pixel_y = -8
+	},
+/obj/item/radio/intercom/directional/south{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel"
+	},
+/obj/machinery/requests_console/directional/east{
+	department = "AI";
+	departmentType = 5;
+	pixel_y = -30
+	},
+/obj/machinery/newscaster/directional/west{
+	pixel_y = -28
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "pVF" = (
 /obj/machinery/modular_computer/console/preset/id,
 /obj/structure/cable,
@@ -15131,10 +16423,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"pVQ" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "pWx" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison)
+"pXl" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pXV" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -15156,6 +16460,11 @@
 /obj/structure/fluff/tram_rail,
 /turf/open/openspace,
 /area/hallway/primary/upper)
+"pYE" = (
+/obj/machinery/holopad/secure,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "pZh" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
@@ -15163,41 +16472,11 @@
 "pZC" = (
 /turf/open/openspace,
 /area/medical/chemistry)
-"qae" = (
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "qaP" = (
 /obj/machinery/light/directional/north,
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/security/prison)
-"qbj" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
-"qbu" = (
-/obj/structure/closet/firecloset,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 9
-	},
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "qcb" = (
 /obj/machinery/gibber,
 /obj/structure/railing,
@@ -15207,6 +16486,11 @@
 /obj/machinery/pdapainter,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"qcH" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "qda" = (
 /obj/structure/chair/sofa/left{
 	desc = "Made of very expensive furs, probably from an endangered animal.";
@@ -15269,7 +16553,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "qgU" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Theater"
@@ -15321,6 +16605,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"qhZ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qiT" = (
 /obj/structure/table,
 /obj/item/exodrone{
@@ -15338,6 +16627,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/garden)
+"qjG" = (
+/obj/structure/cable,
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "qjJ" = (
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
@@ -15414,6 +16710,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"qov" = (
+/obj/machinery/holopad/secure,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
+"qoE" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "qoH" = (
 /turf/open/openspace,
 /area/maintenance/starboard/aft)
@@ -15480,7 +16790,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "qsd" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/delivery,
@@ -15565,6 +16875,14 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
+"quI" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Exterior SSE";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "quW" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15578,12 +16896,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "qvq" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - North";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
 /area/medical/virology)
 "qvG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -15591,26 +16905,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"qvM" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "qvN" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
-"qvS" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "qwk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -15654,12 +16964,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/service/theater)
-"qyt" = (
-/obj/effect/turf_decal/siding/wideplating,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron,
-/area/space)
 "qyS" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
@@ -15672,7 +16976,11 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "qzQ" = (
-/obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - North";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qzY" = (
@@ -15689,21 +16997,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"qAb" = (
-/obj/structure/rack,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "qAL" = (
 /obj/machinery/bluespace_vendor/directional/west,
 /obj/effect/turf_decal/loading_area{
@@ -15742,6 +17035,11 @@
 /obj/machinery/light/dim/directional/east,
 /turf/open/floor/eighties,
 /area/maintenance/department/chapel)
+"qCS" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/dry_ramen,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qEl" = (
 /obj/machinery/button/door/directional/south{
 	id = "xenobio12";
@@ -15757,12 +17055,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"qEo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "qER" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "qFm" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -15787,6 +17091,15 @@
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
+"qFA" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals - South Waiting Room";
+	name = "Arrivals Camera"
+	},
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "qFW" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -15827,11 +17140,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"qHm" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
 "qHq" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "qHw" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/landmark/secequipment,
@@ -15918,13 +17235,18 @@
 /obj/effect/landmark/start/research_director,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"qMq" = (
-/obj/structure/flora/grass/green,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Monkey Pen";
-	network = list("ss13","medbay")
+"qMm" = (
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "Minisat Solars Airlock W";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
 	},
-/turf/open/floor/grass,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/space/basic,
+/area/space)
+"qMq" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "qME" = (
 /obj/structure/fluff/fokoff_sign,
@@ -15962,7 +17284,7 @@
 "qOW" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "qQD" = (
 /obj/item/radio/intercom/directional/north{
 	desc = "A station intercom. It looks like it has been modified to not broadcast.";
@@ -16054,12 +17376,22 @@
 /obj/item/hfr_box/corner,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"qTK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "qTM" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
+"qUb" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "qUn" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/railing{
@@ -16092,10 +17424,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"qVG" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "qVO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/abandoned)
+"qVQ" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Minisat Exterior E";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "qWp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mineral_door/wood,
@@ -16118,7 +17462,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "qXk" = (
 /obj/machinery/door/firedoor,
 /turf/open/openspace,
@@ -16183,11 +17527,7 @@
 "rbD" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
-/area/space)
-"rbG" = (
-/obj/machinery/computer/pandemic,
-/turf/open/floor/iron/dark,
-/area/medical/virology)
+/area/hallway/secondary/entry)
 "rci" = (
 /turf/open/openspace,
 /area/medical/medbay/central)
@@ -16262,11 +17602,11 @@
 "rfv" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera/directional/south{
-	c_tag = "Arrivals N";
-	name = "Hallway Camera"
+	c_tag = "Arrivals - North Entrance";
+	name = "Arrivals Camera"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "rfC" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -16287,6 +17627,10 @@
 /obj/structure/easel,
 /turf/open/floor/glass/reinforced,
 /area/service/library/printer)
+"rhA" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/iron/grimy,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "rhX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -16391,6 +17735,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"rkD" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 3;
+	height = 5;
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/delta;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "rkP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16432,6 +17788,10 @@
 	},
 /turf/open/floor/carpet,
 /area/service/bar)
+"rov" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "row" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -16455,7 +17815,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "rpj" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -16661,10 +18021,6 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/command/bridge)
-"rxb" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "rxS" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/north,
@@ -16672,10 +18028,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"rxT" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "rxZ" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -16745,6 +18097,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"rCr" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_one_access_txt = "13;65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/transit_tube)
 "rCL" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/directional/north{
@@ -16754,10 +18117,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"rCT" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/hallway/secondary/service)
 "rDh" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/dice,
@@ -16784,6 +18143,22 @@
 "rEt" = (
 /turf/closed/wall,
 /area/service/bar/atrium)
+"rEM" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/shovel,
+/obj/item/pickaxe,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "rFi" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass,
@@ -16856,6 +18231,13 @@
 /obj/item/stack/sheet/cardboard/fifty,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"rHA" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 30
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "rHZ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -16865,7 +18247,7 @@
 	icon_state = "L10"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "rIq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -16928,6 +18310,16 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"rLR" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Antechamber";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "rMx" = (
 /obj/effect/spawner/random/contraband/prison,
 /obj/item/cigbutt,
@@ -16972,7 +18364,7 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "rPq" = (
 /obj/structure/table/wood,
 /obj/item/aicard,
@@ -17012,6 +18404,20 @@
 /obj/item/clothing/glasses/welding,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"rQD" = (
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 1;
+	name = "dark corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/service/theater)
 "rQX" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -17062,6 +18468,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"rSw" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "rST" = (
 /obj/machinery/door/firedoor,
 /turf/open/openspace,
@@ -17069,6 +18479,9 @@
 "rTd" = (
 /turf/open/openspace,
 /area/security/office)
+"rTj" = (
+/turf/open/floor/iron,
+/area/space)
 "rTu" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -17097,6 +18510,10 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
+"rUt" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "rUx" = (
 /obj/structure/railing{
 	dir = 8
@@ -17139,6 +18556,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
+"rWo" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "rWu" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner,
@@ -17214,6 +18635,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"rZo" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "rZG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -17312,6 +18737,21 @@
 /obj/item/lighter,
 /turf/open/floor/carpet,
 /area/command/meeting_room)
+"seY" = (
+/obj/structure/rack,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/item/radio/off,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "sfi" = (
 /turf/closed/wall,
 /area/medical/medbay/zone2)
@@ -17352,8 +18792,11 @@
 /turf/open/floor/plating,
 /area/science/breakroom)
 "shb" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/grass/green,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Monkey Pen";
+	network = list("ss13","medbay")
+	},
 /turf/open/floor/grass,
 /area/medical/virology)
 "shA" = (
@@ -17364,7 +18807,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "siB" = (
 /obj/structure/railing{
 	dir = 1;
@@ -17501,24 +18944,23 @@
 "snQ" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/o2,
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals - Pod 1 Entrance";
+	name = "Arrivals Camera"
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "soj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
-"soC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "soN" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Warehouse Maintenance";
 	req_one_access_txt = "12;31"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "spB" = (
@@ -17536,12 +18978,6 @@
 	},
 /turf/open/floor/vault,
 /area/hallway/primary/upper)
-"spS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
 "spU" = (
 /turf/closed/wall,
 /area/maintenance/department/cargo)
@@ -17549,21 +18985,25 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/medical/virology)
-"ssv" = (
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
+"srY" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/service/theater)
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "Minisat Solars Airlock LOCKED W";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/west,
+/obj/item/radio/intercom/directional/west{
+	broadcasting = 1;
+	frequency = 1447;
+	listening = 0;
+	name = "AI Intercom"
+	},
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "ssy" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/structure/reagent_dispensers/peppertank/directional/south,
@@ -17585,9 +19025,17 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "ssP" = (
-/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
+"stx" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "stN" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -17628,6 +19076,11 @@
 	icon_state = "wood-broken3"
 	},
 /area/service/abandoned_gambling_den)
+"swv" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "swI" = (
 /obj/machinery/door/airlock{
 	id_tag = "Blue Dorm";
@@ -17676,12 +19129,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"syu" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "syC" = (
 /turf/closed/wall,
 /area/security/prison/garden)
@@ -17728,9 +19175,8 @@
 /turf/open/openspace,
 /area/service/library/printer)
 "sCJ" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
 /area/medical/virology)
 "sDh" = (
 /obj/structure/cable,
@@ -17762,7 +19208,7 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "sEa" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/directional/west,
@@ -17770,6 +19216,28 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
+"sEl" = (
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 1;
+	name = "dark corner"
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/service/theater)
+"sEP" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 3"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "sFe" = (
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
@@ -17797,6 +19265,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
+"sFC" = (
+/obj/structure/closet/bombcloset,
+/turf/open/floor/iron/dark,
+/area/science/storage)
 "sFV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/black,
@@ -17849,7 +19321,15 @@
 	dir = 1
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
+"sJH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port Out"
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "sKa" = (
 /obj/structure/window{
 	dir = 4
@@ -17857,6 +19337,11 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"sKd" = (
+/obj/structure/lattice,
+/obj/structure/transit_tube/crossing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sKM" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -17932,23 +19417,9 @@
 "sOD" = (
 /turf/open/floor/carpet/purple,
 /area/medical/psychology)
-"sOI" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science)
 "sPg" = (
-/obj/machinery/door/airlock/virology/glass{
-	name = "Monkey Pen";
-	req_access_txt = "39"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "sPl" = (
@@ -18000,17 +19471,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"sQR" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/cargo/miningoffice)
 "sRd" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/structure/sign/poster/contraband/random{
@@ -18018,14 +19478,33 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"sRk" = (
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "sRs" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/grass,
+/obj/machinery/door/airlock/virology/glass{
+	name = "Monkey Pen";
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "sRH" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"sTL" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Exterior SE";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "sUl" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -18034,19 +19513,19 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/openspace,
 /area/hallway/primary/upper)
+"sUn" = (
+/obj/structure/transit_tube,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/transit_tube)
 "sUX" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
-"sVz" = (
-/obj/structure/rack,
-/obj/item/wrench,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/oxygen,
-/turf/open/floor/plating,
-/area/medical/virology)
 "sVF" = (
 /obj/effect/turf_decal/tile{
 	color = "#FF6700";
@@ -18089,6 +19568,16 @@
 	icon_state = "wood-broken"
 	},
 /area/service/abandoned_gambling_den)
+"sYF" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/camera/motion/directional/west{
+	c_tag = "Minisat Atmospherics";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "sYZ" = (
 /obj/machinery/light/dim/directional/south,
 /obj/effect/turf_decal/tile/purple{
@@ -18116,6 +19605,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"tbc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "tbn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -18126,6 +19621,11 @@
 "tck" = (
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"tcw" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tcy" = (
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/plating/asteroid/airless,
@@ -18153,7 +19653,12 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
+"ter" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "teT" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -18166,33 +19671,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
-"teW" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
-"tfj" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"tfF" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "tgs" = (
 /obj/structure/railing{
 	dir = 8
@@ -18201,7 +19679,7 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "tgJ" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
@@ -18223,6 +19701,21 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/hallway/primary/upper)
+"thH" = (
+/obj/structure/ore_box,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "tiz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -18285,7 +19778,7 @@
 /area/cargo/qm)
 "tlJ" = (
 /turf/closed/wall,
-/area/space)
+/area/hallway/secondary/entry)
 "tlS" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -18295,13 +19788,21 @@
 /turf/open/openspace,
 /area/hallway/primary/upper)
 "tna" = (
-/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/ausbushes/sunnybush,
 /turf/open/floor/grass,
 /area/medical/virology)
 "tnh" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"tnG" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Minisat Exterior NE";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "tnM" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
@@ -18384,6 +19885,13 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/captain)
+"tqv" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tqy" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Gear Room";
@@ -18416,9 +19924,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/medical/abandoned)
-"tqV" = (
-/turf/open/floor/plating,
-/area/cargo/miningoffice)
 "tqX" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Dorms";
@@ -18477,6 +19982,15 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"ttd" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "ttg" = (
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/west,
@@ -18485,13 +19999,6 @@
 "tty" = (
 /turf/open/floor/plating,
 /area/maintenance/department/security/upper)
-"tuh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/cargo/miningoffice)
 "tuW" = (
 /obj/item/paicard,
 /obj/item/tape,
@@ -18537,6 +20044,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"twH" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "txo" = (
 /obj/machinery/door/airlock{
 	id_tag = "Black Dorm";
@@ -18575,12 +20089,21 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"tyV" = (
+/turf/open/floor/iron/grimy,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "tzh" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"tzn" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -30
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tzr" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -18640,9 +20163,8 @@
 	},
 /area/medical/abandoned)
 "tCf" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/smartfridge/chemistry,
-/turf/open/floor/iron/dark,
+/mob/living/carbon/human/species/monkey,
+/turf/open/floor/grass,
 /area/medical/virology)
 "tCj" = (
 /obj/machinery/door/airlock/maintenance{
@@ -18689,9 +20211,23 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"tED" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
+"tEO" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "tEV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
+/obj/machinery/light/directional/west,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "tEX" = (
 /turf/closed/wall,
@@ -18765,17 +20301,17 @@
 "tJK" = (
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"tKk" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "tKw" = (
 /turf/closed/wall,
 /area/maintenance/department/engine/atmos)
 "tKH" = (
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
-"tKI" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plating,
-/area/medical/virology)
 "tKO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18783,6 +20319,14 @@
 /obj/machinery/atmospherics/components/tank/plasma,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"tLE" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/north,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron,
+/area/space)
 "tLT" = (
 /obj/structure/table,
 /obj/item/storage/dice{
@@ -18819,7 +20363,7 @@
 /obj/structure/frame/machine,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
-"tNp" = (
+"tNN" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
@@ -18838,7 +20382,7 @@
 	name = "emergency lifejacket"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
@@ -18872,12 +20416,6 @@
 	},
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
-"tPc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "tPp" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
@@ -18903,7 +20441,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "tQO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18955,6 +20493,14 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"tSN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -30
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "tSP" = (
 /obj/structure/railing{
 	dir = 1;
@@ -19020,6 +20566,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
+"tUT" = (
+/obj/machinery/camera/xray/directional/west{
+	c_tag = "AI Chamber E";
+	name = "Upgraded AI Camera";
+	network = list("aicore")
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "tVc" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -19083,6 +20637,12 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"tXb" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "tXi" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Restrooms"
@@ -19090,6 +20650,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/workout)
+"tXF" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/iron/dark,
+/area/medical/virology)
 "tXU" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
@@ -19103,6 +20667,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tYw" = (
+/obj/structure/closet/l3closet,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "tYL" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -19137,6 +20705,16 @@
 /obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"tZH" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_access_txt = "65"
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
 "uaj" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium"
@@ -19168,6 +20746,10 @@
 /obj/effect/landmark/start/mime,
 /turf/open/floor/iron/white,
 /area/service/theater)
+"uaV" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "ubb" = (
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
@@ -19216,8 +20798,8 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "ucq" = (
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/floor/grass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "ucW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -19226,8 +20808,19 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"udc" = (
+/obj/machinery/door/airlock/external{
+	name = "Mining Dock Airlock";
+	req_access_txt = "48";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "udg" = (
-/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/grass,
 /area/medical/virology)
 "udn" = (
@@ -19245,7 +20838,7 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "udQ" = (
 /obj/machinery/computer/security/telescreen/rd{
 	dir = 8;
@@ -19258,6 +20851,9 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/service/bar)
+"uej" = (
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/ai)
 "ueM" = (
 /obj/structure/sign/warning/coldtemp{
 	pixel_y = -32
@@ -19289,6 +20885,11 @@
 "ugd" = (
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
+"ugf" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ugA" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -19315,9 +20916,8 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "uhb" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma/five,
-/turf/open/floor/iron/dark,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/grass,
 /area/medical/virology)
 "uhR" = (
 /obj/structure/table,
@@ -19355,6 +20955,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"uiN" = (
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ujR" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -19368,7 +20971,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ukM" = (
-/obj/machinery/disposal/bin,
+/obj/structure/table/glass,
+/obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "ukN" = (
@@ -19384,6 +20988,10 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/engineering/lobby)
+"umh" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "umv" = (
 /obj/structure/sign/painting/library_private{
 	pixel_x = -32
@@ -19400,12 +21008,33 @@
 "unr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine)
-"unA" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
+"unJ" = (
+/obj/machinery/door_buttons/access_button{
+	idDoor = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
+	name = "Virology Access Button";
+	pixel_y = 25;
+	req_access_txt = "39"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/medical/virology)
+"uom" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Solar Control Bay";
+	req_access_txt = "65"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+/area/ai_monitored/turret_protected/aisat/service)
 "uoE" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Security Office - Table";
@@ -19415,6 +21044,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
+"uoO" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Space Access Airlock";
+	req_one_access_txt = "13;65"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "upd" = (
 /obj/machinery/shower{
 	dir = 4
@@ -19482,6 +21120,13 @@
 "urO" = (
 /turf/closed/wall,
 /area/science/research/abandoned)
+"urY" = (
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Teleporter";
+	req_access_txt = "17;65"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "usd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -19551,6 +21196,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
+"uuk" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Minisat Exterior NW";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "uul" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -19558,6 +21211,21 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"uuN" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Satellite Interior APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"uvo" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/maintenance/solars)
 "uvA" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/south,
@@ -19649,12 +21317,6 @@
 "uyn" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/visit)
-"uyx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
 "uyM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -19670,6 +21332,14 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
+/area/hallway/secondary/entry)
+"uzX" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Minisat Exterior NNW";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
 /area/space)
 "uAg" = (
 /obj/structure/table/wood/poker,
@@ -19696,6 +21366,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"uAZ" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "uBa" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon,
@@ -19747,10 +21425,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uBS" = (
-/obj/structure/table/glass,
-/obj/item/radio/intercom/directional/west,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "uCf" = (
@@ -19765,11 +21440,11 @@
 /turf/open/floor/iron,
 /area/security/prison/workout)
 "uCE" = (
-/obj/structure/cable,
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/west,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "uCR" = (
 /obj/machinery/skill_station,
@@ -19801,6 +21476,13 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"uGZ" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Arrivals - West Ferry Dock";
+	name = "Arrivals Camera"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "uHj" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -19828,7 +21510,7 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "uIA" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_white"
@@ -19846,6 +21528,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"uJp" = (
+/turf/open/floor/plating,
+/area/engineering/transit_tube)
+"uJy" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12;31"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "uJX" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay - Chemistry Lab N";
@@ -19873,6 +21565,11 @@
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
+"uLg" = (
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes/cigpack_candy,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "uLq" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -19959,6 +21656,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/lone/star,
 /area/command/meeting_room)
+"uPR" = (
+/obj/structure/rack,
+/obj/item/clothing/head/welding,
+/obj/item/wrench,
+/obj/item/crowbar,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "uQX" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -20073,10 +21777,6 @@
 "uTX" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"uUp" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "uUS" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical Dormitory Maintenance";
@@ -20140,12 +21840,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/supply)
-"uZl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"uZJ" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Teleporter Antechamber";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
 	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "vak" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/mech_bay_recharge_port{
@@ -20199,6 +21903,17 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/security/interrogation)
+"vcS" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Storage";
+	name = "AI motion-sensitive security camera";
+	network = list("minisat")
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "vdl" = (
 /obj/structure/table/wood,
 /obj/machinery/button/door/directional/west{
@@ -20257,6 +21972,12 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"vho" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "vht" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
@@ -20279,14 +22000,15 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "vjx" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
 /area/medical/virology)
-"vjC" = (
-/obj/machinery/atmospherics/components/tank/air,
-/turf/open/floor/plating,
-/area/medical/virology)
+"vkK" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai)
 "vkO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -20317,6 +22039,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"vlF" = (
+/obj/machinery/status_display/ai/directional/north,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vlX" = (
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
@@ -20340,13 +22066,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
+"vnm" = (
+/obj/machinery/computer/shuttle/mining{
+	dir = 1
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 30
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "vog" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod";
 	safety_mode = 1
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "voi" = (
 /turf/open/floor/iron/white,
 /area/medical/psychology)
@@ -20370,7 +22112,7 @@
 	icon_state = "L12"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "vqw" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/item/radio/intercom/directional/south{
@@ -20391,6 +22133,13 @@
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/wood,
 /area/service/library/printer)
+"vqN" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_one_access_txt = "12;48"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "vrg" = (
 /obj/machinery/door/window/northleft{
 	dir = 2;
@@ -20451,16 +22200,29 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "vta" = (
-/obj/machinery/computer/pandemic,
-/obj/structure/reagent_dispensers/virusfood/directional/west,
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
+"vtR" = (
+/obj/structure/cable,
+/obj/machinery/holopad/secure,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vtY" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/structure/sign/warning/docking{
+	pixel_x = -30
+	},
+/turf/open/space/basic,
+/area/space)
+"vut" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "vuD" = (
 /obj/structure/chair/wood,
 /obj/effect/landmark/start/hangover,
@@ -20490,6 +22252,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison/work)
+"vwJ" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "vxz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -20530,6 +22299,17 @@
 "vzA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"vzU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "teledoor";
+	name = "MiniSat Teleport Shutters Control";
+	req_one_access_txt = "17;65"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "vAg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -20570,9 +22350,12 @@
 /turf/open/openspace,
 /area/security/prison/visit)
 "vBQ" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/machinery/status_display/evac/directional/north,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "vCb" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -20580,21 +22363,25 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery/room_b)
 "vCr" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/camera/directional/north{
-	c_tag = "Virology - Break Room";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/iron/white,
+/obj/machinery/computer/pandemic,
+/obj/structure/reagent_dispensers/virusfood/directional/west,
+/turf/open/floor/iron/dark,
 /area/medical/virology)
 "vCA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"vCK" = (
+/turf/open/floor/plating,
+/area/cargo/miningoffice)
 "vCQ" = (
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"vCY" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vDd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance,
@@ -20699,21 +22486,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science)
-"vHR" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/xenobiology)
 "vIp" = (
 /obj/structure/sign/warning/docking{
 	pixel_y = -30
 	},
 /turf/open/openspace,
 /area/space)
+"vIB" = (
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vIF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -20737,18 +22520,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"vII" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "vJO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/bridge)
+"vJP" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vJV" = (
 /obj/structure/toilet,
 /turf/open/floor/iron/white,
@@ -20758,11 +22538,9 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "vLl" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/holopad,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vLW" = (
@@ -20791,12 +22569,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
-"vMM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
 "vNO" = (
 /obj/machinery/restaurant_portal/restaurant/prison,
 /obj/effect/turf_decal/tile{
@@ -20820,6 +22592,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"vOD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "vOO" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -20856,6 +22634,10 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"vQj" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/service)
 "vQs" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -20884,10 +22666,37 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
+"vRH" = (
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/atmos)
+"vRO" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plating,
+/area/medical/virology)
 "vRS" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"vSj" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/ai_monitored/turret_protected/ai";
+	name = "AI Chamber APC";
+	pixel_y = -23
+	},
+/obj/structure/cable,
+/obj/machinery/flasher/directional/south{
+	id = "AI";
+	pixel_x = -12
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "vSs" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "holding cell locker"
@@ -20954,6 +22763,20 @@
 	},
 /turf/open/floor/iron,
 /area/security/office)
+"vVF" = (
+/obj/structure/table,
+/obj/item/weldingtool,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/toy/mecha/reticence,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "vWd" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron,
@@ -20994,9 +22817,7 @@
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
 "vYj" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/machinery/light/directional/north,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "vYM" = (
@@ -21026,6 +22847,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
 "vZK" = (
@@ -21066,6 +22888,9 @@
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
 /area/service/library/printer)
+"wbI" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/aisat/service)
 "wbV" = (
 /obj/machinery/shower{
 	dir = 1
@@ -21094,6 +22919,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/research/abandoned)
+"wdo" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/department/science/xenobiology)
 "wff" = (
 /obj/structure/lattice,
 /turf/open/openspace,
@@ -21148,7 +22977,7 @@
 	id = "arrivalsElevator"
 	},
 /turf/open/openspace,
-/area/space)
+/area/hallway/secondary/entry)
 "whU" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/melee/flyswatter,
@@ -21161,6 +22990,12 @@
 /obj/structure/window,
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
+"win" = (
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "wiA" = (
 /obj/structure/chair/comfy/brown{
 	buildstackamount = 0;
@@ -21173,12 +23008,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"wkq" = (
+/obj/machinery/porta_turret/ai,
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/service)
 "wkF" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "wkL" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -21205,8 +23045,9 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "wlM" = (
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "wmg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21215,10 +23056,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/mechbay)
-"wnE" = (
-/obj/machinery/power/shieldwallgen,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
+"wno" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "wnJ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -21238,6 +23081,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"wpg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "wpJ" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers,
@@ -21263,6 +23113,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"wqK" = (
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = -30
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "wqS" = (
 /turf/closed/wall,
 /area/service/library/printer)
@@ -21284,6 +23143,12 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"wrX" = (
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron,
+/area/space)
 "wsd" = (
 /obj/structure/table/wood{
 	color = "#101010"
@@ -21310,6 +23175,20 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"wsZ" = (
+/obj/structure/closet/crate,
+/obj/item/stack/ore/glass,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/silver,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/item/stack/ore/iron,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/cargo/miningoffice)
 "wte" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/light/directional/west,
@@ -21410,10 +23289,10 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "wxE" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/structure/sign/nanotrasen{
-	pixel_y = 32
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/camera/directional/north{
+	c_tag = "Virology - Break Room";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -21529,6 +23408,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"wDR" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "wDV" = (
 /obj/structure/table,
 /obj/item/clothing/under/misc/burial,
@@ -21560,9 +23444,6 @@
 /obj/machinery/jukebox,
 /turf/open/floor/eighties/red,
 /area/maintenance/department/chapel)
-"wFV" = (
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "wGe" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -21573,6 +23454,9 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/commons/dorms)
+"wGz" = (
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "wGD" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Pen #9";
@@ -21593,7 +23477,7 @@
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "wHc" = (
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
@@ -21634,20 +23518,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"wIX" = (
-/obj/structure/closet/crate,
-/obj/item/stack/ore/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "wJz" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
@@ -21725,6 +23595,10 @@
 "wMI" = (
 /turf/open/openspace,
 /area/science/xenobiology)
+"wNo" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/hallway/secondary/service)
 "wNB" = (
 /turf/open/floor/plating/asteroid/basalt,
 /area/command/heads_quarters/hos)
@@ -21750,6 +23624,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/vault,
 /area/command/bridge)
+"wOZ" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "wPj" = (
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
@@ -21820,6 +23698,15 @@
 "wRO" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/safe)
+"wSc" = (
+/obj/machinery/bluespace_beacon,
+/obj/machinery/turretid{
+	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
+	name = "AI turret control";
+	pixel_y = 27
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "wSh" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Library Game Room";
@@ -21854,6 +23741,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"wTe" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "wTo" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -21905,11 +23797,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"wVR" = (
-/obj/structure/closet/l3closet,
-/obj/item/toy/mecha/mauler,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "wWk" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/plating/asteroid/basalt,
@@ -21944,9 +23831,9 @@
 /turf/open/floor/carpet/green,
 /area/service/library/printer)
 "xaE" = (
-/obj/item/storage/secure/safe/directional/east,
 /obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/reagentgrinder,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "xaI" = (
@@ -21985,21 +23872,44 @@
 /obj/structure/table,
 /obj/item/pickaxe/emergency,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "xeg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"xej" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xev" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/green,
 /area/commons/dorms)
+"xeS" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xfo" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"xfK" = (
+/obj/machinery/power/solar{
+	id = "aisolar";
+	name = "AI Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/maintenance/solars)
 "xgd" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/blue{
@@ -22020,12 +23930,17 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"xgX" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "xhF" = (
-/obj/structure/table/glass,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "xhN" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -22070,6 +23985,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/science/research)
+"xlw" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "xlN" = (
 /obj/structure/table/wood,
 /obj/item/storage/firstaid/regular,
@@ -22103,6 +24023,15 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"xmO" = (
+/obj/structure/table,
+/obj/item/storage/fancy/cigarettes,
+/obj/item/lighter/greyscale,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xmW" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional/west,
@@ -22111,6 +24040,18 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"xnZ" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"xqx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "xqH" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -22131,7 +24072,7 @@
 "xsF" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "xsP" = (
 /obj/item/toy/plush/chica,
 /obj/effect/decal/cleanable/dirt,
@@ -22146,12 +24087,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
 "xuk" = (
-/obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/science,
-/obj/item/healthanalyzer,
-/turf/open/floor/iron/dark,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/white,
 /area/medical/virology)
 "xus" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -22198,6 +24139,9 @@
 /obj/structure/cable,
 /turf/open/floor/vault,
 /area/command/bridge)
+"xxc" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/solars)
 "xxt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 10
@@ -22227,6 +24171,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"xxK" = (
+/obj/structure/cable,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "xyk" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/directional/north{
@@ -22384,6 +24333,9 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"xGn" = (
+/turf/closed/wall,
+/area/engineering/transit_tube)
 "xGM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile{
@@ -22433,66 +24385,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"xJo" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
-"xJK" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
-"xJR" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/zone2)
+"xJn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "xJZ" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor/massdriver_chapel,
@@ -22515,6 +24411,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
+"xLU" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xMa" = (
 /turf/closed/wall,
 /area/hallway/primary/upper)
@@ -22540,19 +24442,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
-"xMS" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/ore_box,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "xNu" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/purple,
@@ -22567,10 +24456,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"xNC" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/maintenance/department/science/xenobiology)
 "xOd" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
@@ -22587,6 +24472,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"xOR" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/space/basic,
+/area/maintenance/solars)
 "xOT" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
@@ -22632,16 +24523,19 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "xPC" = (
-/obj/machinery/door/airlock/virology{
-	name = "Virology Break Room";
-	req_access_txt = "39"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
+/obj/item/storage/secure/safe/directional/east,
+/obj/structure/table,
+/obj/machinery/microwave,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"xPH" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Minisat Exterior W";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "xPN" = (
 /obj/structure/mirror/directional/south,
 /obj/structure/sink{
@@ -22658,6 +24552,13 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/office)
+"xQm" = (
+/obj/machinery/computer/teleporter{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xQv" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -22688,6 +24589,33 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"xRu" = (
+/obj/structure/rack,
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/maintenance/department/science/xenobiology)
 "xRx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -22695,12 +24623,8 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "xSh" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/landmark/start/virologist,
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "xSC" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/closet/secure_closet/quartermaster,
@@ -22729,12 +24653,8 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
 "xTf" = (
-/obj/structure/table,
-/obj/machinery/computer/med_data/laptop{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "xTC" = (
 /obj/structure/industrial_lift{
 	id = "medbayElevator"
@@ -22748,6 +24668,23 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
+"xUj" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
+"xUu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/department/science/xenobiology)
 "xUQ" = (
 /turf/closed/wall/r_wall,
 /area/service/abandoned_gambling_den)
@@ -22782,20 +24719,6 @@
 "xYO" = (
 /turf/open/openspace,
 /area/hallway/primary/starboard)
-"xYX" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/ore_box,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "xZe" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -22810,17 +24733,9 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "xZY" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Virology - South;
-	network = list("ss13","medbay")
-	},
-/obj/machinery/light/directional/west,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -11
-	},
-/turf/open/floor/iron/white,
-/area/medical/virology)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "yaI" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/stripes/corner{
@@ -22841,6 +24756,9 @@
 /obj/machinery/holopad,
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/cmo)
+"ybm" = (
+/turf/open/openspace,
+/area/engineering/transit_tube)
 "ybp" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance";
@@ -22858,12 +24776,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
-"ybU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+"ycb" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -11
 	},
-/turf/open/floor/iron,
-/area/maintenance/department/science/xenobiology)
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "ycm" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -22960,6 +24879,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
+"yfF" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "yfQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -22971,6 +24894,20 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"ygE" = (
+/obj/machinery/door/window{
+	base_state = "leftsecure";
+	dir = 1;
+	icon_state = "leftsecure";
+	name = "AI Core Access";
+	req_access_txt = "65"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
+"ygS" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "yhu" = (
 /obj/structure/chair/stool{
 	pixel_y = 15
@@ -23022,17 +24959,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
+"yjr" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "yjO" = (
 /turf/closed/wall,
 /area/medical/chemistry)
 "ykk" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/camera/directional/north{
-	c_tag = "Arrivals S";
-	name = "Hallway Camera"
+	c_tag = "Arrivals - South Entrance";
+	name = "Arrivals Camera"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "ykv" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -23051,6 +24992,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/department/chapel)
+"ykZ" = (
+/obj/machinery/camera/directional/north{
+	c_tag = "Minisat Exterior SSW";
+	name = "Minisat Camera";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
+"yli" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ylw" = (
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
@@ -37307,12 +39261,12 @@ pGV
 pGV
 tlJ
 snQ
-wlM
-wlM
+xSh
+rov
 tlJ
-wlM
-tDG
-tDG
+xSh
+nEI
+nEI
 tlJ
 rOW
 sDU
@@ -37320,17 +39274,17 @@ tQL
 uzK
 udr
 tlJ
-tDG
-tDG
-wlM
+nEI
+nEI
+xSh
 tlJ
 fXG
-wlM
+xSh
 xdg
 tlJ
-nwc
-wlM
-wlM
+jgP
+xSh
+rov
 tlJ
 pGV
 pGV
@@ -37567,9 +39521,9 @@ tlJ
 oOs
 tlJ
 tlJ
-wlM
+pXl
 bVM
-bVM
+pjc
 tlJ
 gxC
 whv
@@ -37577,12 +39531,12 @@ vKa
 kZU
 evr
 tlJ
+pjc
 bVM
-bVM
-wlM
+eqA
 tlJ
 hHv
-wlM
+xSh
 ePG
 tlJ
 tlJ
@@ -37821,12 +39775,12 @@ tlJ
 tlJ
 nwc
 oro
+xSh
+xSh
 wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
 tlJ
 tlJ
 sIV
@@ -37834,16 +39788,16 @@ vKa
 uIf
 tlJ
 tlJ
-wlM
-wlM
-wlM
+xSh
+xSh
+mjt
 tlJ
 tlJ
 ars
 tlJ
 tlJ
-wlM
-wlM
+xSh
+xSh
 oro
 tlJ
 pGV
@@ -38062,28 +40016,28 @@ pGV
 cMd
 cQT
 wlM
-wlM
-wlM
+uGZ
+xSh
 eAS
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+rWo
+xLU
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
 wlM
 tlJ
 tdT
@@ -38091,16 +40045,16 @@ shA
 vsX
 tlJ
 wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+bBN
+xSh
 bBN
 wlM
-bBN
-wlM
-wlM
-wlM
+xSh
+xSh
 ePG
 tlJ
 aPY
@@ -38318,46 +40272,46 @@ pGV
 pGV
 cMd
 dpt
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+hpa
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
-wlM
+xSh
+xSh
+mNf
+stx
+fox
+xeS
 mNf
 mNf
-mNf
-mNf
-mNf
-mNf
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
-wlM
-wlM
+xSh
+oWr
+xSh
 lTl
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xmO
 tlJ
 tlJ
 aPY
@@ -38579,42 +40533,42 @@ dNm
 dsT
 evE
 eCd
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
-wlM
+xSh
+tcw
 tlJ
 tlJ
 tlJ
 tlJ
 tlJ
 tlJ
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+qFA
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
 lTl
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+blr
 tlJ
 aPY
 aPY
@@ -38832,7 +40786,7 @@ pGV
 pGV
 pGV
 dsT
-yin
+xTf
 dsT
 dsT
 dsT
@@ -38843,35 +40797,35 @@ dsT
 dsT
 tlJ
 jRe
-wlM
+xSh
 mTh
 mTh
+twH
 mTh
+jkj
 mTh
-mTh
-mTh
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
 qHq
 cMd
 cMd
 cMd
 dsT
-hrz
+iFV
 dsT
 cMd
 cMd
 cMd
 wGZ
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+lZf
 tlJ
 aPY
 aPY
@@ -39089,7 +41043,7 @@ pGV
 pGV
 pGV
 dsT
-yin
+xTf
 dsT
 pGV
 pGV
@@ -39099,17 +41053,17 @@ pGV
 pGV
 pGV
 dsT
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
 qOW
 cMd
 tDG
@@ -39121,14 +41075,14 @@ tDG
 tDG
 dsT
 qOW
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+clZ
 tlJ
 aPY
 aPY
@@ -39356,17 +41310,17 @@ pGV
 pGV
 pGV
 dsT
-wlM
-wlM
+xSh
+xSh
 mNf
 mNf
+fox
 mNf
+stx
 mNf
-mNf
-mNf
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
 evE
 dsT
 tDG
@@ -39378,14 +41332,14 @@ tDG
 tDG
 dsT
 evE
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+lZf
 tlJ
 aPY
 aPY
@@ -39602,9 +41556,9 @@ pGV
 pGV
 pGV
 pGV
+vtY
 pGV
-pGV
-pGV
+vtY
 pGV
 pGV
 pGV
@@ -39613,16 +41567,16 @@ pGV
 pGV
 pGV
 dsT
-wlM
-wlM
+xSh
+ihM
 tlJ
 tlJ
 tlJ
 tlJ
 tlJ
 tlJ
-wlM
-wlM
+tKk
+tzn
 dsT
 dsT
 dsT
@@ -39636,13 +41590,13 @@ tDG
 dsT
 dsT
 dsT
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+oyP
+xSh
+xSh
+xSh
+xSh
+xSh
+lZf
 tlJ
 aPY
 aPY
@@ -39870,18 +41824,18 @@ dsT
 dsT
 dsT
 dsT
-wlM
-wlM
+rHA
+xSh
+mTh
+jkj
+xUj
 mTh
 mTh
 mTh
-mTh
-mTh
-mTh
-wlM
-wlM
+xSh
+xSh
 igc
-yin
+xTf
 jFK
 tDG
 tDG
@@ -39891,15 +41845,15 @@ tDG
 tDG
 tDG
 igc
-yin
+xTf
 klI
-wlM
+xSh
 gvl
 omZ
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+cpI
 tlJ
 aPY
 aPY
@@ -40124,19 +42078,19 @@ pGV
 pGV
 gfo
 igc
-yin
-yin
+xTf
+xTf
 jFK
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
 nFw
-wlM
+xSh
 ptR
-wlM
-wlM
+xSh
+tzn
 dsT
 dsT
 dsT
@@ -40150,13 +42104,13 @@ tDG
 dsT
 dsT
 dsT
-wlM
+oyP
 fvH
 gOU
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+pSN
 tlJ
 aPY
 aPY
@@ -40384,17 +42338,17 @@ dsT
 dsT
 dsT
 dsT
-wlM
-wlM
-wlM
-wlM
-wlM
+rHA
+xSh
+xSh
+xSh
+xSh
 ogI
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
 qWQ
 cMd
 tDG
@@ -40406,13 +42360,13 @@ tDG
 vIp
 cMd
 xsF
-wlM
-wlM
+xSh
+xSh
 fxs
 wkF
-wlM
-wlM
-tlJ
+xSh
+xSh
+cxU
 tlJ
 tlJ
 aPY
@@ -40630,9 +42584,9 @@ pGV
 pGV
 pGV
 pGV
+pLQ
 pGV
-pGV
-pGV
+pLQ
 pGV
 pGV
 pGV
@@ -40641,7 +42595,7 @@ aPY
 aPY
 aPY
 dsT
-wlM
+xSh
 lxY
 njX
 njX
@@ -40649,9 +42603,9 @@ njX
 njX
 njX
 pLD
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
 rbD
 dsT
 tDG
@@ -40663,14 +42617,14 @@ tDG
 tDG
 dsT
 qOW
-wlM
-wlM
+xSh
+xSh
 bPC
 aTI
-wlM
-wlM
+xSh
+pwV
 tlJ
-aPY
+tlJ
 aPY
 aPY
 aPY
@@ -40898,17 +42852,17 @@ aPY
 aPY
 aPY
 dsT
-wlM
+xSh
 lSm
-tDG
-tDG
-tDG
-tDG
-tDG
+hfr
+hfr
+hfr
+hfr
+hfr
 qfR
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
 rfv
 dsT
 tDG
@@ -40920,11 +42874,11 @@ tDG
 tDG
 dsT
 ykk
-wlM
-wlM
+xSh
+xSh
 hSk
 rIg
-wlM
+lZf
 tlJ
 tlJ
 aPY
@@ -41145,7 +43099,7 @@ pGV
 pGV
 pGV
 dsT
-yin
+xTf
 dsT
 pGV
 pGV
@@ -41155,17 +43109,17 @@ aPY
 aPY
 aPY
 dsT
-wlM
+xSh
 lSm
-tDG
-tDG
-tDG
-tDG
-tDG
+hfr
+hfr
+hfr
+hfr
+hfr
 qrm
 pLD
-wlM
-wlM
+xSh
+xSh
 roY
 cMd
 tDG
@@ -41177,11 +43131,11 @@ tDG
 vIp
 cMd
 eCT
-wlM
-wlM
+xSh
+xSh
 mom
 vpo
-wlM
+nhn
 tlJ
 aPY
 aPY
@@ -41402,7 +43356,7 @@ pGV
 pGV
 pGV
 dsT
-yin
+xTf
 dsT
 dsT
 dsT
@@ -41412,16 +43366,16 @@ dsT
 dsT
 dsT
 tlJ
-wlM
+cQT
 lSm
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+hfr
+hfr
+hfr
+hfr
+hfr
+hfr
 qfR
-wlM
+tzn
 dsT
 dsT
 dsT
@@ -41435,10 +43389,10 @@ tDG
 dsT
 dsT
 dsT
-wlM
+oyP
 izf
 gQs
-wlM
+xej
 tlJ
 aPY
 aPY
@@ -41663,24 +43617,24 @@ emJ
 dsT
 evE
 eAS
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
+xSh
 lSm
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+hfr
+hfr
+hfr
+hfr
+hfr
+hfr
 qfR
-wlM
+xSh
 igc
-yin
+xTf
 jFK
 tDG
 tDG
@@ -41690,12 +43644,12 @@ tDG
 tDG
 tDG
 igc
-yin
+xTf
 klI
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+asb
 tlJ
 aPY
 aPY
@@ -41915,27 +43869,27 @@ pGV
 pGV
 pGV
 cMd
-dpt
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
-wlM
+vBQ
+xSh
+win
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
+xSh
 lSm
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+hfr
+hfr
+hfr
+hfr
+hfr
+hfr
 qfR
-wlM
+tzn
 dsT
 dsT
 dsT
@@ -41949,10 +43903,10 @@ tDG
 dsT
 dsT
 dsT
-wlM
-wlM
-wlM
-wlM
+oyP
+xSh
+xSh
+uLg
 tlJ
 aPY
 aPY
@@ -42173,27 +44127,27 @@ pGV
 pGV
 cMd
 cQT
-wlM
-wlM
-wlM
+xZY
+xSh
+aiq
 eCd
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+xSh
 lTl
-wlM
-lSm
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+xSh
+nPf
+hfr
+hfr
+hfr
+hfr
+hfr
+hfr
 qfR
-wlM
-wlM
+xSh
+xSh
 evE
 dsT
 tDG
@@ -42205,11 +44159,11 @@ tDG
 tDG
 dsT
 evE
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+kiS
 tlJ
 aPY
 aPY
@@ -42433,7 +44387,7 @@ cMd
 cMd
 cMd
 cMd
-mXh
+cGp
 unn
 unn
 unn
@@ -42442,16 +44396,16 @@ unn
 mXh
 lbU
 mXh
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+hfr
+hfr
+hfr
+hfr
+hfr
+hfr
 qfR
-wlM
-wlM
-wlM
+xSh
+xSh
+qCS
 dsT
 tDG
 tDG
@@ -42461,11 +44415,11 @@ tDG
 tDG
 tDG
 dsT
-wlM
-wlM
-wlM
-wlM
-wlM
+xSh
+xSh
+xSh
+xSh
+iOg
 qoL
 qoL
 qoL
@@ -42702,13 +44656,13 @@ mXh
 mXh
 mXh
 bVM
-bVM
-bVM
+jWv
+tqv
 bVM
 qER
-wlM
-wlM
-wlM
+xSh
+cXj
+qhZ
 dsT
 tDG
 tDG
@@ -42718,11 +44672,11 @@ tDG
 tDG
 tDG
 dsT
-wlM
-wlM
-wlM
-wlM
-wlM
+xZY
+xSh
+xSh
+xSh
+iOg
 qoL
 xCi
 xCi
@@ -46107,11 +48061,11 @@ aPY
 aPY
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -46364,11 +48318,11 @@ kDk
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -46621,11 +48575,11 @@ kcK
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -46878,11 +48832,11 @@ kcK
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -47135,11 +49089,11 @@ kcK
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -47392,11 +49346,11 @@ kDk
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -47649,11 +49603,11 @@ aPY
 aPY
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -47908,9 +49862,9 @@ bPp
 bPp
 kDk
 kDk
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -48165,9 +50119,9 @@ mde
 mde
 pHg
 kDk
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -48327,9 +50281,9 @@ tty
 tty
 tty
 bHy
-kjA
-kjA
-kjA
+kys
+kys
+kys
 bqJ
 dim
 wNH
@@ -48422,9 +50376,9 @@ mde
 mde
 mde
 bPp
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -48585,8 +50539,8 @@ tty
 tty
 bHy
 wFs
-kjA
-kjA
+kys
+kys
 byc
 dim
 wNH
@@ -48679,9 +50633,9 @@ mde
 mde
 mde
 bPp
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -48841,8 +50795,8 @@ bHy
 bHy
 ocV
 bHy
-kjA
-kjA
+kys
+kys
 aLK
 bCv
 dim
@@ -48936,9 +50890,9 @@ pza
 mde
 mde
 bPp
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -49099,9 +51053,9 @@ tty
 tty
 bHy
 anp
-kjA
-kjA
-kjA
+kys
+kys
+kys
 cmX
 wNH
 wNH
@@ -49193,9 +51147,9 @@ lFl
 mde
 mde
 bPp
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -49355,7 +51309,7 @@ clD
 clD
 clD
 bHy
-kjA
+kys
 aLK
 beo
 aLK
@@ -49451,8 +51405,8 @@ mde
 mde
 nmT
 jGz
-pGV
-pGV
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -49612,10 +51566,10 @@ bHy
 bHy
 tty
 bHy
-kjA
-kjA
+kys
+kys
 aLK
-kjA
+kys
 dim
 wNH
 wNH
@@ -49707,9 +51661,9 @@ mde
 mde
 tZx
 bPp
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -49870,8 +51824,8 @@ bHy
 tty
 bHy
 axW
-kjA
-kjA
+kys
+kys
 aLK
 dim
 wNH
@@ -49964,9 +51918,9 @@ mde
 mde
 mde
 bPp
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -50221,9 +52175,9 @@ mde
 mde
 eYO
 kDk
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -50478,9 +52432,9 @@ bPp
 bPp
 kDk
 kDk
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -50733,11 +52687,11 @@ aPY
 aPY
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -50990,11 +52944,11 @@ kDk
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51208,7 +53162,7 @@ cof
 cof
 cof
 nhr
-eeA
+fVY
 qTM
 qTM
 yaI
@@ -51247,11 +53201,11 @@ kcK
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51504,6 +53458,11 @@ kcK
 kDk
 aPY
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51534,12 +53493,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+xPH
 pGV
 pGV
 pGV
@@ -51723,7 +53677,7 @@ vmM
 twb
 nhr
 jIn
-fAJ
+wDR
 jIn
 jIn
 kjW
@@ -51761,49 +53715,49 @@ kcK
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 aPY
 aPY
 aPY
 aPY
 aPY
-aPY
-aPY
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+xxc
+xxc
+xxc
+xxc
+xxc
+xxc
+xxc
+pGV
+biu
 pGV
 pGV
 pGV
@@ -51980,7 +53934,7 @@ nhr
 nhr
 rEt
 rEt
-fAJ
+wDR
 jIn
 jIn
 ecG
@@ -52018,52 +53972,52 @@ kDk
 kDk
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 aPY
 aPY
 aPY
 aPY
 aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wbI
+wbI
+wbI
+xxc
+xxc
+gOJ
+fjO
+lGj
+xxc
+xxc
+xxc
+xxc
+xxc
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -52237,7 +54191,7 @@ baJ
 baJ
 gsT
 rEt
-fAJ
+wDR
 jIn
 ecG
 ecG
@@ -52275,54 +54229,54 @@ aPY
 aPY
 aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 aPY
 aPY
 aPY
 aPY
 aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+uuk
+wbI
+wbI
+wbI
+wbI
+wbI
+eAc
+kyL
+aLr
+kyL
+uvo
+bvo
+srY
+xxc
+xxc
+xxc
+xxc
+xxc
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -52494,7 +54448,7 @@ baJ
 baJ
 gsT
 rEt
-fAJ
+wDR
 jIn
 ecG
 lsZ
@@ -52516,62 +54470,22 @@ kRd
 iQG
 iQG
 tKw
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
 aPY
 aPY
 aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 aPY
 aPY
 aPY
@@ -52580,6 +54494,46 @@ aPY
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wbI
+wbI
+wbI
+lHU
+uAZ
+wbI
+dZl
+gag
+hpl
+lTC
+xxc
+xxc
+kaE
+xxc
+xxc
+bvU
+bvU
+eAm
+qHm
+yfF
 pGV
 pGV
 pGV
@@ -52751,7 +54705,7 @@ kBO
 kBO
 sVX
 rEt
-fAJ
+wDR
 jIn
 lsZ
 lsZ
@@ -52773,61 +54727,22 @@ kRd
 iQG
 iQG
 tKw
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
 aPY
 aPY
 aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 aPY
 aPY
 aPY
@@ -52838,6 +54753,45 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wbI
+wbI
+wbI
+cEb
+olj
+olj
+uom
+kyL
+kyL
+meq
+xxc
+xxc
+xxc
+uvo
+xxc
+pGV
+pGV
+pGV
+pGV
+pGV
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -52952,7 +54906,7 @@ bHy
 bHy
 bHy
 otS
-bHy
+otS
 bHy
 tty
 bHy
@@ -53008,7 +54962,7 @@ kGM
 kGM
 kGM
 kjr
-fAJ
+wDR
 jIn
 ecG
 lsZ
@@ -53029,62 +54983,23 @@ lrH
 kRd
 iQG
 iQG
-tKw
+mzk
+iQG
+iQG
+kIr
+kIr
+kIr
+kIr
+kIr
+kIr
+kIr
 aPY
 aPY
 aPY
 aPY
 aPY
 aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 aPY
 aPY
 aPY
@@ -53097,6 +55012,45 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wbI
+wbI
+wbI
+nsG
+jri
+qjG
+fRD
+wbI
+hpl
+lTC
+xxc
+xxc
+xxc
+xxc
+hZz
+xxc
+lmP
+bvU
+bvU
+bvU
+bvU
+bvU
+yfF
+yfF
+gLp
 pGV
 pGV
 pGV
@@ -53209,8 +55163,8 @@ tty
 tty
 bHy
 otS
+otS
 bHy
-tty
 tty
 bHy
 gzw
@@ -53265,7 +55219,7 @@ wsn
 wsn
 kGM
 rEt
-fAJ
+wDR
 jIn
 hhb
 hhb
@@ -53287,6 +55241,9 @@ kRd
 iQG
 iQG
 tKw
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -53299,45 +55256,7 @@ aPY
 aPY
 aPY
 aPY
-aPY
-aPY
-aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 aPY
 aPY
 aPY
@@ -53354,6 +55273,41 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wbI
+wbI
+wbI
+aQO
+olj
+olj
+vQj
+kHQ
+wbI
+pYE
+xxc
+xxc
+xxc
+pGV
+pGV
+aNm
+mzy
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -53467,7 +55421,7 @@ tty
 bHy
 bHy
 bHy
-tty
+bHy
 tty
 kGG
 gzw
@@ -53522,12 +55476,12 @@ iTL
 uAg
 wsn
 rEt
-fAJ
+wDR
 jIn
 hhb
 uav
 vjv
-ssv
+sEl
 toc
 jPZ
 tKw
@@ -53544,49 +55498,9 @@ kRd
 iQG
 iQG
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -53611,6 +55525,46 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wbI
+wbI
+rSw
+olj
+olj
+nFR
+eeo
+wkq
+wbI
+xxc
+xxc
+xxc
+pGV
+pGV
+pGV
+pGV
+iZx
+iZx
+xfK
+xfK
+xfK
+xfK
+pGV
+pGV
+pGV
+yfF
 pGV
 pGV
 pGV
@@ -53779,11 +55733,11 @@ rDh
 iTL
 wsn
 rEt
-fAJ
+wDR
 jIn
 hhb
 cwd
-epl
+rQD
 qKJ
 ime
 dcw
@@ -53801,48 +55755,9 @@ kRd
 iQG
 iQG
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -53869,6 +55784,45 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wbI
+wbI
+wbI
+wbI
+wbI
+aoK
+wbI
+wbI
+wbI
+wbI
+xxc
+xxc
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+iZx
+iZx
+iZx
+aNm
+aNm
+xfK
+bvU
+bvU
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -54036,11 +55990,11 @@ wsn
 wsn
 kGM
 rEt
-fAJ
+wDR
 jIn
 hhb
 qgU
-fMl
+ewb
 fak
 frM
 iqJ
@@ -54058,48 +56012,9 @@ kRd
 iQG
 iQG
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -54126,6 +56041,45 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+uzX
+wGz
+wGz
+qcH
+yjr
+oEC
+rUt
+jvo
+tyV
+gay
+wGz
+vkK
+vkK
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+iZx
+xfK
+xfK
+xfK
+pGV
+pGV
+pGV
+pGV
+yfF
 pGV
 pGV
 pGV
@@ -54293,10 +56247,10 @@ eJE
 eJE
 eJE
 eJE
-fAJ
-rCT
+wDR
+wNo
 wZI
-fMl
+ewb
 gMF
 iWS
 avM
@@ -54315,50 +56269,9 @@ tKw
 iQG
 iQG
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -54383,6 +56296,47 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wGz
+wGz
+eMb
+rUt
+xxK
+gzH
+tyV
+rhA
+wqK
+wGz
+vkK
+vkK
+vkK
+vkK
+pGV
+pGV
+pGV
+pGV
+pGV
+iZx
+xfK
+xfK
+xfK
+xfK
+pGV
+pGV
+pGV
+yfF
 pGV
 pGV
 pGV
@@ -54572,47 +56526,9 @@ tKw
 iQG
 iQG
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -54641,6 +56557,44 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+wGz
+wGz
+wGz
+kab
+vCY
+ipR
+ipR
+tyV
+tyV
+xnZ
+wGz
+vkK
+vkK
+vkK
+vkK
+vkK
+qMm
+pGV
+pGV
+pGV
+iZx
+iZx
+iZx
+aNm
+aNm
+xfK
+bvU
+bvU
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -54829,50 +56783,13 @@ tKw
 iQG
 iQG
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+iQG
+iQG
+kIr
+kIr
+kIr
+kIr
+kIr
 aPY
 aPY
 aPY
@@ -54898,6 +56815,43 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+xJn
+wGz
+wGz
+wGz
+wGz
+wGz
+wGz
+dFe
+wGz
+aSP
+icF
+ugf
+wGz
+vkK
+vkK
+oVJ
+vkK
+vkK
+vkK
+vkK
+pGV
+pGV
+pGV
+pGV
+iZx
+xfK
+xfK
+xfK
+pGV
+pGV
+pGV
+pGV
+yfF
 pGV
 pGV
 pGV
@@ -55086,51 +57040,13 @@ iQG
 iQG
 iQG
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -55156,6 +57072,44 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+xJn
+xJn
+kvH
+uuN
+wGz
+wGz
+bib
+vJP
+vCY
+wGz
+egT
+lpK
+wGz
+vkK
+qUb
+pLp
+pLp
+pLp
+pLp
+vkK
+vkK
+vkK
+pGV
+pGV
+pGV
+iZx
+xfK
+xfK
+xfK
+xfK
+pGV
+pGV
+pGV
+yfF
+ykZ
 pGV
 pGV
 pGV
@@ -55341,54 +57295,15 @@ mAU
 tKw
 tKw
 tKw
+mzk
 tKw
-tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+iQG
+iQG
+iQG
+iQG
+iQG
+iQG
+kIr
 aPY
 aPY
 aPY
@@ -55412,6 +57327,45 @@ pGV
 pGV
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+xJn
+xJn
+tEO
+icF
+hfR
+wGz
+wGz
+vlF
+icF
+vIB
+orX
+orX
+orX
+vkK
+hqQ
+pLp
+cIp
+jvj
+cIp
+pLp
+hqQ
+vkK
+vkK
+vkK
+pNk
+bvU
+iZx
+iZx
+aNm
+aNm
+aNm
+xfK
+bvU
+bvU
+yfF
 pGV
 pGV
 pGV
@@ -55596,79 +57550,79 @@ tKw
 mAU
 mAU
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+vzA
+vzA
+vzA
+tKw
+tKw
+tKw
+tKw
+tKw
+mzk
+tKw
+tKw
+xGn
+xGn
+xGn
+xGn
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+xJn
+icF
+mGV
+icF
+jDF
+wGz
+wGz
+dAC
+rUt
+jDF
+orX
+ibQ
+orX
+hMh
+pLp
+cIp
+cIp
+ijF
+cIp
+cIp
+pLp
+hMh
+vkK
+vkK
+pGV
+pGV
+iZx
+xfK
+xfK
+xfK
+xfK
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -55853,79 +57807,79 @@ tKw
 tKw
 mzk
 tKw
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+vzA
+vzA
+vzA
+vzA
+spU
+ybm
+ybm
+jYc
+jYc
+jYc
+xGn
+nxQ
+lpl
+sUn
+kZI
+jVb
+jVb
+jVb
+jVb
+jVb
+jVb
+jVb
+jVb
+oaj
+sKd
+jVb
+jVb
+jVb
+jVb
+sKd
+jVb
+jVb
+sKd
+jVb
+oaj
+jVb
+sKd
+jVb
+egz
+pyp
+kko
+icF
+vIB
+wGz
+wGz
+rLR
+icF
+vCY
+bLj
+nmn
+orX
+pLp
+cIp
+cIp
+nUH
+vkK
+vkK
+cIp
+cIp
+pLp
+vkK
+vkK
 pGV
 pGV
+aNm
+xfK
+xfK
+xfK
+xfK
+xfK
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -56110,79 +58064,79 @@ spU
 diy
 vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+vzA
+vzA
+vzA
+vzA
+spU
+ybm
+ybm
+jYc
+jYc
+jYc
+xGn
+irc
+jYc
+jYc
+drH
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+xJn
+lRP
+kab
+icF
+biY
+fHD
+vCY
+vCY
+oUJ
+vtR
+tZH
+ptf
+evP
+bUM
+bOY
+fzn
+ygE
+pVE
+vkK
+lWR
+aGG
+mkE
+vkK
+vkK
+dUt
+bxA
+aNm
+aNm
+aNm
+aNm
+aNm
+aNm
+xfK
+bvU
+yfF
 pGV
 pGV
 pGV
@@ -56367,79 +58321,79 @@ spU
 diy
 vzA
 spU
+vzA
+vzA
+vzA
+vzA
 spU
-spU
-spU
-spU
-spU
-spU
-spU
-spU
-spU
-spU
-spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+ybm
+ybm
+jYc
+jYc
+oZk
+njQ
+oZk
+oZk
+xqx
+drH
+drH
+drH
+drH
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+xJn
+xJn
+xJn
+xJn
+icF
+icF
+cZU
+wGz
+wGz
+kSD
+icF
+vCY
+bLj
+nHh
+orX
+pLp
+cIp
+cIp
+vSj
+vkK
+vkK
+uej
+uej
+pLp
+vkK
+vkK
 pGV
 pGV
+aNm
+xfK
+xfK
+xfK
+xfK
+xfK
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -56628,75 +58582,75 @@ vzA
 vzA
 vzA
 vzA
-vzA
-vzA
-vzA
-vzA
-vzA
-vzA
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+ybm
+ybm
+oZk
+oZk
+oZk
+xGn
+eNc
+oZk
+oZk
+hKk
+uJp
+uJp
+rCr
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+eIk
+dbQ
+rUt
+rUt
+gUD
+rUt
+rUt
+wTe
+wGz
+wGz
+bRL
+icF
+mWi
+orX
+bPe
+orX
+hMh
+pLp
+uej
+uej
+tUT
+uej
+uej
+pLp
+hMh
+vkK
+vkK
+pGV
+pGV
+iZx
+xfK
+xfK
+xfK
+xfK
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -56886,74 +58840,74 @@ diF
 diF
 fVF
 diF
-vzA
-vzA
-vzA
-vzA
-vzA
-spU
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+mcw
+bWs
+oZk
+jYc
+oZk
+xGn
+xlw
+oZk
+mrp
+drH
+drH
+drH
+drH
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+bvU
+xJn
+xJn
+xJn
+xJn
+icF
+icF
+cIM
+wGz
+wGz
+vlF
+icF
+vIB
+orX
+orX
+orX
+vkK
+fPs
+pLp
+uej
+dww
+uej
+pLp
+fPs
+vkK
+vkK
+vkK
+hLX
+bvU
+iZx
+iZx
+aNm
+aNm
+aNm
+xfK
+bvU
+bvU
+yfF
 pGV
 pGV
 pGV
@@ -57143,17 +59097,16 @@ yfo
 jyH
 qLS
 rXC
-diF
-diF
-vzA
-vzA
-vzA
+rXC
+rXC
+qVG
 spU
-aPY
-aPY
-aPY
-aPY
-aPY
+pVQ
+spU
+jYc
+fPX
+jYc
+drH
 pGV
 pGV
 pGV
@@ -57178,40 +59131,41 @@ pGV
 pGV
 pGV
 pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
+xJn
+xJn
+kvH
+kWq
+wGz
+wGz
+igb
+iKo
+nlZ
+gPj
+vVF
+gPj
+gPj
+vkK
+umh
+pLp
+pLp
+pLp
+pLp
+vkK
+vkK
+vkK
 pGV
 pGV
 pGV
+iZx
+xfK
+xfK
+xfK
+xfK
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
+yfF
+quI
 pGV
 pGV
 pGV
@@ -57401,10 +59355,10 @@ oRz
 juT
 cFI
 tzT
+rXC
 diF
-diF
-vzA
-vzA
+spU
+uaV
 spU
 spU
 spU
@@ -57414,6 +59368,7 @@ spU
 spU
 spU
 spU
+spU
 pGV
 pGV
 pGV
@@ -57434,40 +59389,39 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
+xJn
+wGz
+wGz
+gPj
+gPj
+gPj
+gPj
+nDi
+gPj
+bwl
+gPj
+gPj
+gPj
+vkK
+vkK
+jTo
+vkK
+vkK
+vkK
+vkK
 pGV
 pGV
 pGV
 pGV
+iZx
+xfK
+xfK
+xfK
 pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -57661,8 +59615,9 @@ vbY
 aqQ
 diF
 vzA
-vzA
+uaV
 pyu
+vzA
 vzA
 vzA
 vzA
@@ -57694,37 +59649,36 @@ pGV
 pGV
 pGV
 pGV
+gPj
+gPj
+gPj
+dpn
+fzB
+uiN
+uiN
+hNV
+vzU
+fSk
+gPj
+vkK
+vkK
+vkK
+vkK
+vkK
+ppo
 pGV
 pGV
 pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+iZx
+iZx
+iZx
+aNm
+aNm
+xfK
+bvU
+bvU
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -57917,8 +59871,8 @@ cFI
 uYa
 bOO
 diF
-vzA
-vzA
+uaV
+uaV
 spU
 vzA
 vzA
@@ -57927,6 +59881,7 @@ vzA
 vzA
 vzA
 vzA
+vzA
 spU
 pGV
 pGV
@@ -57952,35 +59907,34 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
+gPj
+gPj
+uZJ
+aVa
+lDi
+tXb
+gPj
+wSc
+cbF
+gPj
+vkK
+vkK
+vkK
+vkK
 pGV
 pGV
 pGV
 pGV
 pGV
+iZx
+xfK
+xfK
+xfK
+xfK
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -58174,7 +60128,7 @@ cFI
 vbY
 vbx
 diF
-pyu
+pVQ
 spU
 spU
 spU
@@ -58183,14 +60137,14 @@ spU
 spU
 spU
 spU
-miU
+dGt
 spU
-cJU
-cJU
-cJU
-cJU
-cJU
-cJU
+diF
+bPq
+bPq
+bPq
+bPq
+bPq
 pGV
 pGV
 pGV
@@ -58209,35 +60163,35 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+uzX
+gPj
+gPj
+pfm
+yli
+liN
+aVa
+urY
+ekE
+xQm
+gPj
+vkK
+fuu
+bPy
 pGV
 pGV
 pGV
 pGV
 pGV
 pGV
+iZx
+xfK
+xfK
+xfK
 pGV
 pGV
 pGV
 pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -58431,23 +60385,23 @@ cFI
 vbY
 uxa
 diF
-vzA
-vzA
-vzA
+uaV
+uaV
+uaV
 vzA
 vzA
 spU
-dgx
-dgx
-iZv
-fzb
-tuh
-bLM
-iZj
-xYX
-xMS
-teW
-cJU
+aNb
+aNb
+gzp
+qTK
+ddb
+nxA
+rEM
+dxL
+oml
+thH
+bPq
 pGV
 pGV
 pGV
@@ -58467,34 +60421,34 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
+nES
+nES
+nES
+nES
+nES
+iMX
+nES
+nES
+nES
+nES
+nES
+nES
+eEq
 pGV
 pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+iZx
+iZx
+iZx
+aNm
+aNm
+xfK
+bvU
+bvU
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -58690,21 +60644,21 @@ gqc
 diF
 vzA
 vzA
-vzA
+uaV
 vzA
 vzA
 spU
-dgx
-dgx
-bmS
-dKv
-hLZ
-xJK
-wFV
-wFV
-wFV
-wIX
-cJU
+aNb
+aNb
+jxm
+mUr
+fED
+bRx
+oAC
+oAC
+oAC
+wsZ
+bPq
 pGV
 pGV
 pGV
@@ -58725,32 +60679,32 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
+nES
+nES
+ygS
+lYV
+rZo
+lYV
+sRk
+kTZ
+nES
+nES
+nES
+nES
 pGV
 pGV
 pGV
 pGV
+iZx
+iZx
+xfK
+xfK
+xfK
+xfK
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
+yfF
 pGV
 pGV
 pGV
@@ -58945,23 +60899,23 @@ rXC
 rXC
 diF
 diF
-vzA
-vzA
-vzA
+uaV
+uaV
+uaV
 vzA
 vzA
 spU
-dgx
-dgx
-bmS
-rxT
-anz
-adi
-wFV
-wFV
-wFV
-pjN
-cJU
+aNb
+aNb
+jxm
+gvw
+ehe
+dDt
+oAC
+oAC
+oAC
+gsD
+bPq
 pGV
 pGV
 pGV
@@ -58982,25 +60936,23 @@ pGV
 pGV
 pGV
 pGV
+nES
+nES
+nES
+pmr
+rZo
+rZo
+gwl
+dzl
+nES
+qov
+nES
+nES
+nES
 pGV
 pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
+aNm
+xOR
 pGV
 pGV
 pGV
@@ -59008,6 +60960,8 @@ pGV
 pGV
 pGV
 pGV
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -59201,8 +61155,8 @@ dQb
 lnJ
 vZG
 soN
-vzA
-vzA
+uaV
+uaV
 vzA
 spU
 spU
@@ -59210,15 +61164,15 @@ spU
 spU
 lXP
 lXP
-tPc
-jnk
-eXa
-ceu
-qvS
-erQ
-vII
-qbj
-cJU
+tbc
+gfZ
+csi
+aJh
+bBl
+ilg
+iNg
+vnm
+bPq
 pGV
 pGV
 pGV
@@ -59240,31 +61194,31 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+nES
+nES
+nES
+vcS
+rZo
+eeZ
+lYV
+nES
+lYV
+vRH
+nES
+nES
+nES
+nES
+kaE
+xxc
+bSh
+bvU
+bvU
+bvU
+bvU
+bvU
+yfF
+yfF
+sTL
 pGV
 pGV
 pGV
@@ -59467,15 +61421,15 @@ tlv
 uqC
 rAR
 lXP
-bRE
+vqN
 lXP
-eXa
-anz
-anz
-fUi
-anz
-cJU
-cJU
+csi
+ehe
+ehe
+udc
+ehe
+bPq
+bPq
 pGV
 pGV
 pGV
@@ -59498,28 +61452,28 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+nES
+nES
+nES
+swv
+rZo
+rZo
+kQS
+wpg
+wpg
+sYF
+nES
+nES
+nES
+uvo
+xxc
 pGV
 pGV
 pGV
 pGV
 pGV
+yfF
+yfF
 pGV
 pGV
 pGV
@@ -59728,9 +61682,9 @@ rAR
 uqC
 pGV
 pGV
-anz
-tqV
-anz
+ehe
+vCK
+ehe
 pGV
 pGV
 pGV
@@ -59756,26 +61710,26 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-pGV
-pGV
-pGV
+nES
+nES
+nES
+bIi
+mhn
+nES
+pgB
+sJH
+rZo
+aky
+nES
+nES
+hZz
+xxc
+xxc
+bvU
+bvU
+eAm
+qHm
+yfF
 pGV
 pGV
 pGV
@@ -59985,9 +61939,9 @@ rAR
 uqC
 pGV
 pGV
-anz
-tqV
-anz
+ehe
+vCK
+ehe
 pGV
 pGV
 pGV
@@ -60013,26 +61967,26 @@ pGV
 pGV
 pGV
 pGV
+tnG
+nES
+nES
+nES
+nES
+nES
+gmr
+vwJ
+vho
+rZo
+aky
+uoO
+luB
+xxc
+xxc
+xxc
+xxc
+xxc
 pGV
 pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 pGV
 pGV
 pGV
@@ -60242,9 +62196,9 @@ rAR
 uqC
 pGV
 pGV
-anz
-sQR
-anz
+ehe
+lOA
+ehe
 pGV
 pGV
 pGV
@@ -60273,21 +62227,21 @@ pGV
 pGV
 pGV
 pGV
+nES
+nES
+nES
+nES
+nES
+aDO
+jrk
+uPR
+nES
+xxc
+xxc
+xxc
+xxc
 pGV
 pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
 pGV
 pGV
 pGV
@@ -60389,7 +62343,7 @@ ohv
 pGV
 pGV
 aPY
-iYY
+kjA
 mjd
 mjd
 mjd
@@ -60499,9 +62453,9 @@ uqC
 uqC
 pGV
 pGV
-fJK
-fgG
-fJK
+vtY
+rkD
+vtY
 pGV
 pGV
 pGV
@@ -60533,15 +62487,15 @@ pGV
 pGV
 pGV
 pGV
+nES
+nES
+nES
+nES
+nES
+nES
+xxc
 pGV
-pGV
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
-aPY
+nda
 pGV
 pGV
 pGV
@@ -60791,7 +62745,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+qVQ
 pGV
 pGV
 pGV
@@ -61515,7 +63469,7 @@ geB
 vCQ
 vCQ
 itf
-ojL
+uJy
 rAR
 rAR
 rAR
@@ -62701,8 +64655,8 @@ pqv
 mSP
 aQj
 snP
-bDk
-bDk
+iYY
+nLz
 nLz
 iGm
 snP
@@ -68392,7 +70346,7 @@ qee
 cPN
 oOF
 cOR
-dBH
+ntg
 rRA
 koY
 bxz
@@ -68648,7 +70602,7 @@ tEX
 tEX
 wzF
 xTC
-xJR
+nRg
 wJz
 pBS
 dQY
@@ -68910,7 +70864,7 @@ siS
 siS
 siS
 siS
-oCM
+enN
 xgd
 siS
 huS
@@ -69167,7 +71121,7 @@ tEX
 tEX
 sfi
 sfi
-oAX
+olY
 sfi
 sfi
 sfi
@@ -69918,18 +71872,18 @@ pGV
 pGV
 pGV
 gPn
-kys
 lCb
-npm
+lHx
+npn
 wAt
-oHQ
+piX
 wAt
-sCJ
-tCf
-uhb
-uBS
-vta
-xhF
+sPg
+tEV
+ukM
+uCE
+vCr
+jVS
 tEX
 kaq
 kaq
@@ -69939,7 +71893,7 @@ hKj
 wJz
 vpa
 wJz
-spS
+bDu
 vpa
 wJz
 ydW
@@ -70176,7 +72130,7 @@ pGV
 pGV
 gPn
 rrS
-lHx
+mIC
 wAt
 wAt
 rwS
@@ -70184,9 +72138,9 @@ wAt
 wCv
 wCv
 wCv
-uCE
+vjx
 wCv
-xuk
+bzI
 hKj
 hKj
 hKj
@@ -70433,9 +72387,9 @@ pGV
 pGV
 gPn
 rrS
-mIC
-npn
-okp
+mQa
+nTv
+opf
 rwS
 wAt
 wAt
@@ -70444,12 +72398,12 @@ wAt
 wAt
 wAt
 wCv
-xZY
+dKI
 wAt
 hWV
 ciy
 rrS
-hHw
+unJ
 mUI
 jIJ
 jky
@@ -70694,9 +72648,9 @@ bTE
 bTE
 bTE
 bTE
-qvq
+qzQ
 wAt
-lCb
+lHx
 wAt
 wAt
 wAt
@@ -70705,7 +72659,7 @@ wCv
 wCv
 wCv
 wCv
-ntH
+irA
 cmT
 wCv
 wCv
@@ -70946,24 +72900,24 @@ pGV
 pGV
 pGV
 gPn
-kys
 lCb
-npm
+lHx
+npn
 wAt
-piX
+pzv
 wAt
 wAt
 wAt
-ukM
-vjx
-vtY
+uBS
+vta
+vLl
 wAt
 wAt
 wAt
 wAt
 aXA
 rrS
-gym
+kyc
 geX
 aIT
 dqM
@@ -71204,7 +73158,7 @@ gPn
 gPn
 gPn
 rrS
-lHx
+mIC
 wAt
 wAt
 rwS
@@ -71213,15 +73167,15 @@ wAt
 wAt
 ahP
 wpJ
-vBQ
+vYj
 wAt
-vMM
-biH
+mnT
+oBx
 wAt
 ptx
 rrS
 rrS
-hJG
+jxW
 rrS
 rrS
 rrS
@@ -71461,13 +73415,13 @@ huc
 huc
 huc
 rrS
-mQa
-nTv
-okp
+ngU
+obd
+opf
 rwS
 wAt
 wAt
-tEV
+ucq
 wAt
 wAt
 wAt
@@ -71477,7 +73431,7 @@ wAt
 mZf
 bWb
 rrS
-sVz
+kYE
 cwt
 gzk
 akM
@@ -71722,7 +73676,7 @@ bTE
 bTE
 bTE
 bTE
-qzQ
+qMq
 wAt
 wAt
 wAt
@@ -71734,7 +73688,7 @@ wAt
 wAt
 krT
 rrS
-tKI
+vRO
 kBM
 gzk
 vQs
@@ -71974,11 +73928,11 @@ pGV
 pGV
 pGV
 pGV
-kys
 lCb
-npm
+lHx
+npn
 wAt
-piX
+pzv
 wAt
 wAt
 wAt
@@ -71987,11 +73941,11 @@ jwq
 wAt
 wAt
 wAt
-rbG
-bVX
-krH
+imx
+fCC
+tXF
 rrS
-vjC
+cGa
 vLW
 gzk
 sqj
@@ -72050,10 +74004,10 @@ xuA
 xuA
 xuA
 xuA
-fpm
+cZm
 xuA
 rAR
-vHR
+qoE
 lXP
 pGV
 pGV
@@ -72232,17 +74186,17 @@ pGV
 pGV
 pGV
 rrS
-lHx
+mIC
 wAt
 wAt
 bTE
 fuD
-sPg
+sRs
 fuD
 fuD
 bTE
 rwS
-xPC
+icm
 rwS
 rrS
 rrS
@@ -72310,7 +74264,7 @@ lXP
 lXP
 xuA
 xuA
-iVM
+wdo
 lXP
 pGV
 pGV
@@ -72489,20 +74443,20 @@ pGV
 pGV
 pGV
 rrS
-ngU
-obd
+npm
 okp
+opf
 fuD
 fVO
-sRs
-ucq
+tna
+udg
 xKX
 bTE
 jZU
 wAt
 wAt
-nQo
-mLI
+ycb
+cSJ
 rrS
 jEh
 pGV
@@ -72750,9 +74704,9 @@ fuD
 fuD
 fuD
 fuD
-qMq
+shb
 fVO
-tna
+tCf
 fVO
 bTE
 lQl
@@ -73005,14 +74959,14 @@ pGV
 fuD
 fVO
 fVO
-opf
-pzv
-shb
+ozo
+qvq
+ssP
 fVO
 fVO
 lPS
 bTE
-vCr
+wxE
 wAt
 wAt
 saw
@@ -73079,12 +75033,12 @@ xuA
 rAR
 rAR
 lXP
-tfj
-unA
-cPT
-pwy
-nBY
-xNC
+ter
+hkY
+hfa
+kpJ
+dpB
+wOZ
 lXP
 pGV
 pGV
@@ -73265,15 +75219,15 @@ fVO
 fVO
 fVO
 fVO
-tna
-udg
-ssP
+tCf
+uhb
+sCJ
 bTE
-vLl
+xaE
 wAt
 wAt
 wAt
-beH
+kzg
 rrS
 pGV
 pGV
@@ -73336,12 +75290,12 @@ xuA
 rAR
 rAR
 lXP
-qae
-odz
-bBK
-bBK
-uyx
-bGR
+aUN
+qEo
+eqR
+eqR
+lSV
+khJ
 lXP
 pGV
 pGV
@@ -73519,17 +75473,17 @@ pGV
 fuD
 fVO
 fVO
-ozo
+oHQ
 fVO
-ssP
+sCJ
 fVO
 fVO
 fVO
 bTE
-vYj
+xhF
 wAt
 wAt
-iow
+iWh
 wAt
 rrS
 pGV
@@ -73586,19 +75540,19 @@ rKD
 eQh
 lWu
 lXP
-fpm
+cZm
 lXP
 lXP
 xuA
 rAR
 rAR
 uqC
-wVR
-kzx
+jPo
+nVh
 aTP
-iSx
-jrk
-mTr
+ndd
+xgX
+nzY
 lXP
 pGV
 pGV
@@ -73783,8 +75737,8 @@ fuD
 fuD
 fuD
 rrS
-wxE
-xSh
+xuk
+lMG
 wAt
 wAt
 wAt
@@ -73850,12 +75804,12 @@ xuA
 rAR
 rAR
 uqC
-oNa
-kzx
+tYw
+nVh
 aTP
 aTP
 aTP
-gDn
+mqM
 lXP
 pGV
 pGV
@@ -74040,11 +75994,11 @@ pGV
 pGV
 pGV
 rrS
-xaE
-xTf
-hUY
+xPC
+pnf
+ild
 wAt
-mGh
+gon
 rrS
 pGV
 pGV
@@ -74107,16 +76061,16 @@ xuA
 rAR
 rAR
 lXP
-jNZ
-bqz
-tNp
-xJo
-rxb
-gPg
-gPm
-gPm
-gPm
-gPm
+tED
+ttd
+bhB
+tNN
+dvG
+tSN
+bue
+bue
+bue
+bue
 pGV
 pGV
 pGV
@@ -74363,17 +76317,17 @@ rAR
 xuA
 xuA
 xuA
-icH
-eQM
-rxb
-qAb
-jMD
-rxb
-gDn
-tfF
+aam
+xUu
+dvG
+seY
+eAF
+dvG
+mqM
+sEP
 rAR
 rAR
-jJC
+jaR
 pGV
 pGV
 pGV
@@ -74621,16 +76575,16 @@ rAR
 rAR
 rAR
 lXP
-iHl
-pqj
-agY
-hJp
-rxb
-gPg
-gPm
-gPm
-gPm
-gPm
+ejG
+haa
+mZR
+xRu
+dvG
+tSN
+bue
+bue
+bue
+bue
 pGV
 pGV
 pGV
@@ -74860,7 +76814,7 @@ gjk
 rmT
 qub
 hQE
-fGs
+sFC
 jdT
 mkX
 mkX
@@ -74878,11 +76832,11 @@ rAR
 rAR
 rAR
 uqC
-wnE
-eQM
+mzH
+xUu
 aTP
 aTP
-rxb
+dvG
 aTP
 lXP
 pGV
@@ -75104,7 +77058,7 @@ gaC
 gaC
 etK
 rmT
-pQE
+lVd
 rDM
 rmT
 rXt
@@ -75135,12 +77089,12 @@ rAR
 rAR
 rAR
 uqC
-wnE
-eQM
-rxb
-rxb
-pOC
-eKH
+mzH
+xUu
+dvG
+dvG
+goQ
+bvZ
 lXP
 pGV
 pGV
@@ -75357,11 +77311,11 @@ hTm
 hTm
 hTm
 luc
-qbu
-pll
-nyx
+aQW
+wno
+jdR
 rmT
-sOI
+jCn
 rmT
 rmT
 rmT
@@ -75392,12 +77346,12 @@ rAR
 rAR
 rAR
 lXP
-wnE
-soC
-uZl
-uZl
-ybU
-uUp
+mzH
+vut
+vOD
+vOD
+kRG
+dFm
 lXP
 pGV
 pGV
@@ -75614,9 +77568,9 @@ hTm
 hTm
 hTm
 luc
-fmO
-wlM
-qyt
+tLE
+rTj
+wrX
 rmT
 fbl
 fbl
@@ -75649,12 +77603,12 @@ rAR
 rAR
 rAR
 lXP
-meo
-syu
-krg
-kLE
-pMi
-xNC
+oVZ
+jOn
+anj
+qvM
+ouo
+wOZ
 lXP
 pGV
 pGV
@@ -75871,9 +77825,9 @@ mtv
 vcf
 hTm
 luc
-dqL
-isM
-cXP
+iyX
+adI
+kra
 rmT
 iXi
 iXi
@@ -75890,7 +77844,7 @@ fbl
 fbl
 fbl
 fbl
-keK
+bLZ
 fbl
 fbl
 fbl
@@ -76128,9 +78082,9 @@ luc
 luc
 luc
 luc
-tlJ
-tlJ
-tlJ
+oMI
+oMI
+oMI
 rmT
 iXi
 iXi

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -338,6 +338,16 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ars" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Shuttle Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/navbeacon/wayfinding,
+/turf/open/floor/iron,
+/area/space)
 "arK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -751,19 +761,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
-"aLs" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/navbeacon/wayfinding{
-	location = "Arrival Shuttle"
-	},
-/turf/open/floor/plating,
-/area/space)
 "aLK" = (
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/eighties,
@@ -855,6 +852,12 @@
 	},
 /turf/open/floor/wood,
 /area/service/library/printer)
+"aTI" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
+/turf/open/floor/iron,
+/area/space)
 "aTP" = (
 /turf/open/floor/iron,
 /area/maintenance/department/science/xenobiology)
@@ -1472,6 +1475,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"bBN" = (
+/obj/structure/sign/warning/gasmask{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/space)
 "bCc" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/requests_console/directional/west{
@@ -1626,6 +1635,13 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
+"bPC" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/space)
 "bPG" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -1647,13 +1663,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/vault,
 /area/command/bridge)
-"bPU" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/space)
 "bQt" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple{
@@ -1670,12 +1679,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"bTn" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/space)
 "bTr" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -1964,6 +1967,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"cjj" = (
+/obj/structure/chair/office/light{
+	color = "#990099";
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "cjD" = (
 /obj/machinery/button/door/directional/west{
 	id = "panic";
@@ -3682,12 +3692,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"dUa" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/space)
 "dUf" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/command/teleporter";
@@ -3743,12 +3747,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"dWJ" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/space)
 "dXC" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
@@ -3760,12 +3758,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/office)
-"dYk" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/iron,
-/area/space)
 "dYT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4425,6 +4417,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"eCT" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "eDb" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "plating"
@@ -4595,6 +4592,10 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"ePG" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/space)
 "ePM" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -5258,6 +5259,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"fvH" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/space)
 "fvI" = (
 /obj/machinery/light/floor,
 /obj/machinery/button/door/directional/north{
@@ -5292,6 +5299,12 @@
 "fwR" = (
 /turf/closed/wall,
 /area/service/hydroponics/upper)
+"fxs" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/space)
 "fxt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -5545,6 +5558,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fLp" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "fMq" = (
 /obj/structure/railing,
 /obj/structure/chair/stool/bar/directional/west,
@@ -5746,6 +5770,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/department/medical)
+"fXG" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "fYa" = (
 /obj/structure/table,
 /obj/item/toy/plush/fly,
@@ -6167,6 +6195,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
+"gvl" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/space)
 "gvn" = (
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Grenade testing"
@@ -6445,6 +6479,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"gOU" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/space)
 "gPn" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -6476,6 +6516,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
+"gQs" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/turf/open/floor/iron,
+/area/space)
 "gQC" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Security";
@@ -6551,12 +6597,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
-"gVQ" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
-/area/space)
 "gWN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -7190,6 +7230,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"hHv" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/space)
 "hIa" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
@@ -7326,6 +7370,12 @@
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
+"hSk" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
+/turf/open/floor/iron,
+/area/space)
 "hTm" = (
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -7839,6 +7889,12 @@
 "izc" = (
 /turf/closed/wall,
 /area/medical/abandoned)
+"izf" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/space)
 "izF" = (
 /obj/structure/railing{
 	dir = 6
@@ -7873,12 +7929,6 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron,
 /area/security/prison)
-"iCU" = (
-/obj/structure/sign/warning/docking{
-	pixel_x = 30
-	},
-/turf/open/space/basic,
-/area/space)
 "iDu" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -8481,12 +8531,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"jiN" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/space)
 "jiR" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -8512,16 +8556,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
-"jkV" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/navbeacon/wayfinding,
-/turf/open/floor/iron,
-/area/space)
 "jlc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -9515,6 +9549,19 @@
 /obj/machinery/recharger,
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
+"klI" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/navbeacon/wayfinding{
+	location = "Arrival Shuttle"
+	},
+/turf/open/floor/plating,
+/area/space)
 "kmb" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9625,12 +9672,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
-"krq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "krT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -9953,12 +9994,6 @@
 "kLx" = (
 /turf/open/openspace,
 /area/maintenance/department/science)
-"kNl" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
-/turf/open/floor/iron,
-/area/space)
 "kOm" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -11191,12 +11226,6 @@
 "mjd" = (
 /turf/open/openspace,
 /area/ai_monitored/command/storage/eva)
-"mjz" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/space)
 "mjY" = (
 /obj/machinery/power/generator,
 /turf/open/floor/plating,
@@ -11298,6 +11327,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"mom" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/space)
 "moI" = (
 /obj/machinery/door/airlock{
 	name = "Prison Restrooms"
@@ -11598,11 +11633,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/command)
-"mHN" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "mHT" = (
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet/lone/star,
@@ -11951,10 +11981,6 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/service/bar)
-"mYT" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/space)
 "mZf" = (
 /obj/machinery/computer/pandemic,
 /turf/open/floor/iron/dark,
@@ -12540,12 +12566,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"nEQ" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/turf/open/floor/iron,
-/area/space)
 "nFq" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -30
@@ -12693,11 +12713,6 @@
 /obj/item/ai_module/core/full/drone,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"nNf" = (
-/obj/structure/table,
-/obj/item/pickaxe/emergency,
-/turf/open/floor/iron,
-/area/space)
 "nNh" = (
 /obj/structure/cable,
 /obj/structure/railing{
@@ -13144,6 +13159,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/storage)
+"omZ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/space)
 "onP" = (
 /obj/structure/frame/computer,
 /obj/effect/turf_decal/tile/blue{
@@ -14332,6 +14353,12 @@
 	},
 /turf/open/floor/iron,
 /area/space)
+"pLQ" = (
+/obj/structure/sign/warning/docking{
+	pixel_x = 30
+	},
+/turf/open/space/basic,
+/area/space)
 "pMz" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -14378,13 +14405,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
-"pQU" = (
-/obj/structure/chair/office/light{
-	color = "#990099";
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "pRa" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -16136,6 +16156,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
+"rIg" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/space)
 "rIq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -17338,12 +17364,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
-"taZ" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/turf/open/floor/iron,
-/area/space)
 "tbn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -18740,10 +18760,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"uuG" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/space)
 "uvA" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/south,
@@ -18905,12 +18921,6 @@
 /obj/item/nullrod,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
-"uBr" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
-	},
-/turf/open/floor/iron,
-/area/space)
 "uBw" = (
 /obj/structure/punching_bag,
 /turf/open/floor/iron,
@@ -19245,13 +19255,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"uTJ" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	safety_mode = 1
-	},
-/turf/open/floor/iron,
-/area/space)
 "uTP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -19465,6 +19468,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/grass,
 /area/medical/virology)
+"vkO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "vkX" = (
 /obj/structure/chair/sofa/right{
 	desc = "Made of very expensive furs, probably from an endangered animal.";
@@ -19512,6 +19521,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
+"vog" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	safety_mode = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "voi" = (
 /turf/open/floor/iron/white,
 /area/medical/psychology)
@@ -19530,6 +19546,12 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"vpo" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/space)
 "vqw" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/item/radio/intercom/directional/south{
@@ -19702,12 +19724,6 @@
 "vzA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"vzO" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
-	},
-/turf/open/floor/iron,
-/area/space)
 "vAg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -19934,18 +19950,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"vLo" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "vLW" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
@@ -20344,6 +20348,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"wkF" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/space)
 "wkG" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -21065,10 +21075,6 @@
 /obj/item/circuitboard/computer/arcade/amputation,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
-"wWT" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "wZI" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -21137,6 +21143,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
+"xdg" = (
+/obj/structure/table,
+/obj/item/pickaxe/emergency,
+/turf/open/floor/iron,
+/area/space)
 "xeg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -21295,12 +21306,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
-"xsY" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/space)
 "xuk" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -21321,6 +21326,18 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"xvz" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "commonmining_home";
+	name = "SS13: Common Mining Dock";
+	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "xvB" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -21941,17 +21958,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
-"ydQ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "ydW" = (
 /turf/closed/wall,
 /area/maintenance/department/medical)
@@ -35857,9 +35863,9 @@ pGV
 pGV
 pGV
 pGV
-iCU
-vLo
-iCU
+pLQ
+xvz
+pLQ
 pGV
 pGV
 oAR
@@ -36119,7 +36125,7 @@ ohn
 tlJ
 tlJ
 tlJ
-uTJ
+vog
 tlJ
 tlJ
 pGV
@@ -36371,9 +36377,9 @@ tDG
 tDG
 wlM
 tlJ
-wWT
+fXG
 wlM
-nNf
+xdg
 tlJ
 nwc
 wlM
@@ -36628,12 +36634,12 @@ bVM
 bVM
 wlM
 tlJ
-mYT
+hHv
 wlM
-uuG
+ePG
 tlJ
 tlJ
-uTJ
+vog
 tlJ
 tlJ
 pGV
@@ -36886,7 +36892,7 @@ wlM
 wlM
 tlJ
 tlJ
-jkV
+ars
 tlJ
 tlJ
 wlM
@@ -37142,13 +37148,13 @@ wlM
 wlM
 wlM
 wlM
+bBN
+wlM
+bBN
 wlM
 wlM
 wlM
-wlM
-wlM
-wlM
-tlJ
+ePG
 tlJ
 aPY
 aPY
@@ -37406,7 +37412,7 @@ wlM
 wlM
 wlM
 tlJ
-aPY
+tlJ
 aPY
 aPY
 aPY
@@ -38939,10 +38945,10 @@ tDG
 tDG
 igc
 yin
-aLs
+klI
 wlM
-uBr
-xsY
+gvl
+omZ
 wlM
 wlM
 wlM
@@ -39198,8 +39204,8 @@ dsT
 dsT
 dsT
 wlM
-bTn
-gVQ
+fvH
+gOU
 wlM
 wlM
 wlM
@@ -39455,8 +39461,8 @@ cMd
 xsF
 wlM
 wlM
-dUa
-mjz
+fxs
+wkF
 wlM
 wlM
 tlJ
@@ -39712,8 +39718,8 @@ dsT
 qOW
 wlM
 wlM
-bPU
-vzO
+bPC
+aTI
 wlM
 wlM
 tlJ
@@ -39969,8 +39975,8 @@ dsT
 ykk
 wlM
 wlM
-nEQ
-jiN
+hSk
+rIg
 wlM
 tlJ
 tlJ
@@ -40223,11 +40229,11 @@ tDG
 tDG
 vIp
 cMd
-mHN
+eCT
 wlM
 wlM
-dYk
-dWJ
+mom
+vpo
 wlM
 tlJ
 aPY
@@ -40483,8 +40489,8 @@ dsT
 dsT
 dsT
 wlM
-kNl
-taZ
+izf
+gQs
 wlM
 tlJ
 aPY
@@ -40738,7 +40744,7 @@ tDG
 tDG
 igc
 yin
-aLs
+klI
 wlM
 wlM
 wlM
@@ -66966,7 +66972,7 @@ qjP
 xKn
 kpw
 ekD
-krq
+vkO
 wpL
 ycm
 qdZ
@@ -68252,7 +68258,7 @@ qub
 rGW
 cAt
 ekD
-pQU
+cjj
 rRv
 oxC
 sKP
@@ -72114,7 +72120,7 @@ oZc
 ocr
 xAn
 xAn
-ydQ
+fLp
 lWu
 lWu
 lWu

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -100,12 +100,16 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"agU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+"agD" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
 	},
 /turf/open/floor/iron,
 /area/space)
+"agU" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/department/security/upper)
 "aho" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/blue{
@@ -224,8 +228,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "anp" = (
-/turf/closed/wall/r_wall,
-/area/hallway/secondary/exit/departure_lounge)
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
+/obj/item/stack/spacecash/c1,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "anU" = (
 /obj/machinery/button/ticket_machine{
 	pixel_x = 24;
@@ -465,15 +473,9 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/workout)
 "axW" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "aza" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -756,15 +758,19 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "aLK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/item/stack/spacecash/c1,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "aMN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/psychology)
+"aNb" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/space)
 "aNf" = (
 /turf/open/floor/wood,
 /area/service/theater)
@@ -782,8 +788,8 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "aPY" = (
-/turf/open/space/basic,
-/area/maintenance/department/bridge)
+/turf/open/floor/engine/hull,
+/area/space)
 "aQd" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/camera/directional/north{
@@ -1064,7 +1070,9 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
 "bek" = (
-/obj/structure/industrial_lift,
+/obj/structure/industrial_lift{
+	id = "permaElevator"
+	},
 /obj/structure/railing{
 	dir = 9
 	},
@@ -1075,11 +1083,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "beo" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/jukebox/disco,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "bew" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
@@ -1143,9 +1149,6 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "biM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
@@ -1156,6 +1159,7 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "bjf" = (
@@ -1285,11 +1289,10 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "bqJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/table,
+/obj/item/storage/pill_bottle/happy,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "bqP" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -1390,17 +1393,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "byc" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/table,
+/obj/item/storage/pill_bottle/lsd,
+/obj/item/storage/fancy/rollingpapers,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "byn" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#4169E1";
@@ -1499,9 +1496,12 @@
 	},
 /area/medical/abandoned)
 "bCv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/table,
+/obj/item/food/grown/cannabis,
+/obj/item/food/grown/cannabis,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "bCZ" = (
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/structure/sign/warning/nosmoking/circle{
@@ -1706,8 +1706,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bVM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/space)
 "bVN" = (
 /obj/machinery/camera{
@@ -1751,6 +1753,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
+"bXw" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/space)
 "bZh" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -2077,13 +2085,12 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "cmX" = (
-/obj/docking_port/stationary/random{
-	dir = 2;
-	id = "pod_lavaland2";
-	name = "lavaland"
+/obj/machinery/door/airlock/maintenance{
+	name = "Long Abandoned Dance Hall"
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "cnc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -2504,10 +2511,7 @@
 /turf/open/floor/engine,
 /area/command/bridge)
 "cMd" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/space)
 "cNb" = (
 /obj/structure/curtain,
@@ -2550,9 +2554,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "cPN" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 9
+	},
+/obj/structure/industrial_lift{
+	id = "medbayElevator"
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
@@ -2609,11 +2615,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cQT" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/space)
 "cRi" = (
@@ -2639,11 +2641,13 @@
 /turf/open/floor/iron,
 /area/security/prison/upper)
 "cSL" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/machinery/light/floor,
+/obj/structure/industrial_lift{
+	id = "permaElevator"
+	},
 /turf/open/openspace,
 /area/security/prison/visit)
 "cSM" = (
@@ -2771,14 +2775,6 @@
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /turf/open/floor/wood,
 /area/service/bar)
-"cYl" = (
-/obj/machinery/firealarm/directional/north,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
 "cYE" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -2794,7 +2790,6 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "cZu" = (
-/obj/machinery/suit_storage_unit/rd,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 1;
@@ -2805,6 +2800,8 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/research_and_development,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "cZJ" = (
@@ -2968,12 +2965,6 @@
 /turf/open/openspace,
 /area/medical/medbay/lobby)
 "djQ" = (
-/obj/machinery/button/door/directional/north{
-	id = "abandonedmechbay";
-	name = "Mech Bay Shutters";
-	pixel_y = -24;
-	req_access_txt = "29"
-	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/science/research/abandoned)
@@ -3095,7 +3086,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "dpt" = (
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/space)
 "dpE" = (
@@ -3141,12 +3132,7 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "dsT" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space)
 "dsW" = (
@@ -3536,8 +3522,13 @@
 /turf/open/openspace,
 /area/hallway/primary/upper)
 "dNm" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/space)
 "dNB" = (
 /obj/structure/cable,
@@ -3618,6 +3609,12 @@
 	icon_state = "wood-broken6"
 	},
 /area/service/abandoned_gambling_den)
+"dQn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "dQu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3699,9 +3696,13 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "dUi" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/space/basic,
 /area/space)
 "dUu" = (
 /obj/machinery/camera/directional/south{
@@ -3958,16 +3959,16 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "ejl" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
-	width = 7
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
 	},
-/turf/open/space/basic,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
 /area/space)
 "ejy" = (
 /turf/open/floor/glass/reinforced,
@@ -4050,13 +4051,17 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "emJ" = (
-/obj/structure/table/glass,
-/obj/item/stamp/denied,
-/obj/item/stamp/rd,
-/obj/item/cartridge/signal/ordnance,
-/obj/item/cartridge/signal/ordnance,
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 2"
+	},
+/turf/open/floor/plating,
+/area/space)
 "enp" = (
 /obj/machinery/door/airlock/medical{
 	name = "Break Room";
@@ -4106,6 +4111,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"eom" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/navbeacon/wayfinding{
+	location = "Arrival Shuttle"
+	},
+/turf/open/floor/plating,
+/area/space)
 "eoE" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -4185,6 +4203,12 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/security/prison)
+"erV" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
+/turf/open/floor/iron,
+/area/space)
 "erX" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/tile{
@@ -4286,17 +4310,16 @@
 /turf/open/openspace,
 /area/hallway/primary/upper)
 "evr" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Arrivals Viewing Area";
-	name = "Hallway Camera"
+/obj/structure/railing{
+	dir = 6
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "evE" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/space)
 "evK" = (
@@ -4350,8 +4373,8 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/customs)
 "eAS" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -4383,10 +4406,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "eCd" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/massdriver_chapel,
-/turf/open/floor/plating,
-/area/service/chapel)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/space)
 "eCu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/stairs{
@@ -4469,6 +4493,17 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"eGB" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "eGJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5084,6 +5119,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison/work)
+"fnW" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/space)
 "foa" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
@@ -5247,18 +5288,19 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "fvW" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
+/obj/structure/table,
+/obj/item/food/grown/poppy,
+/obj/item/food/grown/poppy,
+/obj/item/food/grown/poppy,
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
+	pixel_y = 24
 	},
-/obj/machinery/navbeacon/wayfinding{
-	location = "Arrival Shuttle"
-	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "fvY" = (
 /obj/machinery/door/firedoor,
 /turf/open/openspace,
@@ -5448,15 +5490,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "fFA" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/sign/warning/docking{
+	pixel_y = -30
 	},
-/turf/open/floor/iron,
+/turf/open/space/basic,
 /area/space)
 "fGm" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/research_and_development,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
@@ -5467,6 +5506,7 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/structure/displaycase/labcage,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "fGt" = (
@@ -5645,6 +5685,7 @@
 /obj/item/coin/iron,
 /obj/item/coin/iron,
 /obj/item/coin/iron,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "fRE" = (
@@ -5843,11 +5884,16 @@
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "gfo" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/docking_port/stationary{
+	dwidth = 2;
+	height = 13;
+	id = "ferry_away";
+	json_key = "ferry";
+	name = "CentCom Ferry Dock";
+	width = 5
 	},
-/turf/open/floor/iron/dark,
-/area/service/chapel)
+/turf/open/space/basic,
+/area/space)
 "ggm" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
@@ -5985,6 +6031,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
+"gly" = (
+/obj/structure/table,
+/obj/item/pickaxe/emergency,
+/turf/open/floor/iron,
+/area/space)
 "glE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable,
@@ -5996,10 +6047,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
-"gmc" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/space)
 "gmG" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/grenades,
@@ -6177,8 +6224,13 @@
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
 "gxC" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "gxK" = (
 /obj/structure/noticeboard/directional/north,
@@ -6797,9 +6849,11 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "hna" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 10
+	},
+/obj/structure/industrial_lift{
+	id = "permaElevator"
 	},
 /turf/open/openspace,
 /area/security/prison/visit)
@@ -7211,7 +7265,6 @@
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
-/obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -7228,6 +7281,7 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "hNc" = (
@@ -7312,12 +7366,15 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "hUD" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/mass_driver/chapelgun{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "hUJ" = (
 /obj/machinery/flasher/directional/south{
 	id = "Cell 5"
@@ -7449,11 +7506,11 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "ibg" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "ibv" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
@@ -7504,8 +7561,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "igc" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
 /area/space)
 "igm" = (
 /obj/structure/chair{
@@ -7794,9 +7855,11 @@
 /turf/closed/wall,
 /area/medical/abandoned)
 "izF" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 6
+	},
+/obj/structure/industrial_lift{
+	id = "permaElevator"
 	},
 /turf/open/openspace,
 /area/security/prison/visit)
@@ -7863,6 +7926,7 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "iFU" = (
@@ -8008,9 +8072,14 @@
 /turf/open/floor/iron/white,
 /area/security/prison/toilet)
 "iNL" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "iOM" = (
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
@@ -8497,6 +8566,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"jow" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/turf/open/floor/iron,
+/area/space)
 "jpj" = (
 /obj/machinery/door/airlock/mining{
 	name = "Quartermaster's Office";
@@ -8520,11 +8595,9 @@
 /turf/open/floor/iron/checker,
 /area/maintenance/department/chapel)
 "jpX" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "jqx" = (
 /obj/structure/closet/secure_closet/bar,
 /obj/machinery/airalarm/directional/north,
@@ -8538,6 +8611,18 @@
 	icon_state = "wood-broken5"
 	},
 /area/service/abandoned_gambling_den)
+"jqL" = (
+/obj/structure/sign/warning/docking{
+	pixel_x = 30
+	},
+/turf/open/space/basic,
+/area/space)
+"jqQ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/space)
 "jqZ" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
@@ -8598,6 +8683,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
+"jsA" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/space)
 "jsP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -8782,6 +8873,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"jBO" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/space)
 "jCn" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -8809,7 +8904,6 @@
 	pixel_y = -36;
 	req_access_txt = "30"
 	},
-/obj/structure/displaycase/labcage,
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/rd)
 "jEh" = (
@@ -8852,10 +8946,14 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "jFK" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/space)
 "jFQ" = (
 /obj/structure/table,
@@ -9011,7 +9109,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "jME" = (
-/turf/open/floor/iron,
+/obj/docking_port/stationary/random{
+	dir = 4;
+	id = "pod_lavaland2";
+	name = "lavaland"
+	},
+/turf/open/space/basic,
 /area/space)
 "jMM" = (
 /turf/open/floor/grass,
@@ -9094,15 +9197,8 @@
 /turf/open/floor/iron/white,
 /area/service/theater)
 "jRe" = (
-/obj/docking_port/stationary{
-	dwidth = 2;
-	height = 13;
-	id = "ferry_away";
-	json_key = "ferry";
-	name = "CentCom Ferry Dock";
-	width = 5
-	},
-/turf/open/space/basic,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
 /area/space)
 "jRr" = (
 /turf/open/floor/iron/dark/smooth_large,
@@ -9335,6 +9431,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"kfW" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "kga" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9381,6 +9481,12 @@
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
+"kiw" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
+	},
+/turf/open/floor/iron,
+/area/space)
 "kiD" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/door/firedoor/border_only{
@@ -9487,7 +9593,7 @@
 	req_access_txt = "12"
 	},
 /turf/closed/wall,
-/area/maintenance/department/engine)
+/area/maintenance/department/chapel)
 "koh" = (
 /obj/machinery/computer/upload/borg,
 /obj/structure/window/reinforced{
@@ -9521,8 +9627,6 @@
 /area/command/heads_quarters/cmo)
 "kpw" = (
 /obj/structure/table/glass,
-/obj/item/clothing/mask/facehugger/toy,
-/obj/machinery/status_display/ai/directional/north,
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/purple{
@@ -9535,6 +9639,7 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/item/modular_computer/laptop,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "kqh" = (
@@ -9971,6 +10076,7 @@
 /area/security/range)
 "kUS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "kVq" = (
@@ -10070,9 +10176,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "kZU" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
-/turf/open/floor/iron,
+/obj/structure/railing/corner,
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "lan" = (
 /obj/structure/cable,
@@ -10104,11 +10212,12 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "lbU" = (
-/obj/structure/sign/warning/docking{
-	pixel_y = 30
+/obj/machinery/door/airlock/maintenance{
+	name = "Chapel Arrivals Connection";
+	req_access_txt = "12"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "lci" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/light/directional/north,
@@ -10392,16 +10501,8 @@
 /turf/open/floor/iron,
 /area/science/research/abandoned)
 "lxY" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
-	},
-/turf/open/space/basic,
+/obj/structure/railing/corner,
+/turf/open/floor/iron,
 /area/space)
 "lyl" = (
 /turf/open/openspace,
@@ -10458,6 +10559,10 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"lBd" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/space)
 "lBg" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple{
@@ -10541,6 +10646,12 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron,
 /area/engineering/lobby)
+"lEY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/space)
 "lFl" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/turf_decal/arrows/white{
@@ -10610,6 +10721,7 @@
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lHx" = (
@@ -10820,8 +10932,7 @@
 /turf/open/floor/iron,
 /area/maintenance/department/medical)
 "lSm" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
+/obj/structure/railing,
 /turf/open/floor/iron,
 /area/space)
 "lTi" = (
@@ -10832,9 +10943,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "lTl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/space)
 "lTD" = (
@@ -10851,6 +10960,12 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/medical/abandoned)
+"lTN" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/space)
 "lTX" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -10876,6 +10991,13 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
+"lUt" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/space)
 "lVl" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/mech_bay_power_console,
@@ -11140,6 +11262,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"mkH" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/space)
 "mkL" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -11477,9 +11605,9 @@
 /area/service/chapel)
 "mEG" = (
 /obj/structure/table,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron,
-/area/space)
+/obj/item/storage/box/bodybags,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "mET" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/effect/turf_decal/delivery,
@@ -11552,13 +11680,13 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "mJz" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chemistry Lab Maintenance";
-	req_access_txt = "12"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
+	},
 /turf/open/floor/iron/white,
-/area/hallway/secondary/exit/departure_lounge)
+/area/medical/chemistry)
 "mKt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -11609,16 +11737,11 @@
 /turf/open/floor/carpet/purple,
 /area/commons/dorms)
 "mNf" = (
-/obj/structure/window{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
+/turf/open/floor/iron,
+/area/space)
 "mNi" = (
 /obj/structure/chair{
 	dir = 1
@@ -11714,10 +11837,10 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hop)
 "mTh" = (
-/obj/structure/sign/warning/docking{
-	pixel_x = -30
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/space)
 "mTI" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
@@ -12074,12 +12197,11 @@
 /turf/open/floor/carpet/purple,
 /area/commons/dorms)
 "njX" = (
-/obj/structure/sign/plaques/kiddie/badger{
-	pixel_y = -28
+/obj/structure/railing{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
+/turf/open/floor/iron,
+/area/space)
 "nke" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/green,
@@ -12196,7 +12318,7 @@
 	dir = 1
 	},
 /obj/machinery/button/elevator{
-	id = "publicElevator";
+	id = "medbayElevator";
 	pixel_x = 25
 	},
 /obj/machinery/light/directional/east,
@@ -12270,11 +12392,12 @@
 	},
 /area/service/abandoned_gambling_den)
 "nrL" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
+/obj/structure/sign/plaques/kiddie/badger{
+	pixel_y = -28
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/iron/dark,
+/area/service/chapel)
 "nsK" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
@@ -12329,9 +12452,8 @@
 /turf/open/floor/plating,
 /area/engineering/lobby)
 "nwc" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron,
 /area/space)
 "nwy" = (
@@ -12451,6 +12573,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"nFe" = (
+/obj/structure/chair/office/light{
+	color = "#990099";
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "nFq" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -30
@@ -12470,10 +12599,8 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "nFw" = (
-/obj/structure/sign/warning/docking{
-	pixel_x = 30
-	},
-/turf/open/space/basic,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
 /area/space)
 "nGe" = (
 /obj/machinery/holopad/secure,
@@ -12483,12 +12610,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/breakroom)
-"nGX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/space)
 "nGZ" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -12537,6 +12658,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/work)
+"nIW" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	safety_mode = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "nJY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/blue{
@@ -12881,8 +13009,7 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
 "ogI" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/space)
 "ohh" = (
@@ -12892,7 +13019,12 @@
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "ohn" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Shuttle Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/space)
 "ohv" = (
@@ -13136,11 +13268,9 @@
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
 "oro" = (
-/obj/docking_port/stationary/random{
-	id = "pod_lavaland2";
-	name = "lavaland"
-	},
-/turf/open/space/basic,
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/iron,
 /area/space)
 "ott" = (
 /obj/structure/rack,
@@ -13235,12 +13365,15 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "oAR" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
-/turf/open/floor/iron,
+/turf/open/space/basic,
 /area/space)
 "oBZ" = (
 /obj/structure/window{
@@ -13436,13 +13569,18 @@
 /turf/open/floor/iron,
 /area/security/office)
 "oOs" = (
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	safety_mode = 1
+	},
+/turf/open/space/basic,
 /area/space)
 "oOF" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 10
+	},
+/obj/structure/industrial_lift{
+	id = "medbayElevator"
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
@@ -13946,7 +14084,7 @@
 /turf/closed/wall/r_wall,
 /area/medical/abandoned)
 "ptR" = (
-/obj/effect/spawner/random/vending/colavend,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/space)
 "pvR" = (
@@ -14225,9 +14363,7 @@
 /turf/open/floor/iron,
 /area/security/office)
 "pLD" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -14464,6 +14600,16 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
+"qeC" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Shuttle Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/navbeacon/wayfinding,
+/turf/open/floor/iron,
+/area/space)
 "qfc" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -14486,8 +14632,8 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/cargo)
 "qfR" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -14697,8 +14843,8 @@
 /turf/open/floor/iron/dark,
 /area/science/storage)
 "qrm" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
+/obj/structure/railing{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -14944,8 +15090,9 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "qER" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2,
+/obj/structure/railing/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/space)
 "qFm" = (
@@ -14964,9 +15111,11 @@
 /turf/open/floor/vault,
 /area/hallway/primary/upper)
 "qFs" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 5
+	},
+/obj/structure/industrial_lift{
+	id = "medbayElevator"
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
@@ -15011,7 +15160,8 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "qHq" = (
-/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/status_display/evac/directional/south,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/space)
 "qHw" = (
@@ -15094,11 +15244,10 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/supply)
 "qLX" = (
-/obj/machinery/computer/security/telescreen/rd{
-	dir = 8;
-	pixel_x = 30;
-	pixel_y = 3
+/obj/structure/chair/office/light{
+	dir = 4
 	},
+/obj/effect/landmark/start/research_director,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "qMq" = (
@@ -15144,8 +15293,7 @@
 /turf/open/floor/glass/reinforced,
 /area/security/interrogation)
 "qOW" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/space)
 "qQD" = (
@@ -15297,13 +15445,10 @@
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
 "qWQ" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
+/obj/machinery/light/directional/south,
+/obj/structure/sign/warning/docking{
+	pixel_y = -30
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/iron,
 /area/space)
 "qXk" = (
@@ -15368,12 +15513,8 @@
 /turf/open/floor/iron,
 /area/security/prison/work)
 "rbD" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
 /area/space)
 "rci" = (
 /turf/open/openspace,
@@ -15447,7 +15588,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rfv" = (
-/obj/item/kirbyplants/random,
+/obj/machinery/vending/coffee,
+/obj/machinery/camera/directional/south{
+	c_tag = "Arrivals N";
+	name = "Hallway Camera"
+	},
 /turf/open/floor/iron,
 /area/space)
 "rfC" = (
@@ -15632,7 +15777,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
 "roY" = (
-/obj/structure/table,
+/obj/machinery/disposal/bin,
+/obj/machinery/light/directional/south,
+/obj/structure/sign/warning/docking{
+	pixel_y = -30
+	},
 /turf/open/floor/iron,
 /area/space)
 "rpj" = (
@@ -15663,8 +15812,10 @@
 /area/security/office)
 "rpZ" = (
 /obj/structure/table/glass,
-/obj/item/stamp/denied,
-/obj/item/modular_computer/laptop,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 5
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -15676,6 +15827,12 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/item/stamp/rd{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/cartridge/signal/ordnance,
+/obj/item/cartridge/signal/ordnance,
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
 "rqJ" = (
@@ -16114,21 +16271,16 @@
 /turf/open/floor/iron/checker,
 /area/maintenance/department/chapel)
 "rOF" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/camera/directional/north{
-	c_tag = "Arrivals S";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/iron/white,
+/area/hallway/primary/upper)
 "rOW" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
+/obj/structure/railing{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
 	},
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/space)
 "rPq" = (
 /obj/structure/table/wood,
@@ -16180,6 +16332,10 @@
 "rRv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/chair/office/light{
+	color = "#990099";
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
@@ -16520,7 +16676,12 @@
 /turf/open/floor/plating/airless,
 /area/security/office)
 "shA" = (
-/obj/item/beacon,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/space)
 "siB" = (
@@ -16578,15 +16739,12 @@
 /turf/open/floor/plating,
 /area/engineering/atmospherics_engine)
 "sjt" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/openspace,
+/area/hallway/primary/upper)
 "sjv" = (
 /obj/effect/turf_decal/tile/random,
 /obj/effect/turf_decal/tile/random{
@@ -16659,7 +16817,9 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hop)
 "snQ" = (
-/turf/closed/wall/r_wall,
+/obj/structure/table,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/iron,
 /area/space)
 "soj" = (
 /obj/structure/cable,
@@ -16767,14 +16927,12 @@
 /turf/open/floor/carpet/blue,
 /area/commons/dorms)
 "swK" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/openspace,
+/area/hallway/primary/upper)
 "swO" = (
 /obj/structure/railing/corner,
 /turf/open/floor/wood,
@@ -16880,13 +17038,21 @@
 /turf/open/floor/iron,
 /area/holodeck/rec_center)
 "sDF" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/openspace,
+/area/hallway/primary/upper)
 "sDU" = (
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
+/area/space)
 "sEa" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/directional/west,
@@ -16944,6 +17110,11 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"sHk" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "sHG" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/ale,
@@ -16967,9 +17138,13 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/bridge)
 "sIV" = (
-/obj/structure/table,
-/obj/item/pickaxe/emergency,
-/turf/open/floor/iron,
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/openspace,
 /area/space)
 "sKa" = (
 /obj/structure/window{
@@ -17233,8 +17408,15 @@
 /turf/open/openspace,
 /area/hallway/primary/upper)
 "tdT" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/button/elevator{
+	id = "arrivalsElevator";
+	pixel_y = 25
 	},
 /turf/open/floor/iron,
 /area/space)
@@ -17251,12 +17433,13 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "tgs" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals N";
-	name = "Hallway Camera"
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "tgJ" = (
 /obj/machinery/disposal/bin,
@@ -17625,12 +17808,6 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
-"txS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/space)
 "tzh" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
@@ -17878,6 +18055,18 @@
 /obj/structure/frame/machine,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
+"tNs" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "commonmining_home";
+	name = "SS13: Common Mining Dock";
+	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "tNO" = (
 /obj/structure/chair{
 	dir = 8
@@ -17928,11 +18117,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "tQL" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
 	},
+/obj/machinery/light/floor,
 /turf/open/openspace,
-/area/commons/toilet)
+/area/space)
 "tQO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18075,14 +18265,17 @@
 /turf/open/floor/iron,
 /area/security/prison/work)
 "tWu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 3;
+	height = 15;
+	id = "arrivals_stationary";
+	name = "arrivals";
+	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	width = 7
 	},
-/obj/machinery/computer/pod/old/mass_driver_controller/chapelgun{
-	pixel_x = -24
-	},
-/turf/open/floor/iron/dark,
-/area/service/chapel)
+/turf/open/openspace,
+/area/space)
 "tWD" = (
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/green,
@@ -18269,21 +18462,19 @@
 /turf/open/floor/circuit/green,
 /area/maintenance/department/science)
 "udr" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
 	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/turf/open/floor/plating,
+/turf/open/openspace,
 /area/space)
 "udQ" = (
-/obj/effect/landmark/start/research_director,
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/machinery/computer/security/telescreen/rd{
+	dir = 8;
+	pixel_x = 30;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
@@ -18638,6 +18829,7 @@
 	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uxa" = (
@@ -18697,10 +18889,13 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/crew_quarters/dorms)
 "uzK" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "uAg" = (
 /obj/structure/table/wood/poker,
@@ -18774,6 +18969,7 @@
 	dir = 4;
 	name = "Medical blue corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "uBS" = (
@@ -18855,9 +19051,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "uIf" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/iron,
+/obj/structure/railing,
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "uIA" = (
 /obj/structure/industrial_lift/tram{
@@ -18897,8 +19095,11 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
 "uKN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/full,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/service/chapel)
 "uLq" = (
 /obj/effect/turf_decal/tile/purple{
@@ -18955,9 +19156,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "uOF" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 6
+	},
+/obj/structure/industrial_lift{
+	id = "medbayElevator"
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
@@ -19027,7 +19230,7 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "uSQ" = (
-/obj/machinery/rnd/server,
+/obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "uTb" = (
@@ -19202,13 +19405,6 @@
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/white,
 /area/security/prison/work)
-"vcJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
 "vcK" = (
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/captain)
@@ -19439,9 +19635,13 @@
 	},
 /area/service/abandoned_gambling_den)
 "vsX" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/space)
 "vta" = (
@@ -19570,7 +19770,7 @@
 /area/security/checkpoint/science/research)
 "vBH" = (
 /obj/structure/industrial_lift{
-	id = "publicElevator"
+	id = "permaElevator"
 	},
 /turf/open/openspace,
 /area/security/prison/visit)
@@ -19710,12 +19910,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science)
 "vIp" = (
-/obj/structure/table,
-/obj/item/food/grown/poppy,
-/obj/item/food/grown/poppy,
-/obj/item/food/grown/poppy,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
+/obj/structure/sign/warning/docking{
+	pixel_y = -30
+	},
+/turf/open/openspace,
+/area/space)
 "vIF" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -19749,9 +19948,10 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "vKa" = (
-/obj/structure/table,
-/obj/item/trash/cheesie,
-/turf/open/floor/iron,
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "vLl" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
@@ -20022,7 +20222,7 @@
 	dir = 1
 	},
 /obj/machinery/button/elevator{
-	id = "publicElevator";
+	id = "permaElevator";
 	pixel_x = 25
 	},
 /obj/machinery/light/directional/east,
@@ -20074,11 +20274,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wdf" = (
-/obj/structure/sign/warning/docking{
-	pixel_y = -30
+/obj/machinery/button/door/directional/west{
+	id = "abandonedmechbay";
+	name = "Mech Bay Shutters"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron,
+/area/science/research/abandoned)
 "wff" = (
 /obj/structure/lattice,
 /turf/open/openspace,
@@ -20126,9 +20327,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/captain)
 "whv" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/dry_ramen,
-/turf/open/floor/iron,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/structure/industrial_lift{
+	id = "arrivalsElevator"
+	},
+/turf/open/openspace,
 /area/space)
 "whU" = (
 /obj/structure/closet/crate/hydroponics,
@@ -20191,9 +20396,6 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics/upper)
 "wlM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/space)
 "wmg" = (
@@ -20391,10 +20593,9 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "wyc" = (
-/obj/structure/table,
-/obj/item/storage/box/bodybags,
-/turf/open/floor/iron/dark,
-/area/service/chapel)
+/obj/machinery/door/firedoor,
+/turf/open/openspace,
+/area/maintenance/starboard/aft)
 "wyI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -20413,11 +20614,13 @@
 /turf/open/floor/wood,
 /area/service/library/printer)
 "wzF" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/machinery/light/floor,
+/obj/structure/industrial_lift{
+	id = "medbayElevator"
+	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
 "wzI" = (
@@ -20535,8 +20738,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "wFs" = (
-/turf/open/floor/iron,
-/area/maintenance/department/security/upper)
+/obj/machinery/jukebox,
+/turf/open/floor/eighties,
+/area/maintenance/department/chapel)
 "wGe" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -20564,15 +20768,9 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "wGZ" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/space/basic,
+/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
 /area/space)
 "wHc" = (
 /obj/structure/cable,
@@ -20603,9 +20801,9 @@
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
 "wIC" = (
-/obj/machinery/door/airlock/medical{
-	name = "Chemistry";
-	req_access_txt = "69;33"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Chemistry Lab";
+	req_access_txt = "5; 33"
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -20685,9 +20883,11 @@
 /turf/open/openspace,
 /area/service/chapel)
 "wMF" = (
-/obj/structure/industrial_lift,
 /obj/structure/railing{
 	dir = 5
+	},
+/obj/structure/industrial_lift{
+	id = "permaElevator"
 	},
 /turf/open/openspace,
 /area/security/prison/visit)
@@ -20901,16 +21101,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xam" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/window{
-	name = "Holy Driver";
-	req_access_txt = "22"
-	},
-/obj/machinery/mass_driver/chapelgun{
-	dir = 8
-	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/service/chapel)
 "xaD" = (
 /obj/structure/table/wood,
@@ -21098,7 +21290,7 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "xsF" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/space)
 "xsP" = (
@@ -21387,7 +21579,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
 "xJZ" = (
-/turf/closed/wall/r_wall,
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/massdriver_chapel,
+/turf/open/floor/plating,
 /area/service/chapel)
 "xKn" = (
 /turf/closed/wall/r_wall,
@@ -21609,7 +21803,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "xTC" = (
 /obj/structure/industrial_lift{
-	id = "publicElevator"
+	id = "medbayElevator"
 	},
 /turf/open/openspace,
 /area/medical/medbay/zone2)
@@ -21873,7 +22067,11 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "ykk" = (
-/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/vending/coffee,
+/obj/machinery/camera/directional/north{
+	c_tag = "Arrivals S";
+	name = "Hallway Camera"
+	},
 /turf/open/floor/iron,
 /area/space)
 "ykv" = (
@@ -21883,6 +22081,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"ykw" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/space)
 "ykL" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/soda_cans/sodawater,
@@ -30768,9 +30972,9 @@ pGV
 pGV
 pGV
 pGV
-nFw
-lxY
-nFw
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -31024,11 +31228,11 @@ pGV
 pGV
 pGV
 pGV
-snQ
-snQ
-rOW
-snQ
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -31269,9 +31473,6 @@ pGV
 pGV
 pGV
 pGV
-gPn
-gPn
-gPn
 pGV
 pGV
 pGV
@@ -31280,12 +31481,15 @@ pGV
 pGV
 pGV
 pGV
-gPn
-snQ
-dNm
-jME
-sIV
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -31512,24 +31716,6 @@ pGV
 pGV
 pGV
 pGV
-snQ
-snQ
-snQ
-snQ
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-snQ
-snQ
-snQ
-snQ
-snQ
-snQ
-gPn
 pGV
 pGV
 pGV
@@ -31537,12 +31723,30 @@ pGV
 pGV
 pGV
 pGV
-gPn
-snQ
-sDF
-jME
-roY
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -31769,24 +31973,6 @@ pGV
 pGV
 pGV
 pGV
-snQ
-dpt
-jME
-jME
-jME
-aLK
-jME
-jME
-jME
-jME
-jME
-igc
-ykk
-lSm
-uIf
-roY
-snQ
-snQ
 pGV
 pGV
 pGV
@@ -31794,13 +31980,31 @@ pGV
 pGV
 pGV
 pGV
-snQ
-snQ
-snQ
-qWQ
-snQ
-snQ
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -32026,38 +32230,38 @@ pGV
 pGV
 pGV
 pGV
-snQ
-qHq
-jME
-jME
-jME
-jME
-jME
-jME
-jME
-jME
-jME
-igc
-jME
-jME
-jME
-jME
-ptR
-snQ
 pGV
 pGV
 pGV
 pGV
 pGV
 pGV
-wdf
-snQ
-ykk
-ptR
-jME
-jME
-mEG
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -32283,38 +32487,38 @@ pGV
 pGV
 pGV
 pGV
-snQ
-bVM
-dsT
-bVM
-rfv
-bqJ
-jME
-jME
-jME
-jME
-jME
-igc
-jME
-jME
-jME
-jME
-jME
-snQ
-lbU
 pGV
 pGV
 pGV
 pGV
 pGV
 pGV
-bVM
-jME
-jME
-jME
-jME
-tdT
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -32540,24 +32744,6 @@ pGV
 pGV
 pGV
 pGV
-gPn
-bVM
-yin
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-snQ
-oOs
-jME
-jME
-jME
-rfv
-bVM
 pGV
 pGV
 pGV
@@ -32565,14 +32751,32 @@ pGV
 pGV
 pGV
 pGV
-bVM
-rfv
-jME
-jME
-jME
-tdT
-snQ
-gPn
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -32797,10 +33001,6 @@ pGV
 pGV
 pGV
 pGV
-gPn
-bVM
-yin
-bVM
 pGV
 pGV
 pGV
@@ -32808,13 +33008,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-jME
-jME
-jME
-bVM
-bVM
-bVM
 pGV
 pGV
 pGV
@@ -32822,14 +33015,25 @@ pGV
 pGV
 pGV
 pGV
-bVM
-bVM
-bVM
-jME
-jME
-jME
-snQ
-gPn
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -33055,9 +33259,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-swK
-bVM
 pGV
 pGV
 pGV
@@ -33065,13 +33266,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-jME
-qfR
-jFK
-rbD
-yin
-sjt
 pGV
 pGV
 pGV
@@ -33079,14 +33273,24 @@ pGV
 pGV
 pGV
 pGV
-rbD
-yin
-fvW
-jME
-jME
-xsF
-snQ
-gPn
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -33312,9 +33516,6 @@ pGV
 pGV
 pGV
 pGV
-mTh
-pGV
-mTh
 pGV
 pGV
 pGV
@@ -33322,13 +33523,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-jME
-uzK
-cMd
-bVM
-bVM
-bVM
 pGV
 pGV
 pGV
@@ -33336,15 +33530,25 @@ pGV
 pGV
 pGV
 pGV
-bVM
-bVM
-bVM
-jME
-jME
-jME
-snQ
-snQ
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -33575,33 +33779,33 @@ pGV
 pGV
 pGV
 pGV
-wdf
-bVM
-bVM
-bVM
-bVM
-jME
-evE
-nwc
-jME
-xsF
-snQ
-lbU
 pGV
 pGV
 pGV
 pGV
 pGV
-wdf
-snQ
-iNL
-jME
-jME
-jME
-jME
-snQ
-jME
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -33832,17 +34036,6 @@ pGV
 pGV
 pGV
 pGV
-jRe
-rbD
-yin
-yin
-sjt
-jME
-hUD
-vsX
-jME
-ykk
-bVM
 pGV
 pGV
 pGV
@@ -33850,20 +34043,31 @@ pGV
 pGV
 pGV
 pGV
-bVM
-ptR
-jME
-jME
-jME
-jME
-cQT
-jME
-axW
-wGZ
 pGV
 pGV
 pGV
-cmX
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -34089,17 +34293,6 @@ pGV
 pGV
 pGV
 pGV
-wdf
-bVM
-bVM
-bVM
-bVM
-bCv
-jpX
-nrL
-agU
-tgs
-bVM
 pGV
 pGV
 pGV
@@ -34107,15 +34300,26 @@ pGV
 pGV
 pGV
 pGV
-bVM
-rOF
-jME
-bCv
-jME
-agU
-snQ
-lSm
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -34340,9 +34544,6 @@ pGV
 pGV
 pGV
 pGV
-nFw
-pGV
-nFw
 pGV
 pGV
 pGV
@@ -34350,29 +34551,32 @@ pGV
 pGV
 pGV
 pGV
-bVM
-jME
-eAS
-beo
-jME
-dUi
-snQ
-lbU
 pGV
 pGV
 pGV
 pGV
 pGV
-wdf
-snQ
-ogI
-jME
-jME
-jME
-jME
-snQ
-snQ
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -34597,9 +34801,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-byc
-bVM
 pGV
 pGV
 pGV
@@ -34607,13 +34808,11 @@ pGV
 pGV
 pGV
 pGV
-bVM
+pGV
+pGV
+pGV
+pGV
 jME
-qrm
-ibg
-bVM
-bVM
-bVM
 pGV
 pGV
 pGV
@@ -34621,16 +34820,21 @@ pGV
 pGV
 pGV
 pGV
-bVM
-bVM
-bVM
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 jME
-jME
-xsF
-snQ
-gPn
-pGV
-pGV
 pGV
 pGV
 pGV
@@ -34854,9 +35058,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-yin
-bVM
 pGV
 pGV
 pGV
@@ -34864,13 +35065,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-jME
-jME
-jME
-rbD
-yin
-sjt
 pGV
 pGV
 pGV
@@ -34878,15 +35072,25 @@ pGV
 pGV
 pGV
 pGV
-rbD
-yin
-fvW
-jME
-jME
-jME
-snQ
-snQ
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -35111,23 +35315,6 @@ pGV
 pGV
 pGV
 pGV
-bVM
-yin
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-snQ
-jME
-jME
-jME
-bVM
-bVM
-bVM
 pGV
 pGV
 pGV
@@ -35135,15 +35322,32 @@ pGV
 pGV
 pGV
 pGV
-bVM
-bVM
-bVM
-jME
-jME
-jME
-snQ
-qER
-snQ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -35367,45 +35571,45 @@ pGV
 pGV
 pGV
 pGV
-snQ
-bVM
-udr
-bVM
-rfv
-aLK
-jME
-jME
-jME
-jME
-jME
-igc
-jME
-jME
-jME
-jME
-rfv
-bVM
 pGV
 pGV
 pGV
-ejl
 pGV
 pGV
 pGV
-bVM
-rfv
-jME
-jME
-jME
-jME
-cQT
-jME
-axW
-wGZ
 pGV
 pGV
 pGV
-oro
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 pGV
 pGV
 pGV
@@ -35624,24 +35828,6 @@ pGV
 pGV
 pGV
 pGV
-snQ
-qHq
-jME
-jME
-jME
-jME
-jME
-jME
-jME
-jME
-jME
-igc
-jME
-jME
-jME
-jME
-jME
-bVM
 pGV
 pGV
 pGV
@@ -35649,16 +35835,34 @@ pGV
 pGV
 pGV
 pGV
-bVM
-jME
-jME
-jME
-jME
-jME
-snQ
-jME
-snQ
 pGV
+pGV
+pGV
+pGV
+pGV
+oAR
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
+pGV
+pGV
+pGV
+pGV
+pGV
+jqL
+tNs
+jqL
+pGV
+pGV
+oAR
 pGV
 pGV
 pGV
@@ -35881,24 +36085,6 @@ pGV
 pGV
 pGV
 pGV
-snQ
-dpt
-jME
-jME
-jME
-bqJ
-jME
-jME
-jME
-jME
-jME
-igc
-jME
-jME
-jME
-jME
-jME
-bVM
 pGV
 pGV
 pGV
@@ -35906,18 +36092,36 @@ pGV
 pGV
 pGV
 pGV
-bVM
-jME
-jME
-jME
-jME
+pGV
+pGV
+pGV
+tlJ
+tlJ
+oOs
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
+rOW
+tgs
+udr
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
 ohn
-snQ
-snQ
-snQ
-pGV
-pGV
-pGV
+tlJ
+tlJ
+tlJ
+nIW
+tlJ
+tlJ
 pGV
 pGV
 pGV
@@ -36138,43 +36342,43 @@ pGV
 pGV
 pGV
 pGV
-snQ
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-bVM
-snQ
-snQ
-snQ
-snQ
-cYl
-vcJ
-vcJ
-vcJ
-oAR
-snQ
-snQ
-snQ
-bVM
-bVM
-bVM
-snQ
-snQ
-snQ
-pLD
-vcJ
-vcJ
-vcJ
-vcJ
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+pGV
 tlJ
-pGV
-pGV
-pGV
-pGV
-pGV
+snQ
+wlM
+wlM
+tlJ
+wlM
+tDG
+tDG
+tlJ
+rOW
+sDU
+tQL
+uzK
+udr
+tlJ
+tDG
+tDG
+wlM
+tlJ
+kfW
+wlM
+gly
+tlJ
+nwc
+wlM
+wlM
+tlJ
 pGV
 pGV
 pGV
@@ -36404,34 +36608,34 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
 tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
+tlJ
+tlJ
+oOs
+tlJ
+tlJ
+wlM
 bVM
-fFA
+bVM
+tlJ
 gxC
 whv
 vKa
 kZU
 evr
-qOW
-bVM
-tDG
-tDG
-tDG
-tDG
-tDG
 tlJ
-pGV
-pGV
-pGV
-pGV
-pGV
+bVM
+bVM
+wlM
+tlJ
+lBd
+wlM
+jBO
+tlJ
+tlJ
+nIW
+tlJ
+tlJ
 pGV
 pGV
 pGV
@@ -36645,44 +36849,49 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+cMd
+cMd
+cMd
+cMd
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
 tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+tlJ
+tlJ
+tlJ
+tlJ
+tlJ
+nwc
+oro
 wlM
-jME
-jME
-jME
-jME
-jME
-gmc
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+wlM
+wlM
+wlM
+wlM
+wlM
+tlJ
+tlJ
+sIV
+vKa
+uIf
+tlJ
+tlJ
+wlM
+wlM
+wlM
+tlJ
+tlJ
+qeC
+tlJ
+tlJ
+wlM
+wlM
+oro
 tlJ
 pGV
 pGV
@@ -36714,20 +36923,15 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -36902,45 +37106,63 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+cMd
+cQT
 wlM
-jME
-jME
-shA
-jME
-jME
-gmc
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
+wlM
+wlM
+eAS
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
 tlJ
+tdT
+shA
+vsX
+tlJ
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+tlJ
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -36957,41 +37179,23 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37159,45 +37363,63 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+cMd
+dpt
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+wlM
+mNf
+mNf
+mNf
+mNf
+mNf
+mNf
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+wlM
+wlM
+lTl
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
 tlJ
-tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-nGX
-lTl
-lTl
-lTl
-lTl
-lTl
-txS
-tDG
-tDG
-tDG
-tDG
-tDG
-tlJ
-tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37212,43 +37434,25 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37416,45 +37620,63 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
+cMd
+dsT
+dNm
+dsT
+evE
+eCd
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+wlM
 tlJ
 tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
 tlJ
 tlJ
-gPn
+tlJ
+tlJ
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+wlM
+wlM
+lTl
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37469,43 +37691,25 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37673,45 +37877,63 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 gPn
-pGV
+dsT
+yin
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
 tlJ
+jRe
+wlM
+mTh
+mTh
+mTh
+mTh
+mTh
+mTh
+wlM
+wlM
+wlM
+qHq
+cMd
+cMd
+cMd
+dsT
+dsT
+dsT
+cMd
+cMd
+cMd
+wGZ
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
 tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tlJ
-tlJ
-pGV
-gPn
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37725,48 +37947,30 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37930,45 +38134,63 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
 gPn
+dsT
+yin
+dsT
 pGV
 pGV
+pGV
+pGV
+pGV
+pGV
+pGV
+dsT
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+qOW
+cMd
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+qOW
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
 tlJ
-tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tlJ
-tlJ
-pGV
-pGV
-gPn
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -37982,48 +38204,30 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -38188,6 +38392,9 @@ pGV
 pGV
 pGV
 pGV
+dsT
+dUi
+dsT
 pGV
 pGV
 pGV
@@ -38195,38 +38402,52 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
+dsT
+wlM
+wlM
+mNf
+mNf
+mNf
+mNf
+mNf
+mNf
+wlM
+wlM
+wlM
+evE
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+evE
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
 tlJ
-tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tlJ
-tlJ
-gPn
-pGV
-pGV
-gPn
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -38236,51 +38457,34 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -38455,70 +38659,52 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
+dsT
+wlM
+wlM
 tlJ
 tlJ
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
-tDG
 tlJ
 tlJ
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+tlJ
+tlJ
+wlM
+wlM
+dsT
+dsT
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+dsT
+dsT
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -38528,16 +38714,34 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -38708,41 +38912,56 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
+fFA
+dsT
+dsT
+dsT
+dsT
+wlM
+wlM
+mTh
+mTh
+mTh
+mTh
+mTh
+mTh
+wlM
+wlM
+igc
+yin
+jFK
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+igc
+yin
+eom
+wlM
+agD
+lEY
+wlM
+wlM
+wlM
+wlM
 tlJ
-tlJ
-tlJ
-tlJ
-tlJ
-tlJ
-tlJ
-tlJ
-tlJ
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -38752,49 +38971,34 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -38965,93 +39169,93 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+gfo
+igc
+yin
+yin
+jFK
+wlM
+wlM
+wlM
+wlM
+wlM
+nFw
+wlM
+ptR
+wlM
+wlM
+dsT
+dsT
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+dsT
+dsT
+wlM
+bXw
+ykw
+wlM
+wlM
+wlM
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+pGV
+pGV
+pGV
+pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -39222,93 +39426,93 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+fFA
+dsT
+dsT
+dsT
+dsT
+wlM
+wlM
+wlM
+wlM
+wlM
+ogI
+wlM
+wlM
+wlM
+wlM
+wlM
+qWQ
+cMd
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+vIp
+cMd
+xsF
+wlM
+wlM
+mkH
+jsA
+wlM
+wlM
+tlJ
+tlJ
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+pGV
+pGV
+pGV
+pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -39480,92 +39684,92 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+dsT
+wlM
+lxY
+njX
+njX
+njX
+njX
+njX
+pLD
+wlM
+wlM
+wlM
+rbD
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+qOW
+wlM
+wlM
+lUt
+erV
+wlM
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -39730,99 +39934,99 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+dsT
+ejl
+dsT
+pGV
+pGV
+pGV
+pGV
+aPY
+aPY
+aPY
+dsT
+wlM
+lSm
+tDG
+tDG
+tDG
+tDG
+tDG
+qfR
+wlM
+wlM
+wlM
+rfv
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+ykk
+wlM
+wlM
+kiw
+lTN
+wlM
+tlJ
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -39987,99 +40191,99 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+dsT
+yin
+dsT
+pGV
+pGV
+pGV
+pGV
+aPY
+aPY
+aPY
+dsT
+wlM
+lSm
+tDG
+tDG
+tDG
+tDG
+tDG
+qrm
+pLD
+wlM
+wlM
+roY
+cMd
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+vIp
+cMd
+sHk
+wlM
+wlM
+aNb
+fnW
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -40244,99 +40448,99 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+dsT
+yin
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
+dsT
+tlJ
+wlM
+lSm
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+qfR
+wlM
+dsT
+dsT
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+dsT
+dsT
+wlM
+jqQ
+jow
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -40500,50 +40704,50 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
+cMd
+dsT
+emJ
+dsT
+evE
+eAS
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+lSm
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+qfR
+wlM
+igc
+yin
+jFK
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+igc
+yin
+eom
+wlM
+wlM
+wlM
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
 qoL
 qoL
 qoL
@@ -40558,42 +40762,42 @@ qoL
 qoL
 qoL
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -40757,50 +40961,50 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
+cMd
+dpt
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+lSm
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+qfR
+wlM
+dsT
+dsT
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+dsT
+dsT
+wlM
+wlM
+wlM
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
 qoL
 xCi
 xCi
@@ -40815,42 +41019,42 @@ xCi
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -41014,50 +41218,50 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-pGV
-pGV
+cMd
+cQT
+wlM
+wlM
+wlM
+eCd
+wlM
+wlM
+wlM
+wlM
+wlM
+lTl
+wlM
+lSm
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+qfR
+wlM
+wlM
+evE
+dsT
+tDG
+tDG
+tDG
+tWu
+tDG
+tDG
+tDG
+dsT
+evE
+wlM
+wlM
+wlM
+wlM
+wlM
+tlJ
+aPY
+aPY
+aPY
+aPY
 qoL
 xCi
 xCi
@@ -41072,42 +41276,42 @@ xCi
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -41271,44 +41475,44 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-xJZ
-eCd
+cMd
+cMd
+cMd
+cMd
+cMd
 mXh
 unn
 unn
 unn
 unn
+unn
 mXh
+lbU
 mXh
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+qfR
+wlM
+wlM
+wlM
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+wlM
+wlM
+wlM
+wlM
+wlM
 qoL
 qoL
 qoL
@@ -41329,42 +41533,42 @@ unr
 rVz
 qoL
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -41535,37 +41739,37 @@ pGV
 pGV
 xJZ
 uKN
+hUD
+iNL
+evK
+evK
+nKI
+nKI
 mXh
-evK
-evK
-evK
-evK
-njX
 mXh
-pGV
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-pGV
-gPn
-pGV
-pGV
-gPn
-pGV
-pGV
+mXh
+bVM
+bVM
+bVM
+bVM
+qER
+wlM
+wlM
+wlM
+dsT
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+tDG
+dsT
+wlM
+wlM
+wlM
+wlM
+wlM
 qoL
 xCi
 xCi
@@ -41586,42 +41790,42 @@ unr
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -41778,6 +41982,11 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -41785,21 +41994,16 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-xJZ
-uKN
 mXh
+fvW
+ibg
 nKI
 nKI
 nKI
 nKI
-wyc
-mXh
-mXh
+nKI
+mEG
+nrL
 dim
 dim
 dim
@@ -41814,10 +42018,10 @@ dim
 dim
 dim
 dim
-pGV
-pGV
-pGV
-gPn
+dim
+dim
+dim
+dim
 qoL
 nDx
 nDx
@@ -41843,42 +42047,42 @@ unr
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -42034,24 +42238,24 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-xJZ
+mXh
 xam
-tWu
-gPA
 nKI
+gPA
+jpX
 qxf
 nKI
 nKI
@@ -42064,17 +42268,17 @@ esk
 esk
 esk
 esk
-xyH
+dim
 esk
 esk
 esk
 esk
 esk
 dim
-pGV
-pGV
-pGV
-gPn
+esk
+esk
+esk
+esk
 qoL
 wrT
 wrT
@@ -42100,34 +42304,34 @@ unr
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -42290,24 +42494,24 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-xJZ
-mNf
-gfo
-sDU
+mXh
+nKI
+nKI
+nKI
 nKI
 gKb
 nKI
@@ -42321,17 +42525,17 @@ esk
 esk
 esk
 esk
-dim
+xyH
 esk
 esk
 esk
 esk
 esk
 dim
-pGV
-pGV
-pGV
-gPn
+esk
+esk
+esk
+esk
 qoL
 hPH
 hPH
@@ -42357,33 +42561,33 @@ unr
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -42547,8 +42751,8 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+aPY
+aPY
 fyK
 fyK
 fyK
@@ -42561,8 +42765,8 @@ fyK
 fyK
 fyK
 fyK
-xJZ
-vIp
+mXh
+nKI
 nKI
 nKI
 nKI
@@ -42587,8 +42791,8 @@ esk
 dim
 dim
 dim
+esk
 dim
-qoL
 qoL
 hPH
 hPH
@@ -42614,32 +42818,32 @@ unr
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -42804,8 +43008,8 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+aPY
+aPY
 fyK
 xXh
 xXh
@@ -42845,7 +43049,7 @@ esk
 esk
 esk
 esk
-xCi
+esk
 qoL
 hPH
 hPH
@@ -42871,31 +43075,31 @@ unr
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -43061,8 +43265,8 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+aPY
+aPY
 fyK
 bzZ
 xXh
@@ -43102,7 +43306,7 @@ esk
 esk
 esk
 esk
-xCi
+esk
 rVz
 hPH
 hPH
@@ -43128,19 +43332,19 @@ xCi
 xCi
 xCi
 qoL
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -43318,8 +43522,8 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+aPY
+aPY
 fyK
 eCu
 eCu
@@ -43575,8 +43779,8 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+aPY
+aPY
 fyK
 rff
 cyo
@@ -43832,8 +44036,8 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+aPY
+aPY
 fyK
 jUs
 cyo
@@ -43917,9 +44121,9 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -44090,7 +44294,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 fyK
 xsP
 cyo
@@ -44174,9 +44378,9 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -44431,9 +44635,9 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -44677,21 +44881,21 @@ mzk
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -44943,12 +45147,12 @@ kDk
 kDk
 kDk
 kDk
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -45205,7 +45409,7 @@ kDk
 kDk
 kDk
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -45462,7 +45666,7 @@ kcK
 kcK
 kcK
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -45719,7 +45923,7 @@ kcK
 kcK
 kcK
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -45976,7 +46180,7 @@ kcK
 kcK
 kcK
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -46233,7 +46437,7 @@ kDk
 kDk
 kDk
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -46485,12 +46689,12 @@ jGB
 hnV
 mde
 kDk
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -46912,9 +47116,9 @@ bHy
 bHy
 bHy
 bHy
+agU
 bHy
-bHy
-bHy
+agU
 dim
 dim
 dim
@@ -46951,7 +47155,7 @@ dim
 esk
 dim
 dim
-tgV
+sjt
 giv
 hAo
 giv
@@ -47170,10 +47374,10 @@ tty
 tty
 tty
 bHy
-wFs
-wFs
-wFs
-wFs
+hCh
+hCh
+hCh
+bqJ
 dim
 wNH
 wNH
@@ -47206,9 +47410,9 @@ upd
 wTP
 ppi
 wJS
-tQL
-xMa
-tgV
+wJS
+rOF
+swK
 giv
 hAo
 giv
@@ -47428,9 +47632,9 @@ tty
 tty
 bHy
 wFs
-wFs
-wFs
-wFs
+hCh
+hCh
+byc
 dim
 wNH
 wNH
@@ -47463,9 +47667,9 @@ qui
 fpE
 wJS
 wJS
-tQL
-xMa
-tgV
+wJS
+rOF
+swK
 hAo
 tgV
 hAo
@@ -47684,10 +47888,10 @@ bHy
 bHy
 ocV
 bHy
-bHy
-bHy
-wFs
-wFs
+hCh
+hCh
+aLK
+bCv
 dim
 wNH
 wNH
@@ -47720,9 +47924,9 @@ duu
 wTP
 wJS
 wJS
-tQL
-xMa
-tgV
+wJS
+rOF
+swK
 hAo
 tgV
 hAo
@@ -47940,12 +48144,12 @@ tty
 tty
 tty
 tty
-tty
-tty
 bHy
-wFs
-wFs
-dim
+anp
+hCh
+hCh
+hCh
+cmX
 wNH
 wNH
 xvL
@@ -47977,9 +48181,9 @@ wTP
 wTP
 qRH
 sLk
-tQL
-xMa
-tgV
+wJS
+rOF
+swK
 giv
 tgV
 giv
@@ -48197,11 +48401,11 @@ clD
 clD
 clD
 clD
-clD
-tty
 bHy
-wFs
-wFs
+hCh
+aLK
+beo
+aLK
 dim
 wNH
 wNH
@@ -48234,9 +48438,9 @@ luj
 avS
 avS
 pPX
-tQL
-xMa
-tgV
+wJS
+rOF
+swK
 giv
 tgV
 giv
@@ -48454,11 +48658,11 @@ bHy
 bHy
 bHy
 tty
-clD
-tty
 bHy
-wFs
-wFs
+hCh
+hCh
+aLK
+hCh
 dim
 wNH
 wNH
@@ -48493,7 +48697,7 @@ avS
 pPX
 wTP
 xMa
-tgV
+sDF
 hAo
 tgV
 hAo
@@ -48711,11 +48915,11 @@ tty
 tty
 bHy
 tty
-clD
-tty
 bHy
-bHy
-bHy
+axW
+hCh
+hCh
+aLK
 dim
 wNH
 wNH
@@ -48947,18 +49151,18 @@ rTd
 rTd
 yjj
 gZM
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+tDG
+tDG
+tDG
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 bHy
 bHy
 crB
@@ -48968,12 +49172,12 @@ tty
 tty
 bHy
 tty
-clD
-tty
-tty
+bHy
+bHy
+bHy
 dim
-wNH
-wNH
+dim
+dim
 wNH
 wNH
 dim
@@ -49204,8 +49408,8 @@ mIf
 mIf
 uhS
 gZM
-pGV
-pGV
+tDG
+tDG
 tor
 tor
 tor
@@ -49569,12 +49773,12 @@ mde
 mde
 mde
 kDk
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -49704,10 +49908,10 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
 ohv
 gpo
 fEO
@@ -49831,7 +50035,7 @@ kDk
 kDk
 kDk
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -49961,10 +50165,10 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
 ohv
 caU
 tNO
@@ -50088,7 +50292,7 @@ kcK
 kcK
 kcK
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -50214,14 +50418,14 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 ohv
 hei
 aKO
@@ -50345,7 +50549,7 @@ kcK
 kcK
 kcK
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -50471,14 +50675,14 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 ohv
 qZq
 isg
@@ -50602,7 +50806,7 @@ kcK
 kcK
 kcK
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -50728,14 +50932,14 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 ohv
 oGc
 gpo
@@ -50859,7 +51063,7 @@ kDk
 kDk
 kDk
 kDk
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -50985,14 +51189,14 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 ohv
 mNl
 eis
@@ -51111,12 +51315,12 @@ kDk
 kDk
 kDk
 kDk
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51242,15 +51446,15 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 mNl
 aXM
 oic
@@ -51311,7 +51515,7 @@ dId
 dId
 grb
 egs
-wPj
+wGs
 wPj
 wPj
 wPj
@@ -51359,21 +51563,21 @@ kRd
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51500,11 +51704,11 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 wRO
 wRO
 wRO
@@ -51568,8 +51772,8 @@ dId
 dId
 dId
 hIn
-hIn
-hIn
+wGs
+wGs
 wGs
 wGs
 wGs
@@ -51616,21 +51820,21 @@ kRd
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51757,11 +51961,11 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 wRO
 rMx
 rkV
@@ -51827,8 +52031,8 @@ dId
 hIn
 hIn
 hIn
-wGs
-wGs
+hIn
+hIn
 wGs
 wPj
 bCl
@@ -51873,21 +52077,21 @@ kRd
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52014,11 +52218,11 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 wRO
 cKD
 rkV
@@ -52084,8 +52288,8 @@ dId
 hIn
 hIn
 hIn
-wGs
-wGs
+hIn
+hIn
 wGs
 wPj
 bCl
@@ -52130,21 +52334,21 @@ kRd
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52271,11 +52475,11 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 wRO
 wUN
 rkV
@@ -52339,10 +52543,10 @@ dId
 dId
 dId
 egs
-wPj
 wGs
 wGs
-wGs
+hIn
+hIn
 wGs
 wPj
 bCl
@@ -52387,21 +52591,21 @@ kRd
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52528,11 +52732,11 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 wRO
 emF
 rkV
@@ -52598,8 +52802,8 @@ iSG
 egs
 wPj
 wGs
-wGs
-wGs
+hIn
+hIn
 wGs
 wPj
 bCl
@@ -52644,21 +52848,21 @@ kRd
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52785,8 +52989,8 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
+aPY
+aPY
 ohv
 ohv
 ohv
@@ -52901,21 +53105,21 @@ kRd
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53041,9 +53245,9 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 ohv
 dbd
 ttg
@@ -53158,21 +53362,21 @@ tKw
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53298,9 +53502,9 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 ohv
 dND
 pWx
@@ -53415,25 +53619,25 @@ tKw
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53672,27 +53876,27 @@ tKw
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53929,27 +54133,27 @@ iQG
 iQG
 iQG
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54186,27 +54390,27 @@ tKw
 tKw
 tKw
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54439,29 +54643,29 @@ tKw
 mAU
 mAU
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54696,17 +54900,17 @@ tKw
 tKw
 mzk
 tKw
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54953,17 +55157,17 @@ spU
 diy
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55221,9 +55425,9 @@ spU
 spU
 spU
 spU
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55478,9 +55682,9 @@ vzA
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55735,11 +55939,11 @@ vzA
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55992,11 +56196,11 @@ vzA
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -56249,11 +56453,11 @@ diF
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -56506,11 +56710,11 @@ diF
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -56763,11 +56967,11 @@ diF
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57022,14 +57226,14 @@ spU
 spU
 spU
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57279,14 +57483,14 @@ vzA
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57536,14 +57740,14 @@ vzA
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57793,14 +57997,14 @@ vzA
 vzA
 vzA
 spU
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58051,13 +58255,13 @@ diF
 diF
 gLH
 pVi
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58309,12 +58513,12 @@ xSC
 tlv
 pVi
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58568,9 +58772,9 @@ pVi
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58825,9 +59029,9 @@ pVi
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -59082,9 +59286,9 @@ pVi
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -59231,13 +59435,13 @@ aKO
 ohv
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 dbm
 ggJ
 ggJ
@@ -59488,7 +59692,7 @@ nmv
 ohv
 pGV
 pGV
-pGV
+aPY
 dbm
 cgN
 cgN
@@ -59745,7 +59949,7 @@ ohv
 ohv
 pGV
 pGV
-pGV
+aPY
 dbm
 qFW
 qIs
@@ -60002,7 +60206,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 dbm
 qIs
 cgN
@@ -60106,7 +60310,7 @@ pVi
 pVi
 pVi
 pVi
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -60259,7 +60463,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 dbm
 pRG
 qIs
@@ -60359,11 +60563,11 @@ vCQ
 vCQ
 itf
 pTQ
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -60534,10 +60738,10 @@ eQU
 fpU
 amz
 csg
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
 pKN
 llc
 llc
@@ -60619,8 +60823,8 @@ pTQ
 pTQ
 pTQ
 pTQ
-pGV
-pGV
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -60794,7 +60998,7 @@ lIj
 lIj
 lIj
 lIj
-pGV
+aPY
 pKN
 llc
 llc
@@ -60876,8 +61080,8 @@ fsU
 rTA
 tHE
 uqC
-pGV
-pGV
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -61051,7 +61255,7 @@ nCu
 sky
 rgA
 lIj
-pGV
+aPY
 pKN
 jFr
 jFr
@@ -61133,8 +61337,8 @@ fsU
 hKm
 rws
 uqC
-pGV
-pGV
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -61308,7 +61512,7 @@ nRb
 sky
 tXU
 lIj
-pGV
+aPY
 wcJ
 qRR
 qRR
@@ -61390,8 +61594,8 @@ fsU
 kig
 rws
 uqC
-pGV
-pGV
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -61565,7 +61769,7 @@ hWS
 sky
 tXU
 lIj
-pGV
+aPY
 wcJ
 ydW
 ydW
@@ -61647,8 +61851,8 @@ pTQ
 pTQ
 pTQ
 pTQ
-pGV
-pGV
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -61822,7 +62026,7 @@ lVF
 sky
 iMy
 lIj
-pGV
+aPY
 wcJ
 pIW
 pIW
@@ -61901,14 +62105,14 @@ nVN
 kcJ
 pTQ
 pTQ
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -62079,7 +62283,7 @@ sln
 ubq
 owG
 lIj
-pGV
+aPY
 wcJ
 pIW
 pIW
@@ -62163,9 +62367,9 @@ uTX
 uTX
 uTX
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -62336,7 +62540,7 @@ sln
 sln
 sln
 lIj
-pGV
+aPY
 wcJ
 pIW
 pIW
@@ -62420,9 +62624,9 @@ aol
 aol
 aol
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -62593,7 +62797,7 @@ oMR
 dQa
 vDv
 lIj
-pGV
+aPY
 wcJ
 ydW
 ydW
@@ -62677,9 +62881,9 @@ aol
 hnC
 wof
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -62850,7 +63054,7 @@ lIj
 lIj
 lIj
 lIj
-pGV
+aPY
 wcJ
 hCc
 hCc
@@ -62934,9 +63138,9 @@ vNV
 wcV
 aol
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -63107,7 +63311,7 @@ hqd
 ubA
 nhK
 lIj
-pGV
+aPY
 wcJ
 hCc
 hCc
@@ -63191,9 +63395,9 @@ uTX
 uTX
 uTX
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -63364,7 +63568,7 @@ vcK
 whj
 tqs
 lIj
-pGV
+aPY
 wcJ
 kRi
 ydW
@@ -63448,9 +63652,9 @@ aol
 aol
 aol
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -63621,7 +63825,7 @@ hqd
 hqd
 lIj
 lIj
-pGV
+aPY
 wcJ
 rHj
 ydW
@@ -63705,9 +63909,9 @@ aol
 aol
 wof
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -63878,7 +64082,7 @@ nuW
 nuW
 lIj
 pGV
-pGV
+aPY
 wcJ
 rHj
 ydW
@@ -63962,9 +64166,9 @@ vNV
 rSr
 aol
 uTX
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -64219,10 +64423,10 @@ uTX
 uTX
 uTX
 uTX
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -64476,10 +64680,10 @@ aol
 aol
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -64733,10 +64937,10 @@ aol
 aol
 wof
 uTX
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -64990,10 +65194,10 @@ vNV
 riU
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -65248,9 +65452,9 @@ uTX
 uTX
 uTX
 wxJ
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -65505,9 +65709,9 @@ tnh
 rtP
 uPp
 wxJ
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -65762,9 +65966,9 @@ cod
 cod
 cod
 wxJ
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -66019,9 +66223,9 @@ mCd
 wPJ
 cod
 wxJ
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -66276,9 +66480,9 @@ cRr
 cod
 uPp
 wxJ
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -66533,9 +66737,9 @@ uTX
 uTX
 uTX
 wxJ
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -66703,7 +66907,7 @@ kKL
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 bdb
 fin
@@ -66762,7 +66966,7 @@ qjP
 xKn
 kpw
 ekD
-ekD
+dQn
 wpL
 ycm
 qdZ
@@ -66789,17 +66993,17 @@ aol
 aol
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -66960,7 +67164,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 bTr
 rWM
@@ -67046,17 +67250,17 @@ aol
 aol
 wof
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -67217,7 +67421,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 dyn
 rWM
@@ -67303,17 +67507,17 @@ vNV
 jPL
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -67474,7 +67678,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 onP
 rWM
@@ -67560,17 +67764,17 @@ uTX
 uTX
 uTX
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -67731,7 +67935,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 bTr
 rWM
@@ -67791,7 +67995,7 @@ nTw
 pVF
 ekD
 ekD
-emJ
+par
 par
 iib
 jre
@@ -67817,20 +68021,20 @@ aol
 aol
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -67988,7 +68192,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 jWj
 rWM
@@ -68048,7 +68252,7 @@ qub
 rGW
 cAt
 ekD
-ekD
+nFe
 rRv
 oxC
 sKP
@@ -68074,20 +68278,20 @@ aol
 aol
 wof
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -68245,7 +68449,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 ckD
 uwi
@@ -68331,20 +68535,20 @@ vNV
 ukt
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -68502,7 +68706,7 @@ pGV
 pGV
 pGV
 pGV
-pGV
+aPY
 ptC
 ptC
 ptC
@@ -68588,17 +68792,17 @@ uTX
 uTX
 uTX
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -68759,20 +68963,20 @@ pGV
 pGV
 pGV
 pGV
-pGV
-gPn
-huc
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 tEX
 kaq
 kaq
@@ -68845,17 +69049,17 @@ aol
 aol
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -69018,13 +69222,13 @@ pGV
 pGV
 pGV
 gPn
-huc
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 rrS
 rrS
 rrS
@@ -69058,7 +69262,7 @@ urO
 qsd
 pOZ
 eGJ
-pOZ
+wdf
 ksi
 iXi
 fbl
@@ -69102,17 +69306,17 @@ aol
 szG
 wof
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -69275,13 +69479,13 @@ pGV
 pGV
 pGV
 gPn
-huc
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 cFh
 ahP
 wpJ
@@ -69297,7 +69501,7 @@ mUI
 jIJ
 jky
 rrS
-wJz
+vpa
 wJz
 ydW
 ydW
@@ -69359,17 +69563,17 @@ vNV
 smz
 aol
 uTX
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -69532,13 +69736,13 @@ pGV
 pGV
 pGV
 gPn
-huc
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 rrS
 aQd
 aWA
@@ -69554,7 +69758,7 @@ wCv
 wAt
 aAR
 rrS
-wJz
+vpa
 wJz
 sfi
 rci
@@ -69789,13 +69993,13 @@ pGV
 pGV
 pGV
 gPn
-huc
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 rrS
 bTE
 bTE
@@ -69811,7 +70015,7 @@ geX
 aIT
 dqM
 rrS
-wJz
+vpa
 wJz
 sfi
 rci
@@ -69869,7 +70073,7 @@ rAR
 xuA
 rAR
 lXP
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -70068,7 +70272,7 @@ rrS
 qMq
 rrS
 rrS
-wJz
+vpa
 wJz
 sfi
 yjO
@@ -70126,7 +70330,7 @@ xuA
 xuA
 rAR
 lXP
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -70325,7 +70529,7 @@ cwt
 dnT
 akM
 bTE
-wJz
+vpa
 wJz
 wJz
 yjO
@@ -70383,7 +70587,7 @@ lXP
 lXP
 lXP
 lXP
-pGV
+aPY
 pGV
 pGV
 pGV
@@ -70582,7 +70786,7 @@ kBM
 cXD
 vQs
 bTE
-wJz
+vpa
 wJz
 wJz
 yjO
@@ -70632,15 +70836,15 @@ rAR
 lXP
 xuA
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -70857,7 +71061,7 @@ rST
 rST
 rST
 rST
-rST
+wyc
 kvK
 dkc
 dkc
@@ -70889,15 +71093,15 @@ rAR
 lXP
 xuA
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -71146,15 +71350,15 @@ xuA
 xuA
 xuA
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -71403,15 +71607,15 @@ rAR
 lXP
 rAR
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -71660,15 +71864,15 @@ rAR
 lXP
 rAR
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -71869,10 +72073,10 @@ pGV
 luc
 xHk
 vmQ
-hTm
+vmQ
 uwY
 uBL
-hTm
+vmQ
 hTm
 uGJ
 oIb
@@ -71883,7 +72087,7 @@ nkh
 nkh
 nkh
 nkh
-anp
+luc
 vsi
 vsi
 aYU
@@ -71910,22 +72114,22 @@ oZc
 ocr
 xAn
 xAn
-ugA
+eGB
 lWu
-rAR
+lWu
 lWu
 lXP
 rAR
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -72129,8 +72333,8 @@ hTm
 hTm
 fcl
 rrs
-hTm
-hTm
+vmQ
+vmQ
 hTm
 hTm
 oMJ
@@ -72140,7 +72344,7 @@ hTm
 hTm
 hTm
 hTm
-anp
+luc
 vsi
 vsi
 aYU
@@ -72167,22 +72371,22 @@ gzg
 pEW
 miy
 miy
-sYZ
-lWu
-lWu
+ugA
+rKD
+eQh
 lWu
 rAR
 rAR
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -72387,6 +72591,7 @@ hTm
 fcl
 rrs
 hTm
+vmQ
 hTm
 hTm
 hTm
@@ -72396,11 +72601,10 @@ hTm
 hTm
 hTm
 hTm
-hTm
-anp
-anp
-anp
-anp
+luc
+luc
+luc
+luc
 sNZ
 rDr
 dkc
@@ -72431,15 +72635,15 @@ lWu
 lXP
 oSt
 lXP
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -72644,8 +72848,8 @@ hTm
 fcl
 rrs
 hTm
-hTm
-hTm
+vmQ
+vmQ
 hTm
 qRh
 fTE
@@ -72657,7 +72861,7 @@ hTm
 hTm
 hTm
 nSN
-anp
+luc
 aQm
 rDr
 dkc
@@ -72688,18 +72892,18 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -72945,21 +73149,21 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -73202,21 +73406,21 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -73459,21 +73663,21 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -73716,18 +73920,18 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -73973,11 +74177,11 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -74230,11 +74434,11 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -74457,9 +74661,9 @@ hTm
 hTm
 hTm
 luc
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 rmT
 fbl
 fbl
@@ -74487,11 +74691,11 @@ qub
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -74714,9 +74918,9 @@ mtv
 vcf
 hTm
 luc
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 rmT
 iXi
 iXi
@@ -74744,11 +74948,11 @@ iXi
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -74971,9 +75175,9 @@ luc
 luc
 luc
 luc
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
 rmT
 rmT
 rmT
@@ -75001,11 +75205,11 @@ iXi
 iXi
 iXi
 rmT
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -75216,35 +75420,35 @@ igZ
 igZ
 igZ
 luc
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 rmT
 rmT
 rmT
@@ -75473,39 +75677,39 @@ kvA
 igZ
 luc
 luc
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -75731,22 +75935,22 @@ luc
 luc
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -75988,22 +76192,22 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -76245,19 +76449,19 @@ pGV
 pGV
 pGV
 pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV

--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -100,12 +100,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/upper)
-"agD" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
-	},
-/turf/open/floor/iron,
-/area/space)
 "agU" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -757,6 +751,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"aLs" = (
+/obj/machinery/door/airlock/external{
+	name = "Port Docking Bay 1";
+	safety_mode = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/navbeacon/wayfinding{
+	location = "Arrival Shuttle"
+	},
+/turf/open/floor/plating,
+/area/space)
 "aLK" = (
 /obj/item/stack/spacecash/c1,
 /turf/open/floor/eighties,
@@ -765,12 +772,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/psychology)
-"aNb" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/iron,
-/area/space)
 "aNf" = (
 /turf/open/floor/wood,
 /area/service/theater)
@@ -1646,6 +1647,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/vault,
 /area/command/bridge)
+"bPU" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L7"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/space)
 "bQt" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple{
@@ -1662,6 +1670,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/breakroom)
+"bTn" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L3"
+	},
+/turf/open/floor/iron,
+/area/space)
 "bTr" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -1753,12 +1767,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/prison/visit)
-"bXw" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/space)
 "bZh" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -3609,12 +3617,6 @@
 	icon_state = "wood-broken6"
 	},
 /area/service/abandoned_gambling_den)
-"dQn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
 "dQu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -3680,6 +3682,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"dUa" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L5"
+	},
+/turf/open/floor/iron,
+/area/space)
 "dUf" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/command/teleporter";
@@ -3735,6 +3743,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"dWJ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L12"
+	},
+/turf/open/floor/iron,
+/area/space)
 "dXC" = (
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
@@ -3746,6 +3760,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/office)
+"dYk" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L11"
+	},
+/turf/open/floor/iron,
+/area/space)
 "dYT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -4111,19 +4131,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"eom" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/navbeacon/wayfinding{
-	location = "Arrival Shuttle"
-	},
-/turf/open/floor/plating,
-/area/space)
 "eoE" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -4203,12 +4210,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron,
 /area/security/prison)
-"erV" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
-	},
-/turf/open/floor/iron,
-/area/space)
 "erX" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/turf_decal/tile{
@@ -4493,17 +4494,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
-"eGB" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/white,
-/area/science/breakroom)
 "eGJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5119,12 +5109,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/security/prison/work)
-"fnW" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/space)
 "foa" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
@@ -6031,11 +6015,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/science/research)
-"gly" = (
-/obj/structure/table,
-/obj/item/pickaxe/emergency,
-/turf/open/floor/iron,
-/area/space)
 "glE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/cable,
@@ -6572,6 +6551,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/commons/dorms)
+"gVQ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L4"
+	},
+/turf/open/floor/iron,
+/area/space)
 "gWN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -7888,6 +7873,12 @@
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/iron,
 /area/security/prison)
+"iCU" = (
+/obj/structure/sign/warning/docking{
+	pixel_x = 30
+	},
+/turf/open/space/basic,
+/area/space)
 "iDu" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -8490,6 +8481,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"jiN" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L10"
+	},
+/turf/open/floor/iron,
+/area/space)
 "jiR" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -8515,6 +8512,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/rd)
+"jkV" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Shuttle Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/navbeacon/wayfinding,
+/turf/open/floor/iron,
+/area/space)
 "jlc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -8566,12 +8573,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"jow" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/turf/open/floor/iron,
-/area/space)
 "jpj" = (
 /obj/machinery/door/airlock/mining{
 	name = "Quartermaster's Office";
@@ -8611,18 +8612,6 @@
 	icon_state = "wood-broken5"
 	},
 /area/service/abandoned_gambling_den)
-"jqL" = (
-/obj/structure/sign/warning/docking{
-	pixel_x = 30
-	},
-/turf/open/space/basic,
-/area/space)
-"jqQ" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
-/turf/open/floor/iron,
-/area/space)
 "jqZ" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
@@ -8683,12 +8672,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
-"jsA" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/space)
 "jsP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -8873,10 +8856,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"jBO" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/space)
 "jCn" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -9431,10 +9410,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"kfW" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "kga" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -9481,12 +9456,6 @@
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/plating,
 /area/cargo/warehouse)
-"kiw" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/turf/open/floor/iron,
-/area/space)
 "kiD" = (
 /obj/machinery/seed_extractor,
 /obj/machinery/door/firedoor/border_only{
@@ -9656,6 +9625,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"krq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "krT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -9978,6 +9953,12 @@
 "kLx" = (
 /turf/open/openspace,
 /area/maintenance/department/science)
+"kNl" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L13"
+	},
+/turf/open/floor/iron,
+/area/space)
 "kOm" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -10559,10 +10540,6 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
-"lBd" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/space)
 "lBg" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/purple{
@@ -10646,12 +10623,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"lEY" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/space)
 "lFl" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/turf_decal/arrows/white{
@@ -10960,12 +10931,6 @@
 	initial_gas_mix = "n2=100;TEMP=293.15"
 	},
 /area/medical/abandoned)
-"lTN" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/space)
 "lTX" = (
 /obj/structure/industrial_lift/tram{
 	icon_state = "titanium_blue"
@@ -10991,13 +10956,6 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/white,
 /area/commons/dorms)
-"lUt" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/space)
 "lVl" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/mech_bay_power_console,
@@ -11233,6 +11191,12 @@
 "mjd" = (
 /turf/open/openspace,
 /area/ai_monitored/command/storage/eva)
+"mjz" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L6"
+	},
+/turf/open/floor/iron,
+/area/space)
 "mjY" = (
 /obj/machinery/power/generator,
 /turf/open/floor/plating,
@@ -11262,12 +11226,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"mkH" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/space)
 "mkL" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -11640,6 +11598,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/hallway/secondary/command)
+"mHN" = (
+/obj/machinery/disposal/bin,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "mHT" = (
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet/lone/star,
@@ -11988,6 +11951,10 @@
 /obj/machinery/duct,
 /turf/open/floor/carpet,
 /area/service/bar)
+"mYT" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/space)
 "mZf" = (
 /obj/machinery/computer/pandemic,
 /turf/open/floor/iron/dark,
@@ -12573,13 +12540,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"nFe" = (
-/obj/structure/chair/office/light{
-	color = "#990099";
-	dir = 8
+"nEQ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L9"
 	},
-/turf/open/floor/iron/white,
-/area/command/heads_quarters/rd)
+/turf/open/floor/iron,
+/area/space)
 "nFq" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -30
@@ -12658,13 +12624,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/work)
-"nIW" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	safety_mode = 1
-	},
-/turf/open/floor/iron,
-/area/space)
 "nJY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/tile/blue{
@@ -12734,6 +12693,11 @@
 /obj/item/ai_module/core/full/drone,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"nNf" = (
+/obj/structure/table,
+/obj/item/pickaxe/emergency,
+/turf/open/floor/iron,
+/area/space)
 "nNh" = (
 /obj/structure/cable,
 /obj/structure/railing{
@@ -14414,6 +14378,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/commons/toilet)
+"pQU" = (
+/obj/structure/chair/office/light{
+	color = "#990099";
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/command/heads_quarters/rd)
 "pRa" = (
 /obj/structure/railing{
 	layer = 3.1
@@ -14600,16 +14571,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/medical/medbay/zone2)
-"qeC" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/navbeacon/wayfinding,
-/turf/open/floor/iron,
-/area/space)
 "qfc" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -17110,11 +17071,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"sHk" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "sHG" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/ale,
@@ -17382,6 +17338,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/command/heads_quarters/captain)
+"taZ" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L14"
+	},
+/turf/open/floor/iron,
+/area/space)
 "tbn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
@@ -18055,18 +18017,6 @@
 /obj/structure/frame/machine,
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
-"tNs" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "tNO" = (
 /obj/structure/chair{
 	dir = 8
@@ -18790,6 +18740,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"uuG" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/space)
 "uvA" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/south,
@@ -18951,6 +18905,12 @@
 /obj/item/nullrod,
 /turf/open/floor/iron/grimy,
 /area/service/chapel/office)
+"uBr" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L1"
+	},
+/turf/open/floor/iron,
+/area/space)
 "uBw" = (
 /obj/structure/punching_bag,
 /turf/open/floor/iron,
@@ -19285,6 +19245,13 @@
 	},
 /turf/open/floor/vault,
 /area/command/bridge)
+"uTJ" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	safety_mode = 1
+	},
+/turf/open/floor/iron,
+/area/space)
 "uTP" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -19735,6 +19702,12 @@
 "vzA" = (
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"vzO" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L8"
+	},
+/turf/open/floor/iron,
+/area/space)
 "vAg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -19961,6 +19934,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"vLo" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "commonmining_home";
+	name = "SS13: Common Mining Dock";
+	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
 "vLW" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
@@ -21080,6 +21065,10 @@
 /obj/item/circuitboard/computer/arcade/amputation,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
+"wWT" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "wZI" = (
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
@@ -21306,6 +21295,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel)
+"xsY" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "L2"
+	},
+/turf/open/floor/iron,
+/area/space)
 "xuk" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
@@ -21946,6 +21941,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
+"ydQ" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	color = "#4D0067";
+	name = "Science purple corner"
+	},
+/obj/machinery/light/dim/directional/south,
+/turf/open/floor/iron/white,
+/area/science/breakroom)
 "ydW" = (
 /turf/closed/wall,
 /area/maintenance/department/medical)
@@ -22081,12 +22087,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"ykw" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
-	},
-/turf/open/floor/iron,
-/area/space)
 "ykL" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/soda_cans/sodawater,
@@ -35857,9 +35857,9 @@ pGV
 pGV
 pGV
 pGV
-jqL
-tNs
-jqL
+iCU
+vLo
+iCU
 pGV
 pGV
 oAR
@@ -36119,7 +36119,7 @@ ohn
 tlJ
 tlJ
 tlJ
-nIW
+uTJ
 tlJ
 tlJ
 pGV
@@ -36371,9 +36371,9 @@ tDG
 tDG
 wlM
 tlJ
-kfW
+wWT
 wlM
-gly
+nNf
 tlJ
 nwc
 wlM
@@ -36628,12 +36628,12 @@ bVM
 bVM
 wlM
 tlJ
-lBd
+mYT
 wlM
-jBO
+uuG
 tlJ
 tlJ
-nIW
+uTJ
 tlJ
 tlJ
 pGV
@@ -36886,7 +36886,7 @@ wlM
 wlM
 tlJ
 tlJ
-qeC
+jkV
 tlJ
 tlJ
 wlM
@@ -38939,10 +38939,10 @@ tDG
 tDG
 igc
 yin
-eom
+aLs
 wlM
-agD
-lEY
+uBr
+xsY
 wlM
 wlM
 wlM
@@ -39198,8 +39198,8 @@ dsT
 dsT
 dsT
 wlM
-bXw
-ykw
+bTn
+gVQ
 wlM
 wlM
 wlM
@@ -39455,8 +39455,8 @@ cMd
 xsF
 wlM
 wlM
-mkH
-jsA
+dUa
+mjz
 wlM
 wlM
 tlJ
@@ -39712,8 +39712,8 @@ dsT
 qOW
 wlM
 wlM
-lUt
-erV
+bPU
+vzO
 wlM
 wlM
 tlJ
@@ -39969,8 +39969,8 @@ dsT
 ykk
 wlM
 wlM
-kiw
-lTN
+nEQ
+jiN
 wlM
 tlJ
 tlJ
@@ -40223,11 +40223,11 @@ tDG
 tDG
 vIp
 cMd
-sHk
+mHN
 wlM
 wlM
-aNb
-fnW
+dYk
+dWJ
 wlM
 tlJ
 aPY
@@ -40483,8 +40483,8 @@ dsT
 dsT
 dsT
 wlM
-jqQ
-jow
+kNl
+taZ
 wlM
 tlJ
 aPY
@@ -40738,7 +40738,7 @@ tDG
 tDG
 igc
 yin
-eom
+aLs
 wlM
 wlM
 wlM
@@ -50844,13 +50844,13 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51098,19 +51098,19 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51353,23 +51353,23 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51609,21 +51609,21 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -51865,21 +51865,21 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52121,22 +52121,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52377,19 +52377,19 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52634,18 +52634,18 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -52890,18 +52890,18 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53147,18 +53147,18 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53404,20 +53404,20 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53660,22 +53660,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -53914,26 +53914,26 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54170,28 +54170,28 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54426,30 +54426,30 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54666,47 +54666,47 @@ aPY
 aPY
 aPY
 aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -54911,59 +54911,59 @@ aPY
 aPY
 aPY
 aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55168,59 +55168,59 @@ aPY
 aPY
 aPY
 aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55428,56 +55428,56 @@ spU
 aPY
 aPY
 aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55685,56 +55685,56 @@ spU
 aPY
 aPY
 aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -55944,54 +55944,54 @@ aPY
 aPY
 aPY
 aPY
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -56226,28 +56226,28 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -56484,26 +56484,26 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -56744,22 +56744,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57002,20 +57002,20 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57259,18 +57259,18 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57516,18 +57516,18 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -57774,18 +57774,18 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58031,19 +58031,19 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58289,22 +58289,22 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58547,21 +58547,21 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -58805,21 +58805,21 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -59063,23 +59063,23 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -59322,19 +59322,19 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -59582,13 +59582,13 @@ pGV
 pGV
 pGV
 pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
-pGV
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
+aPY
 pGV
 pGV
 pGV
@@ -66966,7 +66966,7 @@ qjP
 xKn
 kpw
 ekD
-dQn
+krq
 wpL
 ycm
 qdZ
@@ -68252,7 +68252,7 @@ qub
 rGW
 cAt
 ekD
-nFe
+pQU
 rRv
 oxC
 sKP
@@ -72114,7 +72114,7 @@ oZc
 ocr
 xAn
 xAn
-eGB
+ydQ
 lWu
 lWu
 lWu

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -25,9 +25,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aam" = (
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/table,
+/obj/item/weldingtool/mini,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aan" = (
 /obj/machinery/power/tracker{
 	id = "forestarboard"
@@ -82,15 +83,15 @@
 /area/security/processing)
 "aaC" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/button/elevator{
+	id = "permaElevator";
+	pixel_x = 25
 	},
 /turf/open/floor/iron/dark,
 /area/security/processing)
@@ -3922,8 +3923,9 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aEk" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/structure/frame/computer,
+/obj/item/circuitboard/computer/atmos_alert,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aEl" = (
 /obj/structure/closet/secure_closet/exile,
@@ -4106,8 +4108,8 @@
 /area/maintenance/starboard)
 "aFj" = (
 /obj/machinery/power/solar{
-	id = "foreport";
-	name = "Fore-Port Solar Array"
+	id = "forestarboard";
+	name = "Fore-Starboard Solar Array"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
@@ -4143,10 +4145,9 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aFw" = (
-/obj/machinery/power/solar,
-/obj/structure/cable,
-/turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/obj/structure/frame/computer,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aFx" = (
 /turf/closed/wall,
 /area/security/detectives_office)
@@ -4563,7 +4564,8 @@
 /area/security/courtroom)
 "aHW" = (
 /obj/structure/table,
-/obj/item/weldingtool/mini,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/spawner/random/techstorage/security_all,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aIe" = (
@@ -4573,8 +4575,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aIg" = (
-/obj/structure/frame/computer,
-/obj/item/circuitboard/computer/atmos_alert,
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/toy/figure/syndie,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aIi" = (
@@ -4613,25 +4616,23 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aIz" = (
-/obj/structure/frame/computer,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aIA" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil/cut,
-/obj/effect/spawner/random/techstorage/security_all,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aIB" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aIC" = (
+"aIA" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port)
+"aIB" = (
 /obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/toy/figure/syndie,
+/obj/item/circuitboard/computer,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"aIC" = (
+/obj/structure/frame,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aIH" = (
@@ -4700,15 +4701,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aJf" = (
-/obj/effect/spawner/random/clothing/gloves,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aJg" = (
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/maintenance/port)
 "aJh" = (
+/obj/item/stack/sheet/glass,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -4784,43 +4782,40 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aJV" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/obj/effect/spawner/random/clothing/gloves,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aJW" = (
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"aJX" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port)
+"aJY" = (
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"aJZ" = (
 /obj/structure/frame/computer{
 	dir = 4
 	},
 /obj/item/circuitboard/computer,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aJX" = (
+"aKa" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aJY" = (
+"aKb" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
-/area/maintenance/port)
-"aJZ" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port)
-"aKa" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/port)
-"aKb" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
 /area/maintenance/port)
 "aKf" = (
 /obj/structure/closet/firecloset,
@@ -4858,28 +4853,34 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "aKM" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/fore)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port)
 "aKN" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/area/maintenance/solars/port/fore)
-"aKO" = (
 /obj/structure/frame/computer{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aKP" = (
+"aKO" = (
 /obj/item/stack/sheet/glass,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"aKP" = (
+/obj/item/stack/sheet/glass,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "aKQ" = (
-/obj/structure/table,
-/obj/item/circuitboard/computer,
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aKR" = (
@@ -4990,26 +4991,28 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aLq" = (
-/obj/structure/frame/computer{
-	dir = 8
-	},
-/obj/item/stack/cable_coil/cut,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aLH" = (
-/obj/structure/frame,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"aLI" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aLJ" = (
-/obj/item/stack/sheet/glass,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+"aLH" = (
+/obj/structure/table,
+/obj/item/screwdriver,
+/obj/item/wirecutters,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"aLI" = (
+/obj/machinery/power/tracker{
+	id = "forestarboard"
 	},
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/maintenance/solars/port/fore)
+"aLJ" = (
+/obj/structure/table,
+/obj/item/circuitboard/computer,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aLP" = (
 /obj/structure/chair{
@@ -5029,9 +5032,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aLX" = (
-/obj/structure/frame/computer{
-	dir = 8
-	},
+/obj/structure/table,
+/obj/item/stack/cable_coil/cut,
+/obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aLY" = (
@@ -5058,14 +5061,17 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
 "aMs" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "aMt" = (
-/obj/item/stack/sheet/glass,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aMv" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -5185,15 +5191,11 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aNh" = (
-/obj/structure/table,
-/obj/item/screwdriver,
-/obj/item/wirecutters,
+/obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aNi" = (
-/obj/structure/table,
-/obj/item/circuitboard/computer,
-/obj/machinery/light/directional/south,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aNj" = (
@@ -5359,21 +5361,18 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aOa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/solars/port/fore)
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "aOb" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aOc" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil,
+/turf/open/space/basic,
+/area/maintenance/solars/port/fore)
 "aOd" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -5439,11 +5438,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
-"aOy" = (
-/obj/item/stack/sheet/glass,
-/turf/open/space/basic,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aOz" = (
 /obj/machinery/vending/drugs,
 /obj/effect/turf_decal/tile/blue{
@@ -5504,7 +5498,8 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aOI" = (
-/obj/structure/rack,
+/obj/structure/closet/emcloset,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aOJ" = (
@@ -5740,46 +5735,42 @@
 /turf/closed/wall,
 /area/maintenance/starboard)
 "aPY" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars/port/fore)
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/stack/spacecash/c50,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aPZ" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/port/fore";
 	dir = 1;
-	name = "Engineering yellow corner"
+	name = "Port Bow Maintenance APC";
+	pixel_x = -1;
+	pixel_y = 23
 	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aQa" = (
-/turf/open/floor/eighties,
+/obj/effect/spawner/random/maintenance/eight,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aQb" = (
-/obj/machinery/jukebox,
-/turf/open/floor/eighties,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aQc" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/item/stack/spacecash/c1,
-/turf/open/floor/eighties,
+/obj/structure/rack,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/weldingtool,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aQe" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil/cut,
-/obj/machinery/light/directional/south,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aQf" = (
@@ -5810,9 +5801,9 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aQw" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/eighties,
-/area/maintenance/port)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/solars/port/fore)
 "aQA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -5899,18 +5890,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "aRi" = (
-/obj/machinery/power/solar_control{
-	id = "foreport";
-	name = "Fore Port Solars Control"
-	},
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/maintenance/solars/port/fore)
 "aRj" = (
 /obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_access_txt = "10; 13"
+	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
@@ -5923,9 +5910,18 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aRl" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/fore)
 "aRm" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5934,8 +5930,8 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aRn" = (
-/obj/item/stack/spacecash/c1,
-/turf/open/floor/eighties,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
 /area/maintenance/port)
 "aRo" = (
 /obj/structure/table,
@@ -5973,11 +5969,10 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aRw" = (
+/obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 30
 	},
-/obj/machinery/light/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aRx" = (
@@ -5991,9 +5986,12 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "aRz" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/solars/port/fore)
 "aRC" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera/directional/south{
@@ -6067,19 +6065,32 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aSf" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/obj/machinery/camera/directional/east{
+	c_tag = "Solar Control - Port Fore";
+	name = "Solars Camera";
+	network = list("ss13","engineering")
+	},
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aSg" = (
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aSh" = (
-/obj/effect/spawner/random/maintenance/eight,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aSi" = (
-/obj/machinery/jukebox/disco,
-/turf/open/floor/eighties,
-/area/maintenance/port)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/solars/port/fore)
 "aSk" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -6117,13 +6128,6 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aSs" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Solar Control - Port Fore";
-	name = "Solars Camera";
-	network = list("ss13","engineering")
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aSt" = (
@@ -6150,10 +6154,21 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aSA" = (
-/obj/structure/sign/logo{
-	pixel_x = 30
+/obj/machinery/door/airlock/engineering{
+	name = "Port Bow Solar Access";
+	req_access_txt = "10"
 	},
-/turf/open/floor/eighties,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/maintenance/port)
 "aSC" = (
 /obj/structure/sign/departments/lawyer{
@@ -6262,11 +6277,14 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aTc" = (
+/obj/machinery/power/solar_control{
+	dir = 1;
+	id = "foreport";
+	name = "Fore Port Solars Control"
+	},
 /obj/structure/cable,
-/obj/structure/closet/emcloset,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
+/area/space)
 "aTd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -6278,29 +6296,34 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aTf" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron,
+/area/maintenance/solars/port/fore)
+"aTg" = (
+/obj/item/clothing/head/delinquent,
+/obj/item/paper/crumpled/muddy,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"aTh" = (
+/obj/docking_port/stationary{
+	dheight = 4;
+	dwidth = 4;
+	height = 9;
+	id = "aux_base_zone";
+	name = "aux base zone";
+	roundstart_template = /datum/map_template/shuttle/aux_base/small;
+	width = 9
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
+"aTi" = (
 /obj/structure/table_frame,
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
-"aTg" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/happy,
-/turf/open/floor/eighties,
-/area/maintenance/port)
-"aTh" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/lsd,
-/obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/eighties,
-/area/maintenance/port)
-"aTi" = (
-/obj/structure/table,
-/obj/item/food/grown/cannabis,
-/obj/item/food/grown/cannabis,
-/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
-/turf/open/floor/eighties,
 /area/maintenance/port)
 "aTj" = (
 /obj/machinery/meter,
@@ -6408,12 +6431,9 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aTy" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aTz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -6513,29 +6533,14 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aUd" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Port Bow Solar Access";
-	req_access_txt = "10"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
-"aUf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Long Abandoned Dance Hall"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/eighties,
+/obj/structure/chair/stool,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
 /area/maintenance/port)
+"aUf" = (
+/obj/structure/stairs/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aUg" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
@@ -6704,28 +6709,24 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aVh" = (
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/closed/wall,
+/area/hallway/secondary/entry)
 "aVi" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/spacecash/c50,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/floor/plating/elevatorshaft,
+/area/hallway/secondary/entry)
 "aVj" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
-	dir = 1;
-	name = "Port Bow Maintenance APC";
-	pixel_x = -1;
-	pixel_y = 23
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/button/elevator{
+	id = "arrivalsElevator";
+	pixel_y = 25
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aVn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Emergency Oxygen Supply"
@@ -6982,22 +6983,22 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aXe" = (
-/obj/effect/spawner/random/entertainment/arcade{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aXf" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/item/weldingtool,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aXg" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/structure/stairs/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aXh" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -8324,23 +8325,10 @@
 /turf/open/floor/iron,
 /area/space)
 "bfo" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "bfp" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
@@ -8362,29 +8350,6 @@
 /obj/item/reagent_containers/food/drinks/dry_ramen,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bfw" = (
-/obj/effect/spawner/random/trash/grille_or_waste,
-/obj/item/reagent_containers/food/drinks/dry_ramen,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bfx" = (
-/obj/structure/closet,
-/obj/effect/spawner/random/maintenance/eight,
-/obj/item/reagent_containers/food/drinks/dry_ramen,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bfz" = (
-/obj/docking_port/stationary{
-	dheight = 4;
-	dwidth = 4;
-	height = 9;
-	id = "aux_base_zone";
-	name = "aux base zone";
-	roundstart_template = /datum/map_template/shuttle/aux_base/default;
-	width = 9
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
 "bfA" = (
 /obj/structure/sign/warning/docking{
 	pixel_x = 30
@@ -8415,14 +8380,6 @@
 "bfK" = (
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"bfL" = (
-/obj/structure/table_frame,
-/obj/item/shard{
-	icon_state = "small"
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bfY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
@@ -8468,9 +8425,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port)
-"bgf" = (
-/turf/open/space/basic,
 /area/maintenance/port)
 "bgg" = (
 /obj/structure/cable,
@@ -8532,12 +8486,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bgF" = (
-/obj/effect/decal/remains/xeno,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"bgG" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/blobstart,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/item/reagent_containers/food/drinks/dry_ramen,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bgJ" = (
@@ -8741,10 +8691,6 @@
 /obj/item/pickaxe/emergency,
 /turf/open/floor/iron,
 /area/space)
-"bif" = (
-/obj/structure/stairs/west,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bih" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -13052,10 +12998,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"bBk" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bBl" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "researchlock";
@@ -14034,6 +13976,7 @@
 "bEC" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "bED" = (
@@ -14091,6 +14034,7 @@
 	name = "Entry Hall APC";
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "bEL" = (
@@ -14496,6 +14440,7 @@
 	dir = 1
 	},
 /obj/machinery/bounty_board/directional/south,
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "bGu" = (
@@ -15270,22 +15215,10 @@
 /obj/item/beacon,
 /turf/open/floor/iron/white,
 /area/science)
-"bJW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bJX" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/space)
-"bJZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "bKd" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -16276,8 +16209,8 @@
 /area/science/robotics/mechbay)
 "bRM" = (
 /turf/open/space/basic,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/space/basic,
+/area/space)
 "bRP" = (
 /obj/structure/sink{
 	dir = 1;
@@ -16855,11 +16788,6 @@
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/space)
-"bVU" = (
-/obj/item/clothing/head/delinquent,
-/obj/item/paper/crumpled/muddy,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "bVW" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -18040,8 +17968,8 @@
 /turf/open/floor/iron/white,
 /area/science/explab)
 "cey" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -19950,13 +19878,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
-"coR" = (
-/obj/machinery/airalarm/directional/north,
 /obj/structure/railing{
 	dir = 4
 	},
+/turf/open/floor/iron/white,
+/area/science/mixing)
+"coR" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -19965,6 +19892,7 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/structure/stairs/north,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "coT" = (
@@ -24571,10 +24499,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"cIg" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "cIh" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/random/maintenance,
@@ -26755,10 +26679,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
-"cTp" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/engineering/main)
 "cTq" = (
 /obj/machinery/bluespace_beacon,
 /obj/machinery/turretid{
@@ -29150,20 +29070,10 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"fCl" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "fDf" = (
 /obj/item/beacon,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"fDF" = (
-/obj/structure/stairs/south,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "fEA" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -29872,10 +29782,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"hgu" = (
-/obj/structure/stairs/north,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "hhm" = (
 /obj/structure/rack,
 /obj/item/tape,
@@ -30035,12 +29941,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/private_investigators_office)
-"hwm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "hwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30561,6 +30461,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "iyd" = (
@@ -30773,12 +30676,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"jdk" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "jen" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -31575,15 +31472,15 @@
 /area/security/detectives_office)
 "kSq" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_x = 25
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/button/elevator{
+	id = "medbayElevator";
+	pixel_x = 25
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
@@ -31780,10 +31677,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"loG" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/solars/port/fore)
 "lsR" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay Hall - Pharmacy";
@@ -31817,9 +31710,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lvj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lvv" = (
@@ -33093,9 +32984,7 @@
 /turf/open/floor/iron/white,
 /area/commons/toilet)
 "oFl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "oHm" = (
@@ -35868,8 +35757,9 @@
 /turf/open/floor/iron,
 /area/space)
 "vEB" = (
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/hallway/secondary/entry)
+/area/maintenance/solars/port/fore)
 "vEC" = (
 /obj/structure/cable,
 /obj/structure/sign/departments/examroom{
@@ -45971,11 +45861,11 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -46216,9 +46106,6 @@ aaa
 aaa
 aaa
 aaa
-aDq
-aDq
-aDq
 aaa
 aaa
 aaa
@@ -46227,12 +46114,15 @@ aaa
 aaa
 aaa
 aaa
-aDq
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -46459,24 +46349,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-aDq
 aaa
 aaa
 aaa
@@ -46484,12 +46356,30 @@ aaa
 aaa
 aaa
 aaa
-aDq
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -46716,24 +46606,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -46741,13 +46613,31 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -46966,31 +46856,6 @@ aaa
 aaa
 aaa
 aaa
-aaq
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -46998,13 +46863,38 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -47229,25 +47119,6 @@ aaa
 aaa
 aaa
 aaa
-aak
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -47255,13 +47126,32 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -47486,25 +47376,6 @@ aaa
 aaa
 aaa
 aaa
-aak
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -47512,14 +47383,33 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-aDq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -47735,6 +47625,16 @@ aaa
 aaa
 aaa
 aaa
+aak
+aak
+aak
+aak
+aak
+aak
+aOa
+aak
+aak
+aak
 aaa
 aaa
 aaa
@@ -47744,10 +47644,6 @@ aaa
 aaa
 aaa
 aaa
-aDq
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -47755,13 +47651,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -47769,14 +47658,15 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-aDq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -47991,6 +47881,18 @@ aaa
 aaa
 aaa
 aaa
+aak
+aEV
+aMs
+aEV
+aEV
+aMs
+aEV
+aEV
+aEV
+aEV
+aEV
+aak
 aaa
 aaa
 aaa
@@ -48002,9 +47904,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -48012,13 +47911,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -48026,14 +47918,12 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-aDq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -48248,6 +48138,20 @@ aaa
 aaa
 aaa
 aaa
+aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aak
+aak
+aae
 aaa
 aaa
 aaa
@@ -48269,13 +48173,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -48283,15 +48180,8 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -48505,6 +48395,20 @@ aaa
 aaa
 aaa
 aaa
+aae
+aaa
+aaa
+aaa
+aFj
+aaa
+aaa
+aFj
+aaa
+aaa
+aFj
+aaa
+aak
+aaf
 aaa
 aaa
 aaa
@@ -48523,16 +48427,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -48540,15 +48434,11 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -48762,6 +48652,20 @@ aaa
 aaa
 aaa
 aaa
+aae
+aak
+aaa
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aak
+aae
 aaa
 aaa
 aaa
@@ -48780,16 +48684,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -48797,15 +48691,11 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -49019,6 +48909,20 @@ aaa
 aaa
 aaa
 aaa
+aaf
+aak
+aaa
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aak
+aae
 aaa
 aaa
 aaa
@@ -49037,16 +48941,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -49054,15 +48948,11 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -49276,6 +49166,20 @@ aaa
 aaa
 aaa
 aaa
+aae
+aak
+aaa
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aak
+aae
 aaa
 aaa
 aaa
@@ -49297,13 +49201,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -49311,15 +49208,8 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -49530,11 +49420,22 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 aae
-aae
-aae
-aae
-aae
+aak
+aaa
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aak
 aaa
 aaa
 aaa
@@ -49544,9 +49445,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -49554,13 +49452,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -49568,14 +49459,13 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-aDq
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -49787,11 +49677,22 @@ aaa
 aaa
 aaa
 aaa
-aaf
-aak
-aak
-aak
+aaa
+aaa
+aaa
 aae
+aak
+aaa
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aak
 aaa
 aaa
 aaa
@@ -49801,9 +49702,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -49811,13 +49709,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -49825,15 +49716,14 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50045,8 +49935,21 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 aak
-aKM
+aak
+aaa
+aaa
+vEB
+aaa
+aaa
+vEB
+aaa
+aaa
+vEB
+aaa
+aak
 aak
 aaa
 aaa
@@ -50058,23 +49961,6 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -50082,15 +49968,19 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50294,26 +50184,20 @@ aaa
 aaa
 aaa
 aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-aak
+aLI
 aGh
-aak
-aak
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aak
+aGh
 vEB
 vEB
 vEB
@@ -50322,16 +50206,10 @@ vEB
 vEB
 vEB
 vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aGh
+aGh
+aGh
+aGh
 aaa
 aaa
 aaa
@@ -50339,15 +50217,27 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50551,44 +50441,33 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aak
+aaa
+aaa
+aaa
+vEB
+aaa
+aaa
+vEB
+aaa
+aaa
+aOc
+aaa
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
 aGh
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aae
-aak
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aGh
 aaa
 aaa
 aaa
@@ -50596,15 +50475,26 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aaa
+aaa
+aaa
+fIK
+fIK
+fIK
+fIK
+fIK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -50808,44 +50698,34 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aak
 aak
 aaa
 aFj
+aGh
 aFj
 aFj
+aGh
 aFj
 aFj
+aGh
+aFj
+aak
+aaf
+aaa
 aaa
 aGh
 aaa
-aFj
-aFj
-aFj
-aFj
-aFj
-aaa
-aak
-aae
-aak
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
 aaa
 aaa
 aaa
@@ -50853,15 +50733,25 @@ aaa
 aaa
 aaa
 aaa
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+fIK
+fIK
+fIK
+fIK
+fIK
+aVi
+aVi
+aVi
+fIK
+fIK
+fIK
+fIK
+fIK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -51065,53 +50955,53 @@ aaa
 aaa
 aaa
 aaa
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
+aak
+aaa
 aFj
 aGh
+aFj
+aFj
 aGh
-aGh
-aGh
-aGh
-aJV
-aJV
-aJV
-aGh
-aGh
-aGh
-aGh
+aFj
+aFj
 aGh
 aFj
 aak
 aae
-aak
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
+aaa
+aaa
+aGh
+aaa
+aaa
+aaa
+aaa
 fIK
 fIK
 fIK
 fIK
 fIK
-fIK
-fIK
-fIK
-fIK
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-vEB
-fIK
-fIK
+aUf
+bLw
+aVh
+aVi
+aVi
+aVi
+aVi
+aVi
+aVh
+bLw
+aXg
 fIK
 fIK
 fIK
@@ -51322,57 +51212,57 @@ aaa
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aae
 aak
 aaa
 aFj
+aGh
 aFj
 aFj
+aGh
 aFj
 aFj
-aaa
-aJV
-aaa
+aGh
 aFj
-aFj
-aFj
-aFj
-aFj
-aaa
 aak
 aae
 aaa
+aQw
+aRj
+aQw
 aaa
-aaa
-aaa
-aaa
-aaa
-aaj
-aak
-aak
 bdS
 bdS
-bVU
-fIK
-bif
-bif
-bif
-bif
-bif
-fIK
-fIK
-vEB
-vEB
-vEB
-vEB
-vEB
-fIK
-fIK
-bif
-bif
-bif
-bif
-bif
+bdS
+qTU
+bLw
+bLw
+bLw
+bLw
+bLw
+aVh
+aVi
+aVi
+aVi
+aVi
+aVi
+aVh
+bLw
+bLw
+bLw
+bLw
+bLw
+qTU
 bwU
 bGh
 bGh
@@ -51579,56 +51469,56 @@ aaq
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aak
 aaa
 aFj
+aGh
 aFj
 aFj
+aGh
 aFj
 aFj
-aaa
-aJV
-aaa
+aGh
 aFj
-aFj
-aFj
-aFj
-aFj
-aaa
 aak
 aae
 aaa
+aQw
+aRl
+aQw
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
 bdS
-bmV
-bmV
-fIK
-oFl
-bJW
-bJW
-bJW
-bJZ
-fDF
-fIK
-vEB
-vEB
-vEB
-vEB
-vEB
-fIK
-hgu
-hwm
-bJW
-bJW
-bJW
+aTg
+bdS
+qTU
+qTU
+bLw
+bLw
+bLw
+bLw
+aVh
+aVh
+aVi
+aVi
+aVi
+aVh
+aVh
+bLw
+bLw
+bLw
+bLw
+qTU
 oFl
 lFU
 bGh
@@ -51836,55 +51726,55 @@ aaa
 aaa
 aaa
 aaa
-aae
-aak
-aFj
-aGh
-aGh
-aGh
-aGh
-aGh
-aJV
-aKN
-aJV
-aGh
-aGh
-aGh
-aGh
-aGh
-aFj
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aak
 aaa
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aFj
+aGh
+aFj
+aak
+aae
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aQw
+aRl
+aQw
 aaa
 bdS
-bfv
-bfv
+bmV
 bmV
 bjC
 ble
+qTU
 bLw
 bLw
-cIg
-fDF
-fIK
-vEB
-vEB
-vEB
-vEB
-vEB
-fIK
-hgu
-lvj
 bLw
 bLw
+aVh
+aVj
+aXe
+aXe
+aVh
+aXf
+bLw
+bLw
+bLw
+qTU
 bEC
 bGs
 bwU
@@ -52093,54 +51983,54 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aak
 aaa
-aFj
-aFj
-aFj
-aFj
-aFj
-aaa
-aJV
 aaa
 aFj
+aaa
+aaa
 aFj
-aFj
-aFj
+aaa
+aaa
 aFj
 aaa
 aak
-aaf
+aae
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aQw
+aRj
+aQw
+aRi
 bdS
-bfv
 bfv
 bmV
 bmV
 blf
 qTU
+qTU
 bLw
-cIg
-fDF
-fIK
-fIK
-fIK
-fIK
-fIK
-fIK
-fIK
-hgu
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
 lvj
-bBk
+qTU
 qTU
 bEK
 bwU
@@ -52176,7 +52066,7 @@ aaa
 cgj
 aaa
 aaa
-cTp
+aOd
 cyo
 cyt
 cMW
@@ -52350,53 +52240,53 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aak
-aaa
-aFj
-aFj
-aFj
-aFj
-aFj
-aaa
-aJV
-aaa
-aFj
-aFj
-aFj
-aFj
-aFj
-aaa
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
 aak
 aae
-aak
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bdS
+aRi
+aRw
+aSi
+aTc
+bmV
 bfv
-kId
 bfv
 bmV
 bmV
 bmI
 qTU
-fCl
-bJZ
-bif
-bif
-bif
-bif
-bif
-bif
-bif
-hwm
-jdk
+qTU
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+qTU
 qTU
 bDc
 bwU
@@ -52433,7 +52323,7 @@ aaa
 cgj
 aaa
 aaa
-cTp
+aOd
 cyo
 cAW
 cAW
@@ -52607,52 +52497,52 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
-aak
-aFw
-aGh
-aGh
-aGh
-aGh
-aGh
-aJV
-aJV
-aJV
-aGh
-aGh
-aGh
-aGh
-aGh
-aFj
-aak
 aae
+aae
+aae
+aae
+aaf
+aae
+aae
+aae
+aae
+aae
+aae
+aaj
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bdS
-bfw
+aRi
+aRz
+aSs
+aSs
+bmV
 bgF
-kId
+aTy
 bfv
 bmV
 bmV
 boc
 bpi
-fCl
-bJW
-bJW
-bJW
-bJW
-bJW
-bJW
-bJW
-jdk
+qTU
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+bLw
+qTU
 bzX
 bBD
 bwU
@@ -52864,38 +52754,38 @@ aaa
 aaa
 aaa
 aaa
-aae
-aak
-aaa
-aFj
-aFj
-aFj
-aFj
-aFj
-aaa
-aJV
-aaa
-aFj
-aFj
-aFj
-aFj
-aFj
-aaa
-aak
-aae
 aaa
 aaa
 aaa
 aaa
-aaq
 aaa
 aaa
 aaa
 aaa
-bdS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aRi
+aSf
+aSi
+aTf
+bmV
 bfv
-bgG
-kId
+aUd
 kId
 bfv
 bmV
@@ -53121,25 +53011,22 @@ aaa
 aaa
 aaa
 aaa
-aae
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aJV
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -53150,7 +53037,10 @@ aaa
 aaa
 aaa
 bdS
-bfx
+bmV
+aSA
+bmV
+bmV
 bfv
 bfv
 bfv
@@ -53378,26 +53268,23 @@ aaa
 aaa
 aaa
 aaa
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
-aaa
-aJV
 aaa
 aaa
 aaa
 aaa
 aaa
-aPY
-aPY
-aPY
-aPY
-aPY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -53407,6 +53294,9 @@ aaa
 aaa
 aaa
 bdS
+kId
+kId
+kId
 bmV
 bmV
 bmV
@@ -53644,27 +53534,27 @@ aaa
 aaa
 aaa
 aaa
-aJV
 aaa
 aaa
-aOa
-aOa
-aOa
-aOa
-aRi
-aSf
-aTc
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bdS
 bdS
 bdS
 bdS
 bdS
-bdS
-bdS
-bdS
-bdS
-bdS
-bfL
+bmV
+kId
+kId
+kId
 qNB
 bmV
 dDa
@@ -53901,25 +53791,25 @@ aaa
 aaa
 aaa
 aaa
-aGh
-aGh
-aGh
-bfo
-aRj
-aRj
-aPZ
-loG
-aSf
-loG
-aUd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
+kId
 tsg
 tsg
-kId
-kId
-cXf
-kId
-kId
-kId
+tsg
+aSh
+tsg
 kId
 kId
 kId
@@ -54161,28 +54051,28 @@ aaa
 aaa
 aaa
 aaa
-aOa
-aOa
-aOa
-aOa
-aRw
-aSs
-aTy
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bdS
 gnW
 tsg
-aXe
+aQb
 kId
 bmV
+kId
+kId
+kId
+kId
 bmV
-bmV
-bmV
-bmV
-bmV
-bmV
-bmV
-bmV
-bmV
+kId
+kId
 bmV
 bmV
 bmV
@@ -54412,35 +54302,35 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aDr
-aDr
-aDr
-aDr
 aaa
 aaa
 aaa
 aaa
-aPY
-aPY
-aPY
-aPY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bdS
 bmV
 els
 aBB
 kId
 bmV
-baq
-baq
-baq
-baq
-baq
-baq
-baq
-baq
-baq
-bmr
+bmV
+bmV
+bmV
+bmV
+bmV
+bmV
+bmV
+bmV
 bnK
 bpj
 bqr
@@ -54668,28 +54558,28 @@ aaa
 aaq
 aaa
 aaa
-aDr
-aDr
-aLH
-aJW
-aKO
-aDr
-aDr
 aaa
 aaa
 aaa
 aaa
-aak
 aaa
 aaa
-bmV
-aVh
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
+aOI
 tsg
 aBB
 kId
 bmV
-baq
-baq
 baq
 baq
 baq
@@ -54924,29 +54814,29 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aDr
-aIC
-aJZ
-aJX
-aKP
-aLI
-aDr
-bmV
 aaa
 aaa
 aaa
-aak
 aaa
 aaa
-bmV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
 dDa
 tsg
 aBB
 kId
 bmV
-baq
-baq
 baq
 baq
 baq
@@ -55181,29 +55071,29 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aHW
-kId
-kId
-aKa
+aaa
+aaa
+aaa
+aaa
+aaa
 bRM
-kId
-aNi
-bmV
-bmV
-aDr
-aDr
-bmV
-aDr
-bmV
-bmV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
 dDa
 tsg
 aBB
 kId
 bmV
-baq
-baq
 baq
 baq
 baq
@@ -55438,33 +55328,33 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aIg
-kId
-aLJ
-aJY
-kId
-aKa
-aOy
-bmV
-aOI
-kId
-aSh
-aRl
-aSh
-aTf
-bmV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bRM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
 cZG
 tsg
-aXf
+aQc
 kId
 bmV
 baq
 baq
 baq
-baq
-bfz
-baq
+aTh
 baq
 baq
 bld
@@ -55695,29 +55585,29 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aIz
-aIB
-aJf
-aJZ
-aMs
-kId
-aJh
-aOc
-aJh
-kId
-kId
-kId
-kId
-kId
-aOc
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
 kId
 tsg
-aXg
+aQe
 kId
 bmV
-baq
-baq
 baq
 baq
 baq
@@ -55952,29 +55842,29 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aIz
-aKa
-aJg
-kId
-aMt
-kId
-aJZ
-bmV
-aBB
-aBB
-kId
-aRz
-kId
-gnW
-bmV
+aaa
+aaa
+aaa
+bRM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
 aEm
 tsg
 aBB
 kId
 bmV
-baq
-baq
 baq
 baq
 baq
@@ -56209,29 +56099,29 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aIA
-kId
-kId
-kId
-kId
-kId
-aQe
-bmV
-bmV
-aDr
-aDr
-bmV
-aDr
-bmV
-bmV
-aVi
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
+aPY
 tsg
 aBB
 kId
 bmV
-baq
-baq
 baq
 baq
 baq
@@ -56466,37 +56356,37 @@ aaa
 aaa
 aaa
 aaa
-aDr
-aDr
-aKQ
-aJh
-aKb
+aaa
+aaa
+aaa
+aaa
+aaa
 bRM
-aNh
-aDr
-bmV
-aaa
-aak
-aaa
-aak
 aaa
 aaa
-bmV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
 kId
 tsg
 aBB
 cXf
 bmV
-baq
-baq
-baq
-baq
-baq
-baq
-baq
-baq
-baq
-bmr
+bmV
+bmV
+bmV
+bmV
+bmV
+bmV
+bmV
+bmV
 bop
 bpk
 bqA
@@ -56724,35 +56614,35 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aDr
 aDr
-aLX
-aLH
-aLq
+aDr
 aDr
 aDr
 aaa
 aaa
-aak
-aaa
-aak
 aaa
 aaa
-bmV
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bdS
 kId
 tsg
 kId
 kId
 bmV
-bmV
-bmV
-bmV
-bmV
-bmV
-bmV
-bmV
-bmV
-bmV
+kId
+kId
+kId
+kId
+kId
+kId
+kId
 bmV
 bmV
 bmV
@@ -56981,28 +56871,28 @@ aaa
 aaa
 aaa
 aaa
+aDr
+aDr
+aIC
+aJZ
+aKN
+aDr
+aDr
 aaa
-aDr
-aDr
-aDr
-aDr
-aDr
 aaa
 aaa
 aaa
-aOJ
+aaa
+aaa
+aaa
 bmV
-aOJ
 bmV
-bmV
-bmV
-aVj
+bdS
+aPZ
 tsg
-kId
-kId
 bmV
-kId
-kId
+bmV
+bmV
 tsg
 tsg
 tsg
@@ -57237,21 +57127,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aDr
+aDr
+aIg
+aJf
+aKa
+aKO
+aLq
+aDr
 bmV
-aQa
-aQa
-aQa
-aTg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 bmV
 kId
 tsg
@@ -57494,21 +57384,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aDr
+aam
+kId
+kId
+aIA
+kId
+kId
+aLJ
 bmV
-aQb
-aQa
-aQa
-aTh
+bmV
+aDr
+aDr
+bmV
+aDr
+bmV
 bmV
 kId
 tsg
@@ -57751,22 +57641,22 @@ aaa
 aaa
 aaa
 aaa
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aDr
+aEk
+kId
+aJh
+aKb
+kId
+aIA
+aKO
 bmV
+aNh
+kId
 aQa
+aNi
 aQa
-aRn
 aTi
-bmV
+aMt
 kId
 tsg
 kId
@@ -58008,22 +57898,22 @@ aaa
 aaa
 aaa
 aaa
-aaj
-azn
-azn
-azn
-azn
-azn
-azn
-azn
-azn
-aak
+aDr
+aFw
+aIz
+aJV
+aJf
+aJW
+kId
+aJX
+aMt
+aJX
+kId
+kId
+kId
+kId
+kId
 bmV
-aQc
-aQa
-aQa
-aQa
-aUf
 kId
 tsg
 bmV
@@ -58265,21 +58155,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aak
-aaa
-aDq
-aak
-aak
+aDr
+aFw
+aIA
+aJW
+kId
+aKP
+kId
+aJf
 bmV
-aQa
+aBB
+aBB
+kId
 aRn
-aSi
-aRn
+kId
+gnW
 bmV
 kId
 tsg
@@ -58522,21 +58412,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaq
-aaa
-aam
-azn
-azn
-azn
-azn
-azn
-aak
+aDr
+aHW
+kId
+kId
+kId
+kId
+kId
+aLX
 bmV
-aQa
-aQa
-aRn
-aQa
+bmV
+aDr
+aDr
+bmV
+aDr
+bmV
 bmV
 kId
 tsg
@@ -58779,21 +58669,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aak
-aak
-aak
+aDr
+aDr
+aIB
+aJX
+aKM
+kId
+aLH
+aDr
 bmV
-aQw
-aQa
-aSA
-aRn
+aaa
+aak
+aaa
+aak
+aaa
+aak
 bmV
 kId
 tsg
@@ -59037,20 +58927,20 @@ aaa
 aaa
 aaa
 aaa
+aDr
+aDr
+aJY
+aIC
+aKQ
+aDr
+aDr
 aaa
 aaa
-aaa
-aaa
-aaa
-aaj
-azn
-azn
 aak
-bmV
-bmV
-bmV
-bmV
-bmV
+aaa
+aak
+aaa
+aak
 bmV
 wRL
 tsg
@@ -59295,17 +59185,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aDr
+aDr
+aDr
+aDr
+aDr
 aak
 aak
 aOd
 aOd
 aOd
 aOd
-aak
 aak
 aak
 bmV
@@ -59558,7 +59448,7 @@ aaa
 aaa
 aaa
 aak
-aak
+aaa
 aak
 bmV
 bfq
@@ -61090,12 +60980,12 @@ aaa
 aaa
 aaa
 aaa
-aDq
-aDq
-aDq
-aDq
-aDq
-aDq
+aaa
+aaa
+aaa
+aaa
+aaa
+aak
 aak
 aak
 aak
@@ -61347,12 +61237,12 @@ aaa
 aaa
 aaa
 aaa
-aDq
-bgf
-bgf
-bgf
-bgf
-bgf
+aaa
+aaa
+aaa
+aaa
+aaa
+aak
 bmV
 bmV
 bmV
@@ -61605,11 +61495,11 @@ aaa
 aaa
 aaa
 aak
-aEk
-aEk
-aEk
-aEk
-aEk
+aak
+aak
+aak
+aak
+aak
 bmV
 dDa
 kId
@@ -74187,7 +74077,7 @@ ays
 azA
 aAE
 ayl
-aBM
+aye
 aye
 aBD
 aHb
@@ -75993,7 +75883,7 @@ coV
 coV
 cgz
 coV
-cgz
+bVq
 coV
 coV
 coV
@@ -85830,7 +85720,7 @@ epN
 bOz
 jxL
 bVN
-coh
+bfo
 crY
 eWL
 cnp

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -124,8 +124,14 @@
 /turf/open/floor/iron/dark,
 /area/security/processing)
 "aaH" = (
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
+/obj/structure/rack,
+/obj/item/tank/internals/anesthetic,
+/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "aaI" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Brig - Prison Elevator";
@@ -226,6 +232,7 @@
 	name = "Transfers Vent Toggle";
 	req_access_txt = "3"
 	},
+/obj/structure/closet/secure_closet/injection,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aaY" = (
@@ -317,6 +324,8 @@
 /area/security/execution/education)
 "abv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "aby" = (
@@ -360,10 +369,9 @@
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "abO" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/brig)
 "acm" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/end{
@@ -484,9 +492,7 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "acY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "acZ" = (
@@ -629,14 +635,14 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "adz" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "briglockdown";
+	name = "brig shutters"
 	},
-/obj/structure/rack,
-/obj/item/tank/internals/anesthetic,
-/obj/item/wrench,
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "adD" = (
 /obj/structure/table,
 /obj/item/pen,
@@ -689,12 +695,9 @@
 /turf/open/floor/plating/grass,
 /area/security/processing)
 "adW" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/security/execution/education)
+/area/security/brig)
 "adX" = (
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron/showroomfloor,
@@ -898,10 +901,10 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "afl" = (
-/obj/structure/cable,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/security/brig)
 "afm" = (
 /turf/closed/wall/r_wall,
 /area/science/lab)
@@ -1007,6 +1010,7 @@
 	id = "Prison Gate";
 	name = "prison blast door"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/processing)
 "agt" = (
@@ -1039,6 +1043,8 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "agA" = (
@@ -1079,16 +1085,19 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "ahn" = (
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 1"
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "ahr" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/pods{
 	pixel_y = 30
 	},
@@ -1210,12 +1219,12 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "aiP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/machinery/camera/directional/east{
+	c_tag = "Fore Primary Hall - Security Reception";
+	name = "Hallway Camera"
 	},
 /turf/open/floor/iron,
-/area/security/brig)
+/area/hallway/primary/fore)
 "aiV" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -1287,11 +1296,13 @@
 /turf/open/floor/plating,
 /area/security/processing)
 "ajp" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L4"
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_x = 32
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/security/brig)
 "ajs" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -1358,14 +1369,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "ajO" = (
-/obj/structure/table,
-/obj/item/candle{
-	pixel_x = -8;
-	pixel_y = 8
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
 	},
-/obj/item/food/grown/rainbow_flower,
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_x = -30
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ajP" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/north{
@@ -1406,17 +1424,8 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"ajY" = (
-/obj/item/beacon,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/security/brig)
 "aka" = (
 /obj/machinery/vending/coffee,
-/obj/structure/sign/departments/security{
-	pixel_x = -30
-	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 1;
@@ -1449,25 +1458,17 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "akl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "akt" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 30
-	},
+/obj/machinery/bluespace_vendor/directional/east,
 /turf/open/floor/iron,
-/area/hallway/secondary/command)
+/area/hallway/primary/fore)
 "akE" = (
 /obj/machinery/door/window/brigdoor/security/holding/eastleft,
 /obj/structure/chair,
@@ -1479,7 +1480,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "akL" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -1499,25 +1499,13 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "akV" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
+	id = "Cell 1";
+	name = "Cell 1"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "akZ" = (
 /turf/closed/wall/r_wall,
@@ -1532,7 +1520,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ald" = (
-/obj/structure/cable,
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
 	req_access_txt = "63"
@@ -1567,7 +1554,6 @@
 /area/security/brig)
 "alA" = (
 /obj/structure/cable,
-/obj/machinery/firealarm/directional/east,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -1612,25 +1598,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "alK" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
+/obj/machinery/door/poddoor/preopen{
+	id = "briglockdown";
+	name = "brig shutters"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/security/brig)
 "alL" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
@@ -1644,13 +1619,18 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "alS" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/landmark/start/security_officer,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig)
 "alT" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/item/beacon,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig)
 "alW" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "gulagdoor";
@@ -1669,8 +1649,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ami" = (
-/turf/closed/wall/r_wall,
-/area/security/warden)
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "amm" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/sink{
@@ -1705,10 +1691,10 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "amw" = (
+/obj/machinery/light/directional/north,
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "amA" = (
@@ -1739,40 +1725,34 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "amL" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 1;
 	name = "Security red corner"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/security/brig)
-"amP" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Fore Primary Hall - Security Reception";
-	name = "Hallway Camera"
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
 	},
-/obj/machinery/bluespace_vendor/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"amP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "amR" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/obj/structure/closet,
+/obj/item/bedsheet/cosmos,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "amU" = (
 /obj/structure/reflector/box/anchored{
 	dir = 1
@@ -1780,7 +1760,6 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "amY" = (
-/obj/structure/cable,
 /obj/machinery/door/window/brigdoor/security/holding/eastright,
 /turf/open/floor/iron/dark,
 /area/security/brig)
@@ -1794,14 +1773,25 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "anc" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/security/brig)
-"and" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
 	},
-/obj/machinery/light/small/directional/south,
+/obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "anf" = (
@@ -1824,18 +1814,23 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ans" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Security Airlock";
-	name = "Security Camera";
-	network = list("ss13","security")
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 2";
+	name = "Cell 2 Locker"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "any" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/machinery/recharger{
+	pixel_x = 6;
+	pixel_y = 3
+	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "anC" = (
@@ -1852,26 +1847,30 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "anE" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/space)
-"anI" = (
-/obj/structure/sign/departments/security{
-	pixel_x = -30
+/obj/structure/table,
+/obj/machinery/button/door{
+	dir = 4;
+	id = "briglockdown";
+	name = "Brig Lockdown";
+	pixel_x = -5;
+	pixel_y = 7;
+	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_x = 5;
+	pixel_y = 7;
+	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
+/obj/machinery/button/flasher{
+	id = "armoryflash";
+	name = "armory flasher button";
+	pixel_y = -3
 	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "aoa" = (
 /obj/machinery/camera/motion/directional/east{
 	c_tag = "Outer Armory N";
@@ -1918,6 +1917,61 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aol" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
+"aon" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "briglockdown";
+	name = "brig shutters"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/warden)
+"aoo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 2"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"aoq" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
+/area/security/brig)
+"aor" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"aov" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "briglockdown";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
+"aow" = (
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"aoI" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/warden)
+"aoM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
+"aoN" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/security)
+"aoP" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	name = "Security red corner"
@@ -1933,95 +1987,6 @@
 	req_access_txt = "3"
 	},
 /turf/open/floor/iron,
-/area/security/warden)
-"aon" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"aoo" = (
-/obj/structure/table,
-/obj/machinery/button/door{
-	dir = 4;
-	id = "briglockdown";
-	name = "Brig Lockdown";
-	pixel_x = -5;
-	pixel_y = 7;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_x = 5;
-	pixel_y = 7;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/flasher{
-	id = "armoryflash";
-	name = "armory flasher button";
-	pixel_y = -3
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"aoq" = (
-/obj/machinery/computer/prisoner/management{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"aor" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"aos" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"aov" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "briglockdown";
-	name = "brig shutters"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/warden)
-"aow" = (
-/turf/open/floor/iron/dark,
-/area/security/brig)
-"aoI" = (
-/obj/machinery/computer/crew{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"aoM" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
-"aoN" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/maintenance/department/security)
-"aoP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aoR" = (
 /obj/structure/rack,
@@ -2049,14 +2014,15 @@
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "aoW" = (
-/obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
 "apc" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "apd" = (
 /obj/machinery/door/firedoor,
@@ -2086,48 +2052,46 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "apq" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/landmark/start/warden,
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "apr" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/space)
-"apu" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "briglockdown";
-	name = "brig shutters"
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Reception Desk"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Security Reception Desk";
-	req_access_txt = "1"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/warden)
-"apw" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"apx" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"apu" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"apw" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"apx" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Security Airlock";
+	name = "Security Camera";
+	network = list("ss13","security")
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "apA" = (
 /obj/structure/rack,
 /obj/item/storage/box/firingpins,
@@ -2186,46 +2150,52 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "apP" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/closet/secure_closet/warden,
+/obj/item/toy/mecha/durand,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "apQ" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/camera/directional/south{
+	c_tag = "Brig - Warden Office";
+	name = "Security Camera";
+	network = list("ss13","security")
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "apT" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"apW" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/pen/fountain,
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"apW" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "aqa" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_x = 30
 	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aqc" = (
-/obj/item/bodypart/l_arm,
-/obj/item/stack/medical/gauze,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"aqn" = (
-/obj/structure/chair{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
 	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"aqn" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 3";
+	name = "Cell 3 Locker"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "aqo" = (
 /obj/machinery/requests_console/directional/east{
 	department = "E.V.A. Storage";
@@ -2234,18 +2204,14 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
 "aqs" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/item/bedsheet/cosmos,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/space)
-"aqy" = (
-/obj/structure/closet/secure_closet/warden,
-/obj/item/toy/mecha/durand,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "aqz" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/security_space_law,
@@ -2280,18 +2246,19 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aqH" = (
-/obj/structure/bed/dogbed/mcgriff,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
-/obj/machinery/camera/directional/south{
-	c_tag = "Brig - Warden Office";
-	name = "Security Camera";
-	network = list("ss13","security")
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/obj/structure/chair,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aqK" = (
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/obj/machinery/light/directional/east,
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_x = 32
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/brig)
 "aqL" = (
 /obj/machinery/camera/motion/directional/east{
 	c_tag = "Outer Armory C";
@@ -2307,21 +2274,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aqR" = (
-/obj/structure/table,
-/obj/item/toy/figure/warden{
-	pixel_x = -8;
-	pixel_y = 6
-	},
-/obj/item/hand_labeler{
-	pixel_x = -5;
-	pixel_y = -8
-	},
-/obj/item/folder/red{
-	pixel_x = 6;
-	pixel_y = -7
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig)
 "aqS" = (
 /obj/structure/cable,
 /obj/structure/reagent_dispensers/fueltank,
@@ -2334,7 +2290,6 @@
 /area/maintenance/starboard)
 "aqU" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "aqV" = (
@@ -2380,21 +2335,28 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "arr" = (
-/obj/structure/cable,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = -30
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/security/interrogation)
 "arO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "briglockdown";
 	name = "brig shutters"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/southleft{
+	dir = 4;
+	name = "Reception Desk"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Security Reception Desk";
+	req_access_txt = "1"
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/security/warden)
 "arS" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser,
@@ -2412,9 +2374,26 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "arW" = (
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "arZ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
@@ -2429,18 +2408,35 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "asc" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
-/area/space)
-"asj" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "briglockdown";
-	name = "brig shutters"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/warden)
+/obj/machinery/flasher/directional/south{
+	id = "Cell 3"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"asj" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "ask" = (
 /obj/structure/sign/poster/official/here_for_your_safety{
 	pixel_x = 30
@@ -2473,9 +2469,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "asC" = (
-/obj/effect/spawner/structure/window,
+/obj/structure/table,
+/obj/item/candle{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/food/grown/rainbow_flower,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard)
 "asL" = (
 /obj/structure/table,
 /obj/item/grenade/barrier,
@@ -2555,10 +2556,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ate" = (
-/obj/structure/rack,
-/obj/item/weldingtool,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_x = 32
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/security/brig)
 "atf" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -2568,12 +2573,11 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "ath" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_x = 33
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 4";
+	name = "Cell 4 Locker"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "atj" = (
 /obj/machinery/door/poddoor/preopen{
@@ -2582,9 +2586,8 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/security/warden)
 "atl" = (
 /obj/structure/railing{
 	dir = 8
@@ -2597,45 +2600,63 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "atC" = (
-/obj/structure/reflector/single,
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/cable,
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
+	id = "Cell 4";
+	name = "Cell 4"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "aub" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "aum" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/structure/bed/dogbed/mcgriff,
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "auq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/flasher/directional/south{
-	id = "Cell 1"
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "aur" = (
-/obj/structure/bed,
-/obj/item/radio/intercom/prison/directional/south,
-/turf/open/floor/iron/dark,
-/area/security/brig)
-"aus" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
+/obj/structure/table,
+/obj/item/toy/figure/warden{
+	pixel_x = -8;
+	pixel_y = 6
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/item/hand_labeler{
+	pixel_x = -5;
+	pixel_y = -8
+	},
+/obj/item/folder/red{
+	pixel_x = 6;
+	pixel_y = -7
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
+"aus" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/food/grown/chili{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/stack/ore/glass{
+	pixel_x = 8;
+	pixel_y = -6
+	},
+/turf/open/floor/iron/dark,
+/area/security/interrogation)
 "auv" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/bodycontainer/morgue,
+/obj/structure/stairs/west,
 /turf/open/floor/iron,
-/area/maintenance/starboard)
+/area/security/brig)
 "aux" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Fore Primary Hallway - Security";
@@ -2661,9 +2682,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "auA" = (
-/obj/structure/closet/wardrobe/green,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/flasher/directional/south{
+	id = "Cell 4"
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "auD" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -2679,11 +2705,9 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "auJ" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
+/obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/port)
 "auL" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 1
@@ -2696,26 +2720,21 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "auX" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/fore";
-	dir = 1;
-	name = "Fore Maintenance APC";
-	pixel_y = 23
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/port)
 "avn" = (
 /turf/open/floor/iron,
 /area/security/processing)
 "avH" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/effect/landmark/start/warden,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "avI" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating,
@@ -2748,17 +2767,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "awB" = (
+/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 1;
 	name = "Command blue corner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "awC" = (
@@ -2802,6 +2816,10 @@
 /area/ai_monitored/security/armory)
 "awL" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "awN" = (
@@ -2811,15 +2829,6 @@
 /obj/item/storage/lockbox/loyalty,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"awO" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 8;
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "awQ" = (
 /obj/structure/table,
 /obj/item/key/security,
@@ -2863,9 +2872,12 @@
 /turf/open/floor/iron/white,
 /area/science)
 "awX" = (
+/obj/machinery/computer/prisoner/management{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "awY" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
@@ -2955,9 +2967,24 @@
 /turf/open/floor/iron/white,
 /area/science)
 "axF" = (
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "Court Room";
+	name = "Courtroom";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/brig)
 "axG" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
@@ -3022,15 +3049,6 @@
 /obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/iron/white,
 /area/security/brig)
-"axU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/flasher/directional/south{
-	id = "Cell 2"
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
 "axW" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
@@ -3047,10 +3065,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "axY" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -30
-	},
-/obj/machinery/light/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "axZ" = (
@@ -3076,30 +3091,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ayf" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ayg" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ayh" = (
@@ -3107,17 +3106,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ayi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
-"ayj" = (
-/obj/structure/table/glass,
-/obj/item/pen,
-/obj/item/hatchet,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"ayk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -3131,20 +3119,23 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"ayl" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
-/obj/machinery/light/directional/north,
+"ayj" = (
+/obj/structure/table/glass,
+/obj/item/pen,
+/obj/item/hatchet,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
-/area/hallway/secondary/command)
+/area/maintenance/starboard)
+"ayk" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -30
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"ayl" = (
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ayo" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -3286,28 +3277,21 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "ayL" = (
-/obj/machinery/door_timer{
-	id = "Cell 1";
-	name = "Cell 1";
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "ayW" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/machinery/disposal/bin,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "ayX" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "aza" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/dead_body_placer,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "azn" = (
@@ -3329,14 +3313,8 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "azs" = (
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 8;
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/turf/closed/wall/r_wall,
+/area/security/warden)
 "azt" = (
 /obj/structure/cable,
 /obj/machinery/navbeacon{
@@ -3360,8 +3338,14 @@
 /area/hallway/secondary/command)
 "azx" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -3420,14 +3404,16 @@
 	dir = 8;
 	name = "Security red corner"
 	},
-/obj/structure/cable,
+/obj/structure/sign/departments/security{
+	pixel_x = -30
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aAd" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aAg" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
@@ -3493,13 +3479,9 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aAz" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aAA" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
@@ -3560,10 +3542,9 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aAP" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aAS" = (
 /obj/machinery/computer/med_data/laptop{
 	dir = 8;
@@ -3583,13 +3564,6 @@
 	network = list("ss13","security")
 	},
 /turf/open/floor/iron,
-/area/security/brig)
-"aBn" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
-	},
-/turf/open/floor/iron/dark,
 /area/security/brig)
 "aBo" = (
 /obj/machinery/requests_console/directional/east{
@@ -3692,14 +3666,13 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "aBI" = (
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 8;
-	id = "Cell 3";
-	name = "Cell 3"
+/obj/machinery/light/directional/north,
+/obj/structure/closet/secure_closet/courtroom,
+/obj/item/megaphone{
+	name = "The Judge's Megaphone"
 	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aBM" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -3775,13 +3748,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "aCK" = (
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
-/area/maintenance/starboard)
+/area/security/courtroom)
 "aCO" = (
 /obj/machinery/camera/motion/directional/south{
 	c_tag = "Outer Armory S";
@@ -3837,19 +3806,21 @@
 /area/hallway/primary/fore)
 "aDx" = (
 /obj/structure/stairs/west,
+/obj/structure/stairs/west,
 /turf/open/floor/iron,
 /area/security/brig)
 "aDz" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/security/interrogation)
+/obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aDB" = (
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aDE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "aDG" = (
 /turf/closed/wall,
 /area/security/courtroom)
@@ -3891,10 +3862,8 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aDV" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
-	name = "Cell 4 Locker"
-	},
+/obj/structure/bed,
+/obj/item/radio/intercom/prison/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aEc" = (
@@ -3914,10 +3883,12 @@
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "aEj" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/north,
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/security/interrogation)
+/area/security/courtroom)
 "aEk" = (
 /obj/structure/frame/computer,
 /obj/item/circuitboard/computer/atmos_alert,
@@ -4009,7 +3980,6 @@
 /area/maintenance/starboard)
 "aEG" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aEJ" = (
@@ -4019,29 +3989,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"aEN" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "aEO" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
@@ -4224,14 +4171,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "aGj" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_x = 32
-	},
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aGk" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/random/maintenance,
@@ -4244,12 +4187,9 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aGr" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aGt" = (
 /obj/machinery/light/directional/south,
@@ -4275,6 +4215,27 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aGB" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"aGC" = (
+/obj/structure/closet/secure_closet/courtroom,
+/turf/open/floor/iron,
+/area/security/courtroom)
+"aGD" = (
+/obj/structure/table/wood,
+/obj/item/radio/intercom{
+	freerange = 1;
+	freqlock = 1;
+	frequency = 1490;
+	listening = 0;
+	name = "Court Announcer"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	name = "Command blue corner"
@@ -4284,55 +4245,86 @@
 	dir = 4;
 	name = "Command blue corner"
 	},
-/obj/effect/spawner/structure/window,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
-"aGC" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"aGD" = (
-/obj/item/bodypart/r_leg,
-/obj/structure/bed/roller,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
+/area/security/courtroom)
 "aGE" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock{
-	name = "Abandoned Medical Aux Room"
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
 /turf/open/floor/iron,
-/area/maintenance/starboard)
+/area/security/courtroom)
 "aGF" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "aGG" = (
-/obj/structure/filingcabinet,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 30
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aGH" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/table/wood,
+/obj/item/gavelblock,
+/obj/item/gavelhammer,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aGI" = (
-/obj/structure/closet/crate,
+/obj/structure/sign/directions/security{
+	dir = 1;
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"aGJ" = (
+/obj/structure/closet/wardrobe/green,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"aGJ" = (
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "aGP" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron,
@@ -4347,37 +4339,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aGT" = (
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 8;
-	id = "Cell 4";
-	name = "Cell 4"
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/obj/machinery/vending/medical,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aGX" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aGY" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "Court Room";
-	name = "Courtroom";
-	req_access_txt = "63"
+/obj/structure/chair{
+	name = "Judge"
 	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/security/brig)
+/area/security/courtroom)
 "aHb" = (
 /turf/open/floor/iron,
 /area/command/gateway)
@@ -4449,9 +4424,12 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aHv" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aHw" = (
 /turf/closed/wall,
 /area/security/checkpoint/science/research)
@@ -4475,13 +4453,11 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aHB" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aHC" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/bottle/absinthe{
@@ -4492,38 +4468,32 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aHE" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aHI" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/space/basic,
-/area/maintenance/solars)
-"aHK" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "briglockdown";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/security/brig)
+/area/maintenance/starboard)
+"aHI" = (
+/obj/structure/rack,
+/obj/item/weldingtool,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"aHK" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Courtroom Prosecution";
+	name = "Courtroom Camera";
+	network = list("ss13","security","court")
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aHM" = (
 /obj/structure/chair,
 /obj/item/toy/plush/awakenedplushie,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aHN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/flasher/directional/south{
-	id = "Cell 3"
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "aHO" = (
@@ -4534,28 +4504,75 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aHS" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/security/brig)
-"aHT" = (
-/obj/structure/chair{
-	name = "Judge"
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"aHU" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
+"aHT" = (
+/obj/machinery/holopad,
+/obj/item/beacon,
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
-"aHV" = (
-/obj/structure/chair{
-	name = "Bailiff"
+/area/security/courtroom)
+"aHU" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
 	},
-/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/courtroom)
+"aHV" = (
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aHW" = (
@@ -4608,8 +4625,9 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aIn" = (
-/turf/closed/wall,
-/area/hallway/secondary/exit)
+/obj/structure/reflector/single,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aIp" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -4645,12 +4663,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aIM" = (
-/obj/machinery/light/directional/west,
-/obj/structure/sign/departments/court{
-	pixel_x = -32
-	},
+/obj/item/bodypart/l_arm,
+/obj/item/stack/medical/gauze,
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/maintenance/starboard)
 "aIN" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -4756,15 +4772,13 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aJG" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
+/obj/structure/chair{
+	dir = 4;
+	name = "Prosecution"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aJH" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 1
@@ -4773,8 +4787,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aJJ" = (
-/obj/item/storage/box/lights/mixed,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aJU" = (
@@ -4824,8 +4839,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "aKh" = (
-/turf/closed/wall,
-/area/space)
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "aKi" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/plating,
@@ -4890,39 +4910,30 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "aKV" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Courtroom Judge";
-	name = "Courtroom Camera";
-	network = list("ss13","security","court")
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aKY" = (
-/obj/structure/closet/secure_closet/courtroom,
-/turf/open/floor/iron,
-/area/security/courtroom)
-"aKZ" = (
-/obj/structure/table/wood,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "Security red corner"
-	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aLb" = (
@@ -4933,10 +4944,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aLc" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
 /area/security/courtroom)
 "aLg" = (
 /obj/structure/table,
@@ -5017,10 +5026,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aLP" = (
-/obj/structure/chair{
-	name = "Accused"
+/obj/machinery/door/window/southleft{
+	name = "Court Cell";
+	req_access_txt = "2"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aLV" = (
@@ -5088,26 +5097,13 @@
 "aMz" = (
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
-"aME" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom";
-	req_access_txt = "42"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
 "aMF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen{
+	name = "Court Telescreen";
+	network = list("court")
+	},
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aMH" = (
 /obj/machinery/door/airlock/maintenance{
@@ -5238,44 +5234,20 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aNq" = (
-/obj/item/radio/intercom/directional/west{
-	freerange = 1;
-	freqlock = 1;
-	frequency = 1490;
-	name = "Court Announcer"
-	},
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"aNx" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom{
-	freerange = 1;
-	freqlock = 1;
-	frequency = 1490;
-	listening = 0;
-	name = "Court Announcer"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
+/obj/machinery/camera/directional/west{
+	c_tag = "Fore Primary Hallway - Courtroom";
+	name = "Hallway Camera"
 	},
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/hallway/primary/fore)
+"aNx" = (
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aNy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
 	dir = 9
@@ -5473,29 +5445,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aOG" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
-	},
+/obj/effect/decal/cleanable/blood,
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/maintenance/starboard)
 "aOI" = (
 /obj/structure/closet/emcloset,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
@@ -5530,11 +5483,19 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aOO" = (
-/obj/structure/window/reinforced{
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/structure/window/reinforced,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/security/courtroom)
 "aOQ" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -5570,55 +5531,42 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aOX" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+/obj/structure/fluff/broken_flooring{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/effect/mapping_helpers/dead_body_placer,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "aOY" = (
 /obj/structure/table/wood,
-/obj/item/gavelblock,
-/obj/item/gavelhammer,
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
+	color = "#73c2fb";
 	dir = 1;
-	name = "Command blue corner"
+	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
+	color = "#73c2fb";
 	dir = 4;
-	name = "Command blue corner"
+	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
 	dir = 8;
-	name = "Command blue corner"
+	name = "Medical blue corner"
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aPa" = (
-/obj/machinery/holopad,
+/obj/machinery/disposal/bin,
+/obj/machinery/camera/directional/south{
+	c_tag = "Courtroom S";
+	name = "Courtroom Camera";
+	network = list("ss13","security")
+	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "aPc" = (
@@ -5648,18 +5596,17 @@
 /turf/closed/wall,
 /area/commons/fitness)
 "aPk" = (
-/obj/machinery/door/window/southleft{
-	name = "Court Cell";
-	req_access_txt = "2"
+/obj/machinery/camera/directional/east{
+	c_tag = "Courtroom Defence";
+	name = "Courtroom Camera";
+	network = list("ss13","security","court")
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/security/courtroom)
 "aPl" = (
-/obj/structure/sign/directions/security{
-	dir = 1;
+/obj/structure/sign/departments/court{
 	pixel_x = -32
 	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aPm" = (
@@ -5779,11 +5726,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aQl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aQp" = (
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
@@ -5803,22 +5752,20 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "aQA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aQC" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "aQE" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Minisat Exterior E";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/iv_drip,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aQK" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -5932,39 +5879,58 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aRo" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/iron/dark,
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/wood,
 /area/security/courtroom)
 "aRq" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
 /area/security/courtroom)
 "aRr" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/requests_console/directional/north{
+	department = "Law Office";
+	name = "Law Office RC"
+	},
+/turf/open/floor/carpet/purple,
 /area/security/courtroom)
 "aRs" = (
-/obj/structure/table,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/dark,
+/obj/machinery/camera/directional/north{
+	c_tag = "Law Office";
+	name = "Law Office Camera"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/button/door/directional/north{
+	id = "law1";
+	name = "Purple Law Office Privacy";
+	req_access_txt = "38"
+	},
+/turf/open/floor/carpet/purple,
 /area/security/courtroom)
 "aRu" = (
-/obj/structure/chair{
-	dir = 1
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet,
 /area/security/courtroom)
 "aRv" = (
-/obj/structure/chair{
+/obj/structure/chair/sofa/right{
+	desc = "Made of very expensive furs, probably from an endangered animal.";
+	name = "Luxurious sofa"
+	},
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet,
 /area/security/courtroom)
 "aRw" = (
 /obj/structure/cable,
@@ -5991,13 +5957,9 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/fore)
 "aRC" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/camera/directional/south{
-	c_tag = "Courtroom S";
-	name = "Courtroom Camera";
-	network = list("ss13","security")
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/wood,
 /area/security/courtroom)
 "aRF" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -6111,18 +6073,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aSq" = (
-/obj/structure/chair/sofa/left{
-	desc = "Made of very expensive furs, probably from an endangered animal.";
-	name = "Luxurious sofa"
-	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aSr" = (
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/light/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aSs" = (
@@ -6179,21 +6137,14 @@
 /turf/open/floor/plating,
 /area/medical/treatment_center)
 "aSF" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Courtroom Prosecution";
-	name = "Courtroom Camera";
-	network = list("ss13","security","court")
-	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aSG" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Courtroom Defence";
-	name = "Courtroom Camera";
-	network = list("ss13","security","court")
-	},
+/obj/item/bodypart/r_leg,
+/obj/structure/bed/roller,
 /turf/open/floor/iron,
-/area/security/courtroom)
+/area/maintenance/starboard)
 "aSJ" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/iron/white,
@@ -6284,9 +6235,28 @@
 /turf/open/floor/iron,
 /area/space)
 "aTd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
 	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "aTe" = (
@@ -6337,47 +6307,42 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aTl" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light_switch/directional/west,
+/obj/structure/bookcase,
+/obj/machinery/light/directional/west,
+/obj/machinery/button/door/directional/south{
+	id = "law3";
+	name = "Shared Law Office Privacy";
+	req_access_txt = "38"
+	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aTm" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/obj/item/stamp/law,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/purple,
 /area/service/lawoffice)
 "aTn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/taperecorder,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/purple,
 /area/service/lawoffice)
 "aTo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/requests_console/directional/north{
-	department = "Law Office";
-	name = "Law Office RC"
-	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/pen/fountain,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/purple,
 /area/service/lawoffice)
 "aTp" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Law Office";
-	name = "Law Office Camera"
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/button/door/directional/north{
-	id = "law1";
-	name = "Purple Law Office Privacy";
-	req_access_txt = "38"
-	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/purple,
 /area/service/lawoffice)
 "aTq" = (
@@ -6398,20 +6363,15 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aTs" = (
-/obj/machinery/vending/coffee,
 /obj/effect/turf_decal/siding/wood{
-	dir = 9
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aTt" = (
-/obj/structure/chair/sofa/right{
-	desc = "Made of very expensive furs, probably from an endangered animal.";
-	name = "Luxurious sofa"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/structure/table/wood,
+/obj/item/folder,
+/obj/item/pen,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "aTv" = (
@@ -6439,8 +6399,8 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "aTA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/item/radio/intercom/directional/north,
+/obj/item/kirbyplants/random,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aTB" = (
@@ -6582,17 +6542,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
-"aUp" = (
-/obj/structure/chair/comfy/black,
-/obj/effect/landmark/start/lawyer,
-/turf/open/floor/carpet/purple,
-/area/service/lawoffice)
-"aUs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "aUt" = (
 /obj/structure/sign/poster/official/science{
 	pixel_y = -30
@@ -6735,7 +6684,7 @@
 "aVs" = (
 /obj/structure/bookcase,
 /obj/machinery/light/directional/west,
-/obj/machinery/button/door/directional/south{
+/obj/machinery/button/door/directional/north{
 	id = "law3";
 	name = "Shared Law Office Privacy";
 	req_access_txt = "38"
@@ -6744,25 +6693,30 @@
 /area/service/lawoffice)
 "aVu" = (
 /obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/taperecorder,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/purple,
+/obj/item/storage/secure/briefcase,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "aVv" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/pen/fountain,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/purple,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "aVw" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/purple,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "aVx" = (
 /obj/effect/turf_decal/tile/purple{
@@ -6828,7 +6782,6 @@
 /area/security/checkpoint/medical)
 "aVI" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aVJ" = (
@@ -7207,22 +7160,18 @@
 /turf/open/floor/carpet/green,
 /area/service/chapel)
 "aYB" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Law Office Maintenance";
-	req_access_txt = "38"
-	},
-/turf/open/floor/wood,
-/area/maintenance/port)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "aYF" = (
 /obj/item/target/alien,
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "aYH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/service/lawoffice)
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "aYI" = (
 /obj/structure/cable,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -7573,15 +7522,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "bal" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/door/airlock/public/glass,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "bao" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin{
@@ -8324,19 +8269,28 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "bfk" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock{
+	name = "Abandoned Medical Aux Room"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/space)
+/area/maintenance/starboard)
 "bfo" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bfp" = (
-/obj/structure/chair,
-/turf/open/floor/iron,
-/area/space)
+/obj/item/radio/intercom/directional/west{
+	freerange = 1;
+	freqlock = 1;
+	frequency = 1490;
+	name = "Court Announcer"
+	},
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bfq" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -8355,11 +8309,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfA" = (
-/obj/structure/sign/warning/docking{
-	pixel_x = 30
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	freqlock = 1;
+	frequency = 1490;
+	name = "Court Announcer"
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bfB" = (
 /obj/structure/closet/crate/coffin,
 /obj/structure/window/reinforced,
@@ -8390,22 +8347,19 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bfZ" = (
-/obj/machinery/door_timer{
-	id = "Cell 4";
-	name = "Cell 4";
-	pixel_y = -32
+/obj/structure/chair{
+	name = "Bailiff"
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/security/brig)
+/area/security/courtroom)
 "bga" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/structure/chair{
+	name = "Accused"
 	},
-/obj/machinery/flasher/directional/south{
-	id = "Cell 4"
-	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/courtroom)
 "bgc" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -8484,11 +8438,9 @@
 /turf/open/floor/iron/chapel,
 /area/service/chapel)
 "bgA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "bgF" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /obj/item/reagent_containers/food/drinks/dry_ramen,
@@ -8683,18 +8635,18 @@
 /area/medical/medbay/lobby)
 "bhY" = (
 /obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
+	name = "External Airlock";
+	req_access_txt = "24"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard)
 "bie" = (
-/obj/structure/table,
-/obj/item/pickaxe/emergency,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/filingcabinet,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bih" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -8759,9 +8711,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bis" = (
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bit" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
@@ -8801,15 +8753,9 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "biC" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/courtroom";
-	dir = 4;
-	name = "Courtroom APC";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "biE" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -8907,13 +8853,10 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/customs)
 "bjf" = (
-/obj/docking_port/stationary/random{
-	dir = 8;
-	id = "pod_lavaland2";
-	name = "lavaland"
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bjv" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
@@ -8979,26 +8922,9 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "bjM" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
+/obj/structure/chair{
 	dir = 4;
-	name = "Security red corner"
+	name = "Prosecution"
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
@@ -9006,12 +8932,12 @@
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
-	dir = 1;
+	dir = 8;
 	name = "Security red corner"
 	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
-	dir = 8;
+	dir = 1;
 	name = "Security red corner"
 	},
 /obj/effect/turf_decal/tile/red{
@@ -9097,7 +9023,6 @@
 /area/commons/toilet)
 "bkb" = (
 /obj/structure/table/wood,
-/obj/item/folder,
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -9242,17 +9167,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "blk" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
@@ -9552,12 +9469,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bmH" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
-	id = "law3";
-	name = "Law Office Shared Privacy Door"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "bmI" = (
 /obj/machinery/vending/coffee,
@@ -9737,11 +9649,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "bnC" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "bnD" = (
 /obj/structure/chair,
 /obj/machinery/light/small/directional/north,
@@ -10392,11 +10302,13 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "bqY" = (
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
 	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bqZ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=security";
@@ -10626,19 +10538,12 @@
 /turf/open/floor/carpet,
 /area/service/chapel)
 "bsd" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Arrivals to Public Mining Dock";
-	name = "Hallway Camera"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/space)
-"bse" = (
-/obj/structure/table/wood,
-/obj/item/storage/briefcase/lawyer,
-/obj/item/toy/figure/lawyer,
-/turf/open/floor/carpet/purple,
-/area/service/lawoffice)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bsg" = (
 /obj/machinery/door/airlock{
 	id_tag = "Potty1";
@@ -10735,8 +10640,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bsy" = (
-/turf/open/floor/wood,
-/area/service/lawoffice)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bsB" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -10857,12 +10765,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"btk" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/service/lawoffice)
 "btm" = (
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -10956,10 +10858,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "btI" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/dry_ramen,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/door/airlock/public/glass{
+	name = "Courtroom"
+	},
+/obj/machinery/navbeacon/wayfinding,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "btS" = (
 /obj/machinery/food_cart,
 /turf/open/floor/iron/cafeteria,
@@ -11032,10 +10937,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "buj" = (
-/obj/structure/sign/directions/command{
-	dir = 1;
-	pixel_x = 32
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "buk" = (
@@ -11062,9 +10973,9 @@
 /area/hallway/primary/starboard)
 "bum" = (
 /obj/structure/table,
-/obj/item/trash/cheesie,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/microwave,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bur" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=green";
@@ -11168,9 +11079,9 @@
 /area/hallway/secondary/exit)
 "bvi" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bvm" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -11252,19 +11163,16 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "bvB" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Arrivals Viewing Area";
-	name = "Hallway Camera"
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bvD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bvI" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=evac";
@@ -11361,10 +11269,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"bwg" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/security/courtroom)
 "bwh" = (
 /obj/structure/sign/barsign{
 	pixel_y = -30
@@ -11531,9 +11435,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "bwI" = (
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bwL" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -11716,11 +11623,16 @@
 /turf/open/floor/plating,
 /area/service/library)
 "bxn" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/light_switch/directional/west{
+	pixel_x = -36
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
@@ -13270,13 +13182,6 @@
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"bBY" = (
-/obj/structure/chair{
-	dir = 4;
-	name = "Prosecution"
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "bBZ" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/carpet/green,
@@ -13579,13 +13484,12 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "bDa" = (
-/obj/structure/table/wood,
-/obj/machinery/door/window/northright{
-	name = "Library Desk Door";
-	req_access_txt = "37"
+/obj/structure/chair{
+	dir = 1
 	},
-/turf/open/floor/carpet/green,
-/area/service/library)
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/courtroom)
 "bDb" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13948,31 +13852,32 @@
 /turf/open/floor/iron/white,
 /area/science/lab)
 "bEq" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/space)
-"bEw" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/space)
-"bEz" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance Access";
-	req_access_txt = "12"
+/turf/open/floor/carpet/purple,
+/area/security/courtroom)
+"bEw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "law1";
+	name = "Purple Office Privacy Door"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/security/courtroom)
+"bEz" = (
+/obj/structure/chair/sofa{
+	desc = "Made of very expensive furs, probably from an endangered animal.";
+	name = "Luxurious sofa"
+	},
+/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/carpet,
+/area/security/courtroom)
 "bEA" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science/research)
@@ -14736,11 +14641,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bHN" = (
-/obj/machinery/door/airlock/public/glass,
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/structure/chair/sofa/left{
+	desc = "Made of very expensive furs, probably from an endangered animal.";
+	name = "Luxurious sofa"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/carpet,
+/area/security/courtroom)
 "bHT" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -14853,10 +14763,12 @@
 /turf/open/floor/plating,
 /area/science)
 "bIn" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/door/airlock/maintenance{
+	name = "Law Office Maintenance";
+	req_access_txt = "38"
+	},
+/turf/open/floor/wood,
+/area/maintenance/port)
 "bIo" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -15224,9 +15136,8 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bJX" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/space)
+/turf/open/floor/wood,
+/area/service/lawoffice)
 "bKd" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
@@ -15337,9 +15248,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bKJ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/carpet/purple,
+/area/service/lawoffice)
 "bKN" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -15513,10 +15423,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/service/bar/atrium)
-"bLb" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/security/courtroom)
 "bLd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -15566,15 +15472,10 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bLu" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Fore Primary Hallway - Courtroom";
-	name = "Hallway Camera"
-	},
-/obj/structure/sign/departments/court{
-	pixel_x = -32
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/lawyer,
+/turf/open/floor/carpet/purple,
+/area/service/lawoffice)
 "bLw" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -15725,18 +15626,17 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bNf" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/table/wood,
+/obj/item/storage/briefcase/lawyer,
+/obj/item/toy/figure/lawyer,
+/turf/open/floor/carpet/purple,
+/area/service/lawoffice)
 "bNm" = (
-/obj/machinery/disposal/bin,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
+/turf/open/floor/carpet/purple,
+/area/service/lawoffice)
 "bNw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -15787,9 +15687,20 @@
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "bNK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/door/airlock{
+	name = "Law Office A";
+	req_access_txt = "38"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "law1";
+	name = "Purple Office Privacy Door"
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/service/lawoffice)
 "bNQ" = (
 /obj/structure/table/wood,
 /obj/item/toy/figure/detective,
@@ -15807,17 +15718,16 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bOe" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_x = -32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/structure/railing,
-/obj/structure/table/wood,
-/obj/item/toy/figure/curator,
-/turf/open/floor/wood,
-/area/service/library)
+/turf/open/floor/carpet,
+/area/service/lawoffice)
 "bOf" = (
-/turf/closed/wall,
-/area/science/misc_lab/range)
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "bOg" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/light_switch/directional/south,
@@ -15910,7 +15820,7 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "bOI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/computer/warrant{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -15965,9 +15875,10 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "bPB" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/security/courtroom)
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/carpet,
+/area/service/lawoffice)
 "bPF" = (
 /obj/item/stack/sheet/pizza,
 /obj/machinery/space_heater,
@@ -16045,10 +15956,17 @@
 /turf/open/space/basic,
 /area/space)
 "bQp" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/door/airlock/public/glass{
+	name = "Law Reception"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/navbeacon/wayfinding,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/service/lawoffice)
 "bQr" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -16123,9 +16041,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bQO" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/space)
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/service/lawoffice)
 "bQR" = (
 /obj/structure/railing{
 	dir = 4
@@ -16133,9 +16054,12 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bQS" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/obj/effect/landmark/start/lawyer,
+/turf/open/floor/carpet/blue,
+/area/service/lawoffice)
 "bQV" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/north{
@@ -16218,9 +16142,10 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bRA" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "bRC" = (
@@ -16318,18 +16243,10 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bSz" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/navbeacon/wayfinding{
-	location = "Arrival Shuttle"
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/structure/table/wood,
+/obj/item/storage/briefcase/lawyer,
+/turf/open/floor/carpet/blue,
+/area/service/lawoffice)
 "bSG" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/ai_all,
@@ -16427,17 +16344,11 @@
 /turf/closed/wall,
 /area/service/hydroponics)
 "bTt" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/carpet/blue,
+/area/service/lawoffice)
 "bTB" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -16451,15 +16362,20 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bTJ" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_x = -32
+/obj/machinery/door/airlock{
+	name = "Law Office B";
+	req_access_txt = "38"
 	},
-/obj/structure/railing{
+/obj/machinery/door/poddoor/preopen{
+	id = "law2";
+	name = "Blue Office Privacy Door"
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/libraryscanner,
-/turf/open/floor/wood,
-/area/service/library)
+/turf/open/floor/carpet,
+/area/service/lawoffice)
 "bTM" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
@@ -16690,39 +16606,30 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bVm" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
+/obj/structure/chair/comfy/brown{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/carpet,
+/area/service/lawoffice)
 "bVp" = (
-/obj/structure/chair{
+/obj/machinery/door/airlock/public/glass{
+	name = "Courtroom";
+	req_access_txt = "42"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
 	dir = 1;
-	name = "Witness"
+	name = "Security red corner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/security/courtroom)
 "bVq" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -16752,8 +16659,12 @@
 /area/security/detectives_office/private_investigators_office)
 "bVz" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/explab)
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bVA" = (
 /turf/open/floor/iron/white,
 /area/science/explab)
@@ -16790,15 +16701,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "bVR" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/secondary/entry)
 "bVS" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -16813,9 +16720,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bVT" = (
-/obj/structure/table,
-/turf/open/floor/iron,
-/area/space)
+/turf/closed/wall,
+/area/hallway/secondary/exit)
 "bVW" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -16893,12 +16799,15 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bWN" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Air Out"
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
 	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bWS" = (
 /obj/structure/table/glass,
 /obj/item/radio/headset/headset_medsci,
@@ -16924,9 +16833,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bXc" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "bXe" = (
 /obj/structure/rack,
 /obj/item/multitool/circuit{
@@ -16994,10 +16909,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bXz" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/o2,
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "bXE" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
@@ -17026,9 +16942,13 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bXN" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/obj/structure/table/wood,
+/obj/machinery/door/window/northright{
+	name = "Library Desk Door";
+	req_access_txt = "37"
+	},
+/turf/open/floor/carpet/green,
+/area/service/library)
 "bXO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -17281,6 +17201,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/full,
+/obj/machinery/mass_driver/ordnance{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/mixing)
 "cae" = (
@@ -18932,10 +18855,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "cjW" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
-/turf/open/floor/engine,
-/area/science/mixing/chamber)
+/obj/machinery/disposal/bin,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "cjX" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -19009,10 +18934,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ckr" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/crossing,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
+	},
+/obj/structure/railing,
+/obj/structure/table/wood,
+/obj/item/toy/figure/curator,
+/turf/open/floor/wood,
+/area/service/library)
 "ckt" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
@@ -19427,12 +19356,8 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cmr" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/ordnance{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/mixing)
+/turf/closed/wall,
+/area/science/misc_lab/range)
 "cms" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/airalarm/directional/north,
@@ -19709,20 +19634,6 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
-"cnR" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "cnT" = (
 /obj/structure/closet/firecloset,
 /obj/structure/railing{
@@ -19731,13 +19642,15 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cnV" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4;
-	frequency = 1441;
-	id = "inc_in"
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
 	},
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/libraryscanner,
+/turf/open/floor/wood,
+/area/service/library)
 "cnW" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -20009,12 +19922,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cpo" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/courtroom)
 "cpr" = (
 /obj/structure/chair,
@@ -20626,30 +20535,13 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "csL" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"csM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/turf/open/floor/iron/white,
+/area/science/explab)
+"csM" = (
+/obj/machinery/ore_silo,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "csN" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -21000,7 +20892,7 @@
 	req_access_txt = "63"
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/primary/aft)
+/area/security/checkpoint/engineering)
 "ctT" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/iron/dark,
@@ -21068,9 +20960,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
-"cug" = (
-/turf/closed/wall/r_wall,
-/area/engineering/transit_tube)
 "cuj" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -21354,24 +21243,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"cvo" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/engineering/transit_tube)
-"cvq" = (
-/obj/structure/cable,
-/obj/machinery/camera/directional/north{
-	c_tag = "Transit Tubes";
-	name = "Tubes Camera";
-	network = list("ss13","minisat")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/engineering/transit_tube)
 "cvr" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
@@ -21505,17 +21376,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"cvK" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/transit_tube";
-	dir = 1;
-	name = "Transit Tubes APC";
-	pixel_y = 25
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/engineering/transit_tube)
 "cvL" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -21688,8 +21548,10 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cwy" = (
-/turf/open/floor/plating,
-/area/space)
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "cwz" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -21732,22 +21594,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cwF" = (
-/obj/structure/chair{
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/ordnance{
 	dir = 8
 	},
-/obj/item/beacon,
-/turf/open/floor/iron,
-/area/space)
-"cwG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/transit_tube_pod,
-/obj/structure/transit_tube/station/reverse{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
-/area/engineering/transit_tube)
+/area/science/mixing)
 "cwJ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
@@ -21861,14 +21713,13 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cxi" = (
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	frequency = 1441;
+	id = "inc_in"
 	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cxj" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -21886,10 +21737,8 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cxn" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/engineering/transit_tube)
+/turf/open/floor/circuit,
+/area/hallway/primary/aft)
 "cxo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -22002,20 +21851,9 @@
 "cxT" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"cxV" = (
-/obj/structure/transit_tube,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/transit_tube)
 "cxW" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/transit_tube)
-"cxX" = (
-/turf/open/floor/iron,
-/area/engineering/transit_tube)
+/turf/closed/wall/r_wall,
+/area/hallway/primary/aft)
 "cxY" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -22267,16 +22105,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/transit_tube)
-"cza" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/transit_tube,
-/turf/open/floor/plating,
-/area/engineering/transit_tube)
-"czc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/transit_tube)
+/area/maintenance/disposal/incinerator)
 "czd" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
@@ -22336,15 +22165,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"czB" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/transit_tube)
 "czC" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/iron,
@@ -22498,16 +22318,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"cAt" = (
-/obj/structure/transit_tube,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"cAu" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cAw" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -22597,12 +22407,22 @@
 /area/cargo/miningoffice)
 "cAI" = (
 /obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cAJ" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/transit_tube)
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 8;
+	name = "Satellite Supply";
+	req_access_txt = "65"
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "cAO" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/power/terminal{
@@ -23527,9 +23347,23 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cEP" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	dir = 8;
+	name = "Satellite Supply";
+	req_access_txt = "65"
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "cEQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple{
 	dir = 8
@@ -24499,11 +24333,14 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cIa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cIb" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
@@ -24522,11 +24359,9 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cIc" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L6"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cIf" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light/directional/south,
@@ -26153,11 +25988,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"cQk" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cQn" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -26176,260 +26006,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cRb" = (
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRe" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access_txt = "32;19"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRf" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "teledoor";
-	name = "MiniSat Teleport Access"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cRh" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRj" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Antechamber";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRm" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRq" = (
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/mob/living/simple_animal/bot/secbot/pingsky,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRt" = (
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRu" = (
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	name = "AI turret control";
-	pixel_x = 27
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRw" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRx" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRy" = (
-/obj/structure/cable,
-/obj/machinery/holopad/secure,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRz" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/service)
-"cRA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cRB" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cRC" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cRD" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/small/directional/west,
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cRE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/hallway";
-	name = "AI Hallway APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cRG" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/status_display/ai/directional/east,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cRI" = (
-/obj/structure/table,
-/obj/item/weldingtool,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/toy/mecha/reticence,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cRJ" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRL" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRN" = (
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/item/radio/off,
-/obj/item/screwdriver,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRO" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRQ" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "AI Core";
-	req_access_txt = "65"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cRS" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cRY" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cSj" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/service)
-"cSl" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/service)
-"cSn" = (
-/obj/machinery/computer/station_alert{
-	dir = 1
-	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -30
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cSp" = (
-/obj/machinery/teleport/station,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cSq" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/directional/west,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cSr" = (
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cSt" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cSu" = (
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "Minisat Foyer";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/structure/table,
-/obj/item/phone,
-/turf/open/floor/iron/grimy,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cSv" = (
-/mob/living/simple_animal/bot/floorbot,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cSw" = (
-/turf/open/floor/iron/grimy,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cSx" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cSB" = (
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "Minisat Teleporter";
-	name = "AI motion-sensitive security camera";
-	network = list("ss13","minisat")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cSD" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cSE" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "cSG" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -26450,19 +26026,18 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /obj/item/stamp/law,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/purple,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "cSJ" = (
+/obj/machinery/photocopier,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"cSK" = (
-/mob/living/simple_animal/bot/cleanbot,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "cSL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engineering/storage_shared";
@@ -26477,32 +26052,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"cSN" = (
-/obj/machinery/computer/teleporter{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "cSQ" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"cSR" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/service)
 "cSU" = (
 /obj/structure/rack,
 /obj/item/storage/box/halloween/edition_21/willard,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cSV" = (
-/obj/machinery/computer/monitor{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "cSW" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -26521,13 +26079,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"cTd" = (
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cTf" = (
-/turf/open/floor/circuit,
-/area/maintenance/solars)
 "cTg" = (
 /obj/machinery/door/airlock/vault{
 	name = "Vault Door";
@@ -26561,666 +26112,19 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/cargo/office)
-"cTj" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
 "cTk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
-"cTl" = (
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
 "cTm" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/cargo/office)
-"cTn" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cTo" = (
-/obj/machinery/door/window{
-	base_state = "leftsecure";
-	dir = 1;
-	icon_state = "leftsecure";
-	name = "AI Core Access";
-	req_access_txt = "16"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cTq" = (
-/obj/machinery/bluespace_beacon,
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
-	name = "AI turret control";
-	pixel_y = 27
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cTr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTs" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTt" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cTv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Out"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cTw" = (
-/obj/structure/transit_tube,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTy" = (
-/obj/structure/transit_tube,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTz" = (
-/obj/structure/rack,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTA" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTB" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTD" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTF" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cTG" = (
-/obj/structure/transit_tube/station/reverse/flipped{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTI" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
-"cTJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTK" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Satellite Interior APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTL" = (
-/obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom/directional/south{
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel"
-	},
-/obj/item/radio/intercom/directional/west{
-	freerange = 1;
-	name = "Common Channel"
-	},
-/obj/item/radio/intercom/directional/north{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cTM" = (
-/obj/machinery/camera/xray/directional/east{
-	c_tag = "AI Chamber W";
-	name = "Upgraded AI Camera";
-	network = list("aicore")
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cTN" = (
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTP" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cTQ" = (
-/obj/effect/landmark/start/ai,
-/obj/item/radio/intercom/directional/east{
-	freerange = 1;
-	name = "Common Channel";
-	pixel_y = -8
-	},
-/obj/item/radio/intercom/directional/west{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom";
-	pixel_y = -8
-	},
-/obj/item/radio/intercom/directional/south{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel"
-	},
-/obj/machinery/requests_console/directional/east{
-	department = "AI";
-	departmentType = 5;
-	pixel_y = -30
-	},
-/obj/machinery/newscaster/directional/west{
-	pixel_y = -28
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cTR" = (
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/south{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTS" = (
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTT" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cTW" = (
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
-"cTX" = (
-/obj/structure/lattice/catwalk,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
-"cTY" = (
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "Minisat Main Airlock";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cTZ" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/solars)
-"cUa" = (
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUc" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/maintenance/solars)
-"cUd" = (
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
-	name = "AI Foyer turret control";
-	pixel_y = -27
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUe" = (
-/obj/structure/lattice,
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Solars W";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"cUf" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cUg" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUj" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cUk" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Minisat Exterior NNW";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
-"cUl" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cUp" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
-	dir = 1;
-	name = "AI Satellite Foyer APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUq" = (
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUr" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUu" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUv" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cUy" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Teleporter Antechamber";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cUB" = (
-/obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cUC" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Space Access Airlock";
-	req_one_access_txt = "32;19"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cUD" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cUF" = (
-/obj/structure/cable,
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "Minisat Solars Airlock LOCKED W";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/west,
-/obj/item/radio/intercom/directional/west{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom"
-	},
-/turf/open/floor/circuit,
-/area/maintenance/solars)
-"cUI" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Foyer";
-	req_one_access_txt = "65"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUJ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
-"cUK" = (
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "cUL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/main)
-"cUN" = (
-/obj/structure/cable,
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "Minisat Solars Airlock LOCKED E";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light/small/directional/east,
-/obj/item/radio/intercom/directional/east{
-	broadcasting = 1;
-	frequency = 1447;
-	listening = 0;
-	name = "AI Intercom"
-	},
-/turf/open/floor/circuit,
-/area/maintenance/solars)
-"cUO" = (
-/obj/structure/cable,
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat/hallway";
-	name = "AI Hallway control";
-	pixel_y = -27
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUP" = (
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cUT" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter";
-	req_access_txt = "17;65"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cUV" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cUW" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cUY" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Space Access Airlock";
-	req_one_access_txt = "32;19"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor,
-/turf/open/floor/circuit,
-/area/maintenance/solars)
-"cUZ" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cVa" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cVb" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cVc" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Minisat Exterior NW";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
-"cVd" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cVe" = (
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"cVf" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/multitool,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 35
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cVg" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cVh" = (
-/obj/structure/cable,
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat/service";
-	name = "Service Bay Turret Control";
-	pixel_x = -27;
-	req_access = null;
-	req_access_txt = "65"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cVi" = (
-/obj/structure/cable,
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cVj" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cVk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cVl" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cVm" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/maintenance/solars)
-"cVp" = (
-/obj/structure/cable,
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cVq" = (
-/obj/structure/cable,
-/obj/machinery/turretid{
-	control_area = "/area/ai_monitored/turret_protected/aisat/atmos";
-	name = "Atmospherics Turret Control";
-	pixel_x = 27;
-	req_access = null;
-	req_access_txt = "65"
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cVs" = (
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cVt" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cVu" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/maintenance/solars)
-"cVv" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Minisat Exterior NE";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
-"cVw" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Service Bay";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/recharge_station,
-/obj/machinery/light/directional/west,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cVy" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Service Bay";
-	req_one_access_txt = "65"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cVz" = (
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/space/basic,
-/area/space)
-"cVA" = (
-/obj/structure/lattice,
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Solars E";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"cVB" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cVC" = (
-/obj/machinery/power/solar{
-	id = "aisolar";
-	name = "AI Solar Array"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars)
-"cVD" = (
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cVF" = (
-/obj/machinery/power/tracker{
-	id = "aisolar"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars)
-"cVG" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/maintenance/solars)
-"cVH" = (
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/hallway)
 "cVL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -27244,45 +26148,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/miningoffice)
-"cVY" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cVZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
-"cWb" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/space)
 "cWc" = (
 /obj/machinery/navbeacon/wayfinding,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cWe" = (
-/obj/machinery/door/airlock/command{
-	name = "MiniSat Access";
-	req_access_txt = "65"
-	},
-/obj/structure/cable,
-/obj/machinery/navbeacon/wayfinding,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
+/obj/structure/stairs/south,
 /turf/open/floor/iron,
-/area/engineering/transit_tube)
+/area/hallway/primary/aft)
 "cWh" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/window{
@@ -27321,21 +26194,6 @@
 /obj/machinery/duct,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"cWn" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"cWo" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Storage";
-	req_one_access_txt = "65"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "cWq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -27417,16 +26275,8 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "cWI" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/transit_tube)
+/turf/open/floor/circuit,
+/area/space)
 "cWM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27453,31 +26303,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"cWU" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Storage";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"cWV" = (
-/obj/machinery/recharge_station,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cWW" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
-"cWX" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
 "cWZ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -27504,10 +26329,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"cXk" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
 "cXn" = (
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
@@ -27637,10 +26458,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"cXG" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "cXI" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/blue{
@@ -27672,21 +26489,6 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"cXQ" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"cXR" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/turf/open/floor/plating,
-/area/space)
 "cXS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -27720,11 +26522,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"cZb" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
 "cZG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -27784,11 +26581,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"dhx" = (
-/obj/machinery/light/directional/south,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "dhZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -27804,29 +26596,14 @@
 /area/medical/medbay/central)
 "diw" = (
 /obj/structure/table/wood,
-/obj/item/folder,
-/obj/item/pen,
+/obj/item/paper_bin,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"diA" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/space)
 "djJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"djP" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "djZ" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -27875,14 +26652,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"dri" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/camera/directional/north{
-	c_tag = "Arrivals S";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/space)
 "drP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
 /turf/open/floor/plating,
@@ -28027,9 +26796,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dGh" = (
-/obj/item/kirbyplants/random,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
@@ -28188,14 +26958,16 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dXH" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
+/obj/structure/chair/comfy/brown{
+	buildstackamount = 0;
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -30
+	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
-"dZj" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "dZV" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -28303,14 +27075,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"epw" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Exterior SSE";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "epN" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -28334,20 +27098,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"eqU" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/service";
-	dir = 1;
-	name = "AI Satellite Service APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/obj/item/storage/toolbox/electrical,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
 "esy" = (
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = 30
@@ -28407,17 +27157,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"exm" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 2;
-	height = 13;
-	id = "ferry_home";
-	name = "port bay 2";
-	width = 5
-	},
-/turf/open/space/basic,
-/area/space)
 "eyW" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -28449,10 +27188,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating,
 /area/construction)
-"eEO" = (
-/obj/machinery/teleport/hub,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "eHp" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255
@@ -28484,16 +27219,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eNp" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/light_switch/directional/west{
-	pixel_x = -36
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
@@ -28543,13 +27273,6 @@
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"eYK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "eZc" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -28653,17 +27376,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
-"ffi" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
-"ffx" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/space)
 "fju" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -28759,29 +27471,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"frR" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "Security red corner"
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "fsz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28904,13 +27593,6 @@
 /obj/structure/grille,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
-"fHl" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/turf/open/floor/iron,
-/area/space)
 "fHA" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -28924,24 +27606,6 @@
 "fIK" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
-"fIL" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
-"fKU" = (
-/obj/structure/table,
-/obj/item/clothing/mask/gas,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/space)
-"fLV" = (
-/obj/structure/rack,
-/obj/item/clothing/head/welding,
-/obj/item/wrench,
-/obj/item/crowbar,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "fMK" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -28962,24 +27626,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"fQB" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/turf/open/floor/iron,
-/area/space)
 "fQS" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"fSs" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Escape Pod N";
-	name = "Hallway Camera"
-	},
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "fTJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -29023,13 +27673,6 @@
 /obj/item/stock_parts/subspace/filter,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"fZz" = (
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
 "fZI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -29049,14 +27692,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"gcJ" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Public Mining Dock E";
-	name = "Hallway Camera"
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "gcS" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil,
@@ -29129,16 +27764,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
-"gky" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals SW";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/space)
 "gkA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -29274,21 +27899,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"gxY" = (
-/obj/machinery/door/airlock{
-	name = "Law Office B";
-	req_access_txt = "38"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "law2";
-	name = "Blue Office Privacy Door"
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/service/lawoffice)
 "gzx" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 6
@@ -29329,13 +27939,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"gKu" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
-/area/space)
 "gKH" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
@@ -29484,17 +28087,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"hfp" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/space)
-"hgf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/wood,
-/area/service/lawoffice)
 "hhm" = (
 /obj/structure/rack,
 /obj/item/tape,
@@ -29525,15 +28117,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"hjP" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars";
-	dir = 8;
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
 "hkj" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/turf_decal/tile/red{
@@ -29624,21 +28207,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"htT" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/space)
-"huR" = (
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "Minisat Solars Airlock E";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/space/basic,
-/area/space)
 "hvY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -29664,11 +28232,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"hAu" = (
-/obj/structure/table/wood,
-/obj/item/storage/briefcase/lawyer,
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
 "hAX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -29754,10 +28317,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"hJp" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "hJt" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 9
@@ -29814,12 +28373,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"hPV" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L1"
-	},
-/turf/open/floor/iron,
-/area/space)
 "hQo" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -29835,25 +28388,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"hQG" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai";
-	name = "AI Chamber APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/machinery/flasher/directional/south{
-	id = "AI";
-	pixel_x = -12
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "hSx" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -29964,13 +28498,6 @@
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"idi" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter";
-	req_access_txt = "17;65"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "idt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -30051,30 +28578,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"ipz" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals SE";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/space)
-"iqA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
-"iqJ" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "Minisat Solar Control";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/maintenance/solars)
 "iro" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/optable,
@@ -30190,10 +28693,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"iGq" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
 "iJi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -30237,26 +28736,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/construction)
-"iMq" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L11"
-	},
-/turf/open/floor/iron,
-/area/space)
-"iMI" = (
-/obj/structure/table/wood,
-/obj/item/book/random,
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/service/lawoffice)
-"iNk" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L14"
-	},
-/turf/open/floor/iron,
-/area/space)
 "iNH" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -30317,11 +28796,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"iYI" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/carpet,
-/area/service/lawoffice)
 "jaJ" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/bounty_board/directional/north,
@@ -30418,13 +28892,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"jiN" = (
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "jjw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/chair{
@@ -30432,10 +28899,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
-"jjA" = (
-/obj/structure/chair/comfy/black,
-/turf/open/floor/iron/grimy,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "jpa" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -30508,15 +28971,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"jtO" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes,
-/obj/item/lighter/greyscale,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/space)
 "jtQ" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -30612,13 +29066,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"jEv" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/light/directional/south,
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "jEQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -30639,18 +29086,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jJQ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Law Reception"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/navbeacon/wayfinding,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/service/lawoffice)
 "jKC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -30694,12 +29129,6 @@
 "jKP" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/cargo/office)
-"jMk" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "jNN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -30863,10 +29292,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"kcs" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron,
-/area/space)
 "kej" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple{
@@ -30936,25 +29361,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"klI" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
-"knb" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/space)
-"knp" = (
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
-/area/space)
 "knY" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -31005,16 +29411,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"kzE" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/camera/motion/directional/west{
-	c_tag = "Minisat Atmospherics";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "kBz" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -31025,11 +29421,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/private_investigators_office)
-"kBU" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
 "kCg" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Morgue Maintenance";
@@ -31108,13 +29499,11 @@
 	departmentType = 2;
 	name = "Cargo RC"
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/cargo/office)
 "kQf" = (
@@ -31391,12 +29780,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"lvv" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L3"
-	},
-/turf/open/floor/iron,
-/area/space)
 "lyT" = (
 /obj/item/trash/chips,
 /turf/open/floor/plating,
@@ -31569,12 +29952,8 @@
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
 "maP" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/item/stamp/law,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/structure/filingcabinet/employment,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "mcJ" = (
@@ -31692,15 +30071,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"mlp" = (
-/obj/structure/lattice,
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Solars Weak Point W";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "mnv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/neutral{
@@ -31788,10 +30158,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"mzK" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/space)
 "mAr" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Medbay Hall - Morgue";
@@ -31824,15 +30190,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"mCc" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Solar Control Bay";
-	req_one_access_txt = "65"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
 "mCk" = (
 /obj/machinery/disposal/bin,
 /turf/open/floor/plating,
@@ -31905,12 +30262,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"mHw" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
-/area/space)
 "mIa" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -31992,12 +30343,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"mMY" = (
-/obj/structure/sign/warning/pods{
-	pixel_x = -30
-	},
-/turf/open/floor/iron,
-/area/space)
 "mQq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -32036,20 +30381,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/commons/storage/tools)
-"mYH" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L13"
-	},
-/turf/open/floor/iron,
-/area/space)
-"mYI" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Exterior SW";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "nbH" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -32088,12 +30419,6 @@
 /obj/item/weldingtool,
 /turf/open/floor/iron,
 /area/commons/storage/tools)
-"nhV" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L2"
-	},
-/turf/open/floor/iron,
-/area/space)
 "nif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -32111,10 +30436,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nkf" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/space)
 "nkw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -32169,24 +30490,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"nqr" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Minisat Exterior SEE";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "nqF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"nqH" = (
-/obj/item/paperplane,
-/turf/open/floor/iron,
-/area/space)
 "nqM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -32212,12 +30521,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"nvB" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L12"
-	},
-/turf/open/floor/iron,
-/area/space)
 "nye" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/machinery/light/directional/south,
@@ -32304,10 +30607,6 @@
 /obj/item/crowbar,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nHB" = (
-/obj/machinery/holopad/secure,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "nIY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -32335,13 +30634,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "nNx" = (
-/obj/machinery/camera/directional/south{
-	c_tag = "Brig - Hallway S";
-	name = "Security Camera";
-	network = list("ss13","security")
+/obj/machinery/camera/directional/north{
+	c_tag = "Courtroom Judge";
+	name = "Courtroom Camera";
+	network = list("ss13","security","court")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/brig)
+/area/security/courtroom)
 "nNS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -32357,15 +30657,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"nSk" = (
-/obj/item/radio/intercom/directional/east{
-	freerange = 1;
-	freqlock = 1;
-	frequency = 1490;
-	name = "Court Announcer"
-	},
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
 "nSm" = (
 /turf/open/floor/iron/dark,
 /area/command/gateway)
@@ -32380,12 +30671,6 @@
 /obj/item/stock_parts/subspace/analyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"nUN" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "nVI" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -32396,11 +30681,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"nWp" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/pinpointer_dispenser,
-/turf/open/floor/plating,
-/area/space)
 "nYG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -32425,45 +30705,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"nZK" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "oaI" = (
-/obj/structure/rack,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"oaW" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Minisat Exterior W";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
-"oaX" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Minisat Exterior SWW";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "odg" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"odk" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Atmospherics";
-	req_one_access_txt = "65"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "odr" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
@@ -32510,9 +30762,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ogZ" = (
-/obj/machinery/photocopier,
+/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/carpet,
 /area/service/lawoffice)
@@ -32531,13 +30783,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"opP" = (
-/obj/structure/cable,
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "oqb" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
@@ -32631,13 +30876,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"oIk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
 "oJr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -32650,39 +30888,12 @@
 /obj/machinery/defibrillator_mount/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"oJU" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
-"oLK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat/atmos";
-	dir = 1;
-	name = "AI Satellite Service APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/obj/machinery/portable_atmospherics/pump,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "oLR" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"oNX" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/button/door/directional/south{
-	id = "law";
-	name = "Blue Law Office Privacy";
-	req_access_txt = "38"
-	},
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
 "oOD" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -32712,20 +30923,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"oRd" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L7"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/space)
-"oRh" = (
-/obj/machinery/atmospherics/components/tank/air{
-	dir = 8
-	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "oRH" = (
 /obj/structure/table,
 /obj/item/surgicaldrill,
@@ -32777,16 +30974,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"oWr" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Arrivals NW";
-	name = "Hallway Camera"
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/turf/open/floor/iron,
-/area/space)
 "oWB" = (
 /obj/structure/rack,
 /obj/item/stock_parts/manipulator,
@@ -32873,7 +31060,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pjx" = (
-/obj/machinery/computer/warrant{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -32894,12 +31081,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"pnE" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L10"
-	},
-/turf/open/floor/iron,
-/area/space)
 "ppo" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -32908,18 +31089,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"pqA" = (
-/obj/structure/lattice,
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Solars Weak Point E";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"psb" = (
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
 "psH" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/south,
@@ -32961,13 +31130,6 @@
 "pyc" = (
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"pzm" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Public Mining Dock W";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/space)
 "pzz" = (
 /obj/structure/closet/lasertag,
 /turf/open/floor/plating,
@@ -33053,12 +31215,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"pHV" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/space)
 "pHZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -33083,20 +31239,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"pKq" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/carpet,
-/area/service/lawoffice)
-"pMb" = (
-/obj/structure/table,
-/obj/item/storage/fancy/cigarettes/cigpack_candy,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "pMo" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -33104,24 +31246,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"pML" = (
-/obj/structure/chair/comfy/brown{
-	buildstackamount = 0;
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet,
-/area/service/lawoffice)
-"pNP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
 "pOX" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -33131,11 +31255,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pPS" = (
-/obj/structure/table/wood,
-/obj/item/storage/secure/briefcase,
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
 "pRX" = (
@@ -33157,14 +31280,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"pWh" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
 "pXf" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
@@ -33241,17 +31356,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"qnP" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/maintenance/solars)
 "qop" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple{
@@ -33309,15 +31413,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"qwh" = (
-/obj/machinery/power/solar_control{
-	id = "aisolar";
-	name = "AI Solar Control"
-	},
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
 "qwp" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics Internal Airlock";
@@ -33350,10 +31445,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"qzZ" = (
-/obj/machinery/atmospherics/components/tank/air,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "qAS" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/central)
@@ -33376,14 +31467,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qFp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
-/area/maintenance/solars)
 "qGe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -33410,14 +31493,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"qGB" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Exterior SE";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "qGC" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
@@ -33425,20 +31500,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"qIv" = (
-/obj/effect/landmark/start/ai/secondary,
-/obj/item/radio/intercom/directional/south,
-/obj/item/radio/intercom/directional/east{
-	freerange = 1;
-	name = "Common Channel"
-	},
-/obj/item/radio/intercom/directional/north{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "qIF" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -33496,10 +31557,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qPM" = (
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/structure/table/wood,
+/obj/item/book/random,
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "qQD" = (
@@ -33522,12 +31584,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
 /area/maintenance/solars/starboard/aft)
-"qRX" = (
-/obj/structure/table,
-/obj/item/pen/blue,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "qRY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -33634,23 +31690,6 @@
 /obj/effect/spawner/random/techstorage/tcomms_all,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"rbn" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
-"rbo" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "rcl" = (
 /obj/structure/closet/emcloset,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -33717,14 +31756,6 @@
 "rkl" = (
 /turf/closed/wall,
 /area/commons/vacant_room/commissary)
-"rlz" = (
-/obj/machinery/turretid{
-	control_area = "/area/maintenance/solars";
-	name = "AI solar control turret panel";
-	pixel_y = -27
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/service)
 "ror" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -33756,18 +31787,31 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "rqh" = (
-/obj/machinery/holopad,
-/obj/item/beacon,
-/turf/open/floor/iron,
-/area/security/courtroom)
-"rqn" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/camera/directional/south{
-	c_tag = "Arrivals N";
-	name = "Hallway Camera"
+/obj/structure/chair{
+	dir = 1;
+	name = "Witness"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/security/courtroom)
 "rrb" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -33786,11 +31830,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"rsn" = (
-/obj/structure/filingcabinet/employment,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
 "rtZ" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -33800,24 +31839,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
-"ruZ" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/space)
-"rvm" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/turretid{
-	name = "AI Chamber turret control";
-	pixel_x = 5;
-	pixel_y = -24
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "rwL" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 30
@@ -33952,11 +31973,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "rTh" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen{
-	name = "Court Telescreen";
-	network = list("court")
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "rTt" = (
@@ -33987,7 +32004,7 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "sgG" = (
-/obj/machinery/status_display/ai/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "shM" = (
@@ -34032,21 +32049,10 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "sjz" = (
-/obj/structure/bookcase,
-/obj/machinery/light/directional/west,
-/obj/machinery/button/door/directional/north{
-	id = "law3";
-	name = "Shared Law Office Privacy";
-	req_access_txt = "38"
-	},
+/obj/machinery/disposal/bin,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/wood,
 /area/service/lawoffice)
-"sjQ" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -30
-	},
-/turf/open/floor/iron,
-/area/space)
 "smn" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/blue{
@@ -34102,9 +32108,6 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "ssn" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -30
-	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 1;
@@ -34118,14 +32121,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"suj" = (
-/obj/machinery/light/directional/north,
-/obj/structure/closet/secure_closet/courtroom,
-/obj/item/megaphone{
-	name = "The Judge's Megaphone"
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "sva" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -34178,10 +32173,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"sHB" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/security/courtroom)
 "sKe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -34282,17 +32273,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/construction)
-"sWZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/west{
-	id = "teledoor";
-	name = "MiniSat Teleport Shutters Control";
-	req_one_access_txt = "17;65"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
 "sXn" = (
 /obj/structure/reflector/single,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -34316,12 +32296,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"sYf" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/status_display/ai/directional/east,
-/turf/open/space/basic,
-/area/maintenance/solars)
 "sYz" = (
 /turf/closed/wall,
 /area/security/detectives_office/private_investigators_office)
@@ -34329,12 +32303,6 @@
 /obj/machinery/power/floodlight,
 /turf/open/floor/plating,
 /area/construction)
-"teE" = (
-/obj/structure/table,
-/obj/item/toy/eightball,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "tgU" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plating,
@@ -34384,10 +32352,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"tmp" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/space)
 "tmr" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -34473,13 +32437,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"twY" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/obj/effect/landmark/start/lawyer,
-/turf/open/floor/carpet/blue,
-/area/service/lawoffice)
 "txC" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -34565,12 +32522,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"tFG" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/space)
 "tHO" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating/airless,
@@ -34600,14 +32551,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/medical/coldroom)
-"tLp" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/carpet,
-/area/service/lawoffice)
 "tMk" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -34767,11 +32710,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "uhD" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/plating,
 /area/service/lawoffice)
 "uhZ" = (
 /obj/structure/bed/roller,
@@ -34803,14 +32742,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"unv" = (
-/obj/structure/chair,
-/obj/machinery/camera/directional/north{
-	c_tag = "Arrivals NE";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/space)
 "unA" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -34845,12 +32776,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"utP" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
-/area/space)
 "uul" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -34909,6 +32834,7 @@
 /area/medical/coldroom)
 "uKJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "uKM" = (
@@ -34996,25 +32922,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"uTy" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access_txt = "32;19"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
 "uTN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"uUW" = (
-/obj/machinery/holopad/secure,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/circuit,
-/area/maintenance/solars)
 "uXd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -35062,18 +32973,6 @@
 /obj/item/hemostat,
 /turf/open/floor/iron/dark,
 /area/medical/surgery)
-"var" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron,
-/area/space)
-"vcn" = (
-/obj/machinery/camera/xray/directional/west{
-	c_tag = "AI Chamber E";
-	name = "Upgraded AI Camera";
-	network = list("aicore")
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "vco" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -35087,12 +32986,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
-"vdY" = (
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
 "vdZ" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/radio/intercom/directional/north,
@@ -35196,12 +33089,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"voi" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L9"
-	},
-/turf/open/floor/iron,
-/area/space)
 "vpK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -35223,14 +33110,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"vro" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Escape Pod S";
-	name = "Hallway Camera"
-	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "vrF" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -35247,14 +33126,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"vtp" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Courtroom"
-	},
-/obj/machinery/navbeacon/wayfinding,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
 "vvv" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -35339,12 +33210,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"vCJ" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "vEB" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -35393,9 +33258,6 @@
 "vHB" = (
 /turf/closed/wall/r_wall,
 /area/cargo/storage)
-"vIK" = (
-/turf/open/floor/iron,
-/area/space)
 "vJH" = (
 /obj/structure/window/reinforced/plasma{
 	dir = 8
@@ -35424,16 +33286,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"vLD" = (
-/obj/machinery/porta_turret/ai,
-/obj/machinery/light/directional/east,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
-"vNw" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/turf/open/floor/iron,
-/area/space)
 "vOj" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -35473,14 +33325,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"vQG" = (
-/obj/machinery/space_heater,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "vSh" = (
 /obj/machinery/rnd/bepis,
 /obj/effect/turf_decal/stripes/box,
@@ -35624,11 +33468,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"wmV" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
-/area/space)
 "wog" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -35677,13 +33516,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"wyo" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/coffee,
-/obj/machinery/light/directional/south,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "wzd" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -35694,12 +33526,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wAO" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L8"
-	},
-/turf/open/floor/iron,
-/area/space)
 "wBt" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plating,
@@ -35711,26 +33537,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"wEs" = (
-/obj/structure/chair/sofa{
-	desc = "Made of very expensive furs, probably from an endangered animal.";
-	name = "Luxurious sofa"
-	},
-/obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/newscaster/directional/north,
-/turf/open/floor/carpet,
-/area/service/lawoffice)
-"wEP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/north,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "wGo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -35793,13 +33599,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
-"wPK" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "wQe" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/bot_red,
@@ -35864,12 +33663,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"wUN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/ai)
 "wUZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
@@ -35917,12 +33710,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"xev" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "L5"
-	},
-/turf/open/floor/iron,
-/area/space)
 "xfJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -35974,15 +33761,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"xjC" = (
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "Minisat Solars Airlock W";
-	name = "AI motion-sensitive security camera";
-	network = list("minisat")
-	},
-/obj/machinery/status_display/ai/directional/north,
-/turf/open/space/basic,
-/area/space)
 "xjL" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -36006,7 +33784,12 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
 "xkk" = (
-/turf/open/floor/carpet/purple,
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "law3";
+	name = "Law Office Shared Privacy Door"
+	},
+/turf/open/floor/plating,
 /area/service/lawoffice)
 "xkv" = (
 /obj/machinery/door/airlock/maintenance{
@@ -36020,14 +33803,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xkQ" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Minisat Exterior SSW";
-	name = "Minisat Camera";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "xlx" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -36042,16 +33817,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"xng" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/space)
 "xog" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -36077,7 +33842,10 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "xqE" = (
-/obj/item/kirbyplants/random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "xuU" = (
@@ -36088,40 +33856,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xyG" = (
-/obj/structure/closet/emcloset,
-/obj/effect/landmark/start/hangover/closet,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "xzJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"xAK" = (
-/obj/machinery/door/airlock{
-	name = "Law Office A";
-	req_access_txt = "38"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "law1";
-	name = "Purple Office Privacy Door"
-	},
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/service/lawoffice)
 "xDh" = (
 /turf/open/floor/iron,
-/area/maintenance/port)
-"xEf" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/plating,
 /area/maintenance/port)
 "xEZ" = (
 /obj/effect/turf_decal/tile/purple{
@@ -36151,10 +33893,6 @@
 /obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xJs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/space)
 "xKA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/engine,
@@ -36169,10 +33907,6 @@
 "xQB" = (
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"xRS" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/space)
 "xSU" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -36205,10 +33939,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"xXK" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/space)
 "xXO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -36243,9 +33973,6 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "yai" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -36253,14 +33980,16 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/cargo/office)
 "yal" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/button/door/directional/south{
+	id = "law";
+	name = "Blue Law Office Privacy";
+	req_access_txt = "38"
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
@@ -36290,11 +34019,6 @@
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/iron,
 /area/security/brig)
-"yeW" = (
-/obj/machinery/holopad/secure,
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "yfX" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/hangover,
@@ -50824,8 +48548,8 @@ bdS
 qTU
 bLw
 bLw
-aHE
-aHE
+bVR
+bVR
 bLw
 aVh
 aVi
@@ -50835,8 +48559,8 @@ aVi
 aVi
 aVh
 bLw
-aHE
-aHE
+bVR
+bVR
 bLw
 bLw
 qTU
@@ -63357,7 +61081,7 @@ ahO
 air
 aiV
 adU
-aiP
+aPA
 aPA
 aju
 aju
@@ -63877,7 +61601,7 @@ hob
 amw
 alD
 mcJ
-aju
+aoS
 aoS
 aoS
 aoS
@@ -64125,16 +61849,16 @@ ajh
 ajh
 ajh
 ajh
-ajh
+aak
 aak
 alH
-ajT
+abO
 alD
 ald
 alD
 alD
 mcJ
-aju
+aoS
 ana
 wZO
 aqz
@@ -64153,9 +61877,9 @@ aak
 bmV
 aGX
 kId
-kId
-kId
-kId
+bmV
+bmV
+bmV
 bmV
 aEm
 bit
@@ -64380,9 +62104,9 @@ aeA
 iWf
 abF
 agz
-xQB
-adz
+aaH
 ajh
+aak
 aak
 alH
 akT
@@ -64391,7 +62115,7 @@ hob
 amw
 alD
 mcJ
-aju
+aoS
 ana
 wZO
 wZO
@@ -64411,8 +62135,8 @@ bmV
 bmV
 bmV
 bmV
-kId
-kId
+auJ
+auJ
 bmV
 pzz
 aGX
@@ -64638,8 +62362,8 @@ abg
 abH
 acM
 acY
-xQB
 ajh
+aak
 aak
 aju
 ajP
@@ -64648,7 +62372,7 @@ hob
 mcJ
 alD
 mcJ
-aju
+aoS
 ana
 wZO
 rYx
@@ -64664,12 +62388,12 @@ hob
 hob
 aHk
 aHk
-aEj
 foS
 foS
+foS
 bmV
-bmV
-bmV
+auX
+aAP
 bmV
 bmV
 bmV
@@ -64719,7 +62443,7 @@ byq
 bFb
 byq
 blM
-bqY
+bXz
 btV
 bLX
 bOd
@@ -64798,7 +62522,7 @@ aaa
 aaa
 aaa
 aaa
-oaW
+aaa
 aaa
 aaa
 aaa
@@ -64895,8 +62619,8 @@ abi
 xQB
 acP
 aho
-acY
 ajh
+aak
 aak
 aju
 ajS
@@ -64905,7 +62629,7 @@ hob
 hob
 hob
 hob
-aju
+aoS
 aoS
 apJ
 wZO
@@ -64920,7 +62644,7 @@ awC
 amq
 axT
 aHk
-aDz
+aDB
 foS
 aFJ
 foS
@@ -64977,7 +62701,7 @@ byq
 byq
 kxR
 bJo
-bNm
+cjW
 bLX
 vkV
 bOd
@@ -65054,15 +62778,15 @@ aaa
 aaa
 aaa
 aaa
-cTZ
-cTZ
-cTZ
-cTZ
-cTZ
-cTZ
-cTZ
 aaa
-oaX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65152,8 +62876,8 @@ abo
 gqT
 agG
 gdo
-adW
 ajh
+aak
 aak
 alH
 akT
@@ -65177,7 +62901,7 @@ ayF
 awD
 aAh
 aHk
-aDB
+arr
 aEv
 fBY
 tAj
@@ -65194,7 +62918,7 @@ kId
 kId
 kId
 kId
-kId
+tsg
 kId
 kId
 kId
@@ -65308,19 +63032,19 @@ aaa
 aaa
 aaa
 aaa
-cRz
-cRz
-cRz
-cTZ
-cTZ
-qFp
-pNP
-hjP
-cTZ
-cTZ
-cTZ
-cTZ
-cTZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65410,14 +63134,14 @@ afH
 ajh
 ajh
 ajh
-ajh
+aak
 aak
 alH
 ajQ
 alD
 hob
 amn
-awX
+aow
 aow
 aow
 aoS
@@ -65439,31 +63163,31 @@ aEw
 aGl
 aDM
 bmV
-xEf
-uKJ
-bgA
 bmV
+kId
 cZG
-biC
 bmV
 kId
 kId
+bmV
 kId
 bmV
 bmV
 bmV
 bmV
-bio
+bqY
 bmV
 bmV
 bmV
-aYB
+bIn
 bmV
 bmV
 bmV
-aYB
+bIn
 bmV
 bmV
+kId
+kId
 tsg
 xUx
 bmV
@@ -65562,24 +63286,24 @@ aaa
 aaa
 aaa
 aaa
-cVc
-cRz
-cRz
-cRz
-cRz
-cRz
-qwh
-cTj
-ffi
-cTj
-cVu
-cUY
-cUF
-cTZ
-cTZ
-cTZ
-cTZ
-cTZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65674,7 +63398,7 @@ ajT
 alD
 hob
 amo
-awX
+aow
 axw
 aoj
 aoS
@@ -65695,9 +63419,7 @@ aDB
 foS
 aHp
 aEs
-bmV
-qzZ
-uKJ
+aus
 bmV
 bmV
 bmV
@@ -65707,19 +63429,21 @@ bmV
 bmV
 bmV
 bmV
-aNq
-oJU
+bfp
+biC
 aQp
-aQp
+rTh
+bum
+aDG
 aRo
-bqR
+bJX
 aTl
-bsy
+bqR
 aVs
-bqR
+bJX
 sjz
-bsy
-aTl
+bqR
+bqR
 bmV
 els
 bmV
@@ -65819,26 +63543,26 @@ aaa
 aaa
 aaa
 aaa
-cRz
-cRz
-cRz
-eqU
-pWh
-cRz
-cZb
-cTI
-cTW
-cTf
-cTZ
-cTZ
-cUc
-cTZ
-cTZ
-aak
-aak
-aae
-aaj
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -65920,7 +63644,7 @@ iBu
 ajh
 aaX
 abv
-abO
+gqT
 ajh
 aak
 aak
@@ -65931,7 +63655,7 @@ akT
 alD
 hob
 aAn
-awX
+aow
 anC
 aok
 aoS
@@ -65952,32 +63676,32 @@ aDB
 foS
 aHk
 aHk
-bmV
-qzZ
-uKJ
-bmV
-suj
-aKY
+hob
+hob
+aBI
+aGC
 aEr
+aKY
+aHK
 aSr
 aSF
-bwg
-bPB
-aMF
+cpo
 aLV
 aLV
 aLV
-aQp
+rTh
+bvi
+aDG
 aRq
-bqR
+bKJ
 aTm
 xkk
 cSI
 bmH
 maP
-psb
-rsn
-bmV
+bqR
+uhD
+kId
 tsg
 dDa
 bmV
@@ -66075,28 +63799,28 @@ aaa
 aaa
 aaa
 aaa
-cRz
-cRz
-cRz
-cWV
-cVg
-cVg
-mCc
-cTj
-cTj
-iqJ
-cTZ
-cTZ
-cTZ
-cVu
-cTZ
 aaa
 aaa
 aaa
 aaa
 aaa
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66209,32 +63933,32 @@ aHk
 aEC
 aHk
 aDx
+auv
 hob
-bmV
-bmV
-bmV
-bis
+aCK
 aEr
 aEr
 aEr
+aHS
+aJG
 bjM
-bBY
-bBY
+cpo
+aLV
 aMF
 aLV
 rTh
-aLV
-aQp
-aRq
-bqR
+bvi
+aDG
+bEq
+bLu
 aTn
-aUp
+xkk
 aVu
-bmH
+bQS
 pPS
-twY
-oIk
-bmV
+bqR
+uhD
+kId
 tsg
 cZG
 bmV
@@ -66331,31 +64055,31 @@ aaa
 aaa
 aaa
 aaa
-cRz
-cRz
-cRz
-cVw
-cWW
-fZz
-rlz
-cRz
-cTW
-cTf
-cTZ
-cTZ
-cTZ
-cTZ
-qnP
-cTZ
-mlp
-aak
-aak
-aak
-aak
-aak
-adJ
-adJ
-mYI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66443,10 +64167,10 @@ akZ
 akZ
 ajU
 alD
+afl
 alD
 alD
 alD
-ahn
 alD
 aoW
 aog
@@ -66462,36 +64186,36 @@ akT
 alD
 aBm
 cdk
-akT
-alD
-alD
 alD
 akT
+alD
 alD
 alD
 hob
+aDz
 sgG
-aEr
-aEr
+sgG
+aHv
+aHU
 aTd
 bjN
-aKZ
-frR
+cpo
+aLV
 aMF
 aLV
 rTh
-aLV
-aQp
+bvB
+aDG
 aRr
-bqR
+bNf
 aTo
-bse
+xkk
 aVv
-bmH
+bSz
 apW
-hAu
-kBU
-bmV
+bqR
+uhD
+kId
 tsg
 kId
 bmV
@@ -66587,23 +64311,6 @@ aaa
 aaa
 aaa
 aaa
-cRz
-cRz
-cRz
-cVf
-cVg
-cVg
-iGq
-cSR
-cRz
-uUW
-cTZ
-cTZ
-cTZ
-aaa
-aaa
-cVm
-aHI
 aaa
 aaa
 aaa
@@ -66611,8 +64318,25 @@ aaa
 aaa
 aaa
 aaa
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66703,7 +64427,12 @@ alD
 ycR
 alD
 alD
-ahn
+akT
+akT
+alA
+akT
+akT
+akT
 akT
 akT
 akT
@@ -66719,36 +64448,31 @@ akT
 alD
 alD
 alD
-akT
-alD
-alD
-alD
-akT
-alD
-nNx
 hob
+nNx
+aGD
 aKV
-aNx
-aOX
 aEr
 aEr
-aEr
-aEr
-aMF
+sgG
+sgG
+cpo
 aLV
 aLV
 aLV
-aQl
+bsd
+bvD
+aDG
 aRs
-bqR
+bNm
 aTp
-btk
+xkk
 aVw
-bmH
+bTt
 yal
-bnC
-oNX
-bmV
+bqR
+uhD
+kId
 tsg
 gnW
 bmV
@@ -66844,32 +64568,32 @@ aaa
 aaa
 aaa
 aaa
-cRz
-cRz
-cUD
-cVg
-cVg
-cWX
-cSj
-cSl
-cRz
-cTZ
-cTZ
-cTZ
 aaa
 aaa
 aaa
 aaa
-cVG
-cVG
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -66960,52 +64684,52 @@ akT
 alE
 akT
 akT
-alA
+akT
+alD
+jcz
+alD
+alS
+alD
+alD
 alD
 alD
 akT
-ycR
-alD
-akT
 alD
 alD
-akT
+alD
+alD
 akT
 akT
 amr
 akT
 akT
 akT
-amr
 akT
-akT
-akT
-akT
-akT
-alD
+axF
+sgG
 aGY
-aEr
+aGH
 aHT
 aOY
 rqh
-aEN
+sgG
 bVp
-aEr
-aME
-aQp
-aQp
+rTh
+rTh
+bjf
+rTh
 aPa
-aQp
+aDG
 aRC
-bqR
+bJX
 aTA
-bsy
-aVI
 bqR
+aVI
+bJX
 xqE
-bsy
-hgf
-bmV
+bqR
+uhD
+kId
 tsg
 rTt
 bmV
@@ -67100,34 +64824,34 @@ aaa
 aaa
 aaa
 aaa
-cRz
-cRz
-cRz
-cRz
-cRz
-cVy
-cRz
-cRz
-cRz
-cRz
-cTZ
-cTZ
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cVG
-cVG
-cVG
-cVm
-cVm
-cVC
-aak
-aak
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67217,17 +64941,19 @@ akT
 alD
 alD
 alD
-ami
+akT
+alD
+jcz
+alD
+akT
+alD
+alD
 auN
+aoI
+aoP
 auN
-aol
-auN
-apc
-akT
-ath
-alD
-akT
-alD
+aoI
+aoI
 alD
 alD
 akT
@@ -67235,34 +64961,32 @@ alD
 alD
 alD
 akT
-alD
-alD
 ycR
-akT
-aHS
 hob
 aEr
-aOG
-aOX
+aGE
+aKV
 aEr
 aEr
 aEr
 aEr
-aMF
+cpo
 aLV
 aLV
 aLV
-aQA
+bsy
 aLV
-bqR
-blC
-xAK
+aDG
+bEw
+bNK
 blC
 bqR
 brb
-gxY
+bTJ
 brb
-bmV
+bqR
+uhD
+kId
 tsg
 kId
 bmV
@@ -67356,19 +65080,6 @@ aaa
 aaa
 aaa
 aaa
-cUk
-cRx
-cRx
-cUu
-cRw
-cVh
-cRS
-cSu
-cSw
-cSV
-cRx
-cTl
-cTl
 aaa
 aaa
 aaa
@@ -67376,15 +65087,28 @@ aaa
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67471,55 +65195,55 @@ aji
 abc
 aqU
 akT
+alD
+ajp
+alD
 akT
 alD
-anc
-auN
-amR
 aqK
-arW
-aoM
-auN
-auN
-ami
 alD
 akT
+alD
+auN
+auN
+auq
+aDE
 aum
 ayL
+auN
+azs
 alD
 akT
 alD
-aAz
+ate
 alD
 akT
 alD
-aGj
-alD
-akT
-bfZ
 hob
+bfZ
+aEr
+aEr
+aHB
 aHV
-aEr
-aEr
-aUs
 bkb
-cnR
-cnR
+bkb
+cpo
+aLV
 aMF
 aLV
-rTh
-aLV
 aQp
+bwI
+aDG
 aRu
-bqR
+eNp
 aTs
 bxn
 cSJ
 eNp
 ogZ
-bxn
+bqR
 uhD
-bmV
+kId
 tsg
 kId
 bmV
@@ -67614,34 +65338,34 @@ aaa
 aaa
 aaa
 aaa
-cRx
-cRx
-cUv
-cRS
-cVi
-cVB
-cSw
-jjA
-cSn
-cRx
-cTl
-cTl
-cTl
-cTl
 aaa
 aaa
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67726,57 +65450,57 @@ akZ
 akZ
 akZ
 akZ
-aju
-akV
-alH
-akV
-aju
-ami
-aon
-any
-arW
-aoP
-arW
-aqy
-ami
 bZU
-awO
+akV
 alH
 aju
+bZU
+ami
 alH
+aju
+arW
+alH
+arW
+azs
+any
+aoM
+aDE
+apq
+auq
+apP
 azs
 alH
-aju
-alH
-aBI
+aqs
 alH
 aju
 alH
-aGT
+atC
 alH
 aju
+aEj
+aGF
 oaI
-aLc
-aOO
 aEr
+aOO
+aKh
 blk
 cpo
-jiN
+aLV
 aMF
 aLV
-rTh
-aLV
 aQp
+bDa
+aDG
 aRv
-bqR
+bOe
 aTt
 bOI
 diw
 pjx
 dXH
-aYH
-pML
-bmV
+bqR
+uhD
+kId
 tsg
 aRf
 bmV
@@ -67870,36 +65594,36 @@ aaa
 aaa
 aaa
 aaa
-cRx
-cRx
-cRx
-cTC
-cRL
-cVj
-cVj
-cSw
-cSw
-cSD
-cRx
-cTl
-cTl
-cTl
-cTl
-cTl
-xjC
 aaa
 aaa
 aaa
-cVG
-cVG
-cVG
-cVm
-cVm
-cVC
-aak
-aak
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -67983,57 +65707,57 @@ aif
 aif
 aif
 akZ
-ajY
-alD
-alH
-alD
-and
-auN
+aHN
+adW
+ahn
+aju
+aHN
+adW
 aoo
-arW
+aju
 aoq
-aqK
-aqK
-aqH
+alT
+alD
 auN
+anE
 aDE
 awX
 auq
-aju
-aDE
-awX
-axU
-aju
-aDE
-awX
+auq
+apQ
+aoI
 aHN
+adW
+asc
 aju
-aDE
-awX
+aHN
+adW
+auA
+aju
 bga
-aju
+aQp
 aLP
-aQp
+aEr
 aPk
+aLc
 aEr
-aSG
-bLb
-aEr
-aMF
+cpo
 aLV
 aLV
 aLV
 aQp
 aLV
+aDG
+bEz
+blD
+blD
+bPB
+blD
+blD
+bVm
 bqR
-wEs
-blD
-blD
-iYI
-blD
-blD
-pKq
-bmV
+uhD
+kId
 tsg
 kId
 bmV
@@ -68124,39 +65848,39 @@ aaa
 aaa
 aaa
 aaa
-cTr
-cRx
-cRx
-cRx
-cRx
-cRx
-cRx
-cUI
-cRx
-cVD
-cRt
-cRY
-cRx
-cTl
-cTl
-cTL
-cTl
-cTl
-cTl
-cTl
 aaa
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68229,7 +65953,7 @@ akZ
 akZ
 akZ
 akZ
-aaH
+akZ
 aaa
 akZ
 afj
@@ -68241,33 +65965,31 @@ aif
 ajt
 akZ
 akl
-alD
-alH
-alD
+adW
+aDV
+aju
 ans
-auN
-aos
-apq
-aoI
+adW
+aDV
+aju
+alD
 aqR
 apx
-axF
 auN
+aol
 avH
-awX
+apc
 aur
-aju
+apr
 ayW
-awX
-aur
-aju
-aBn
-awX
-aur
-aju
+aoI
+aqn
+adW
 aDV
-awX
-aur
+aju
+ath
+adW
+aDV
 aju
 aDG
 aDG
@@ -68277,19 +65999,21 @@ aDG
 aDG
 aDG
 aDG
-nSk
+bfA
 aQp
 aQp
 aQp
 aLV
-bqR
+aDG
+bHN
+aSq
 aSq
 bRA
-bRA
+bQO
 qPM
 dGh
-iMI
-tLp
+bqR
+uhD
 bmV
 frm
 uEA
@@ -68380,41 +66104,41 @@ aaa
 aaa
 aaa
 aaa
-cTr
-cTr
-cTD
-cTK
-cRx
-cRx
-cRh
-cRm
-cRL
-cRx
-cRJ
-cRN
-cRx
-cTl
-cSE
-cTn
-cTn
-cTn
-cTn
-cTl
-cTl
-cTl
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
-adJ
-xkQ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68497,56 +66221,56 @@ aif
 aeK
 afq
 akZ
-aju
+adz
 alK
-alH
-amL
+adz
 aju
-ami
+avJ
+avJ
 aov
-apu
+aju
 asj
-asj
-asj
-asj
-ami
+alH
+anc
+azs
+aon
 arO
 atj
-arO
+atj
+atj
+aon
+azs
+aov
+avJ
+avJ
 aju
 avJ
-avJ
-avJ
-aju
-avJ
-avJ
-avJ
-aju
-avJ
-aHK
+aov
 avJ
 aju
 alc
+alc
+aGI
 alc
 aPl
-alc
-alc
-bLu
+aNq
 alc
 aDG
 aDG
 aDG
-sHB
-vtp
+bnC
+btI
 aDG
+aDG
+bnC
+brj
+brj
+bQp
+brj
+brj
+brj
 bqR
-brj
-brj
-brj
-jJQ
-brj
-brj
-brj
+bqR
 bqR
 aXu
 btj
@@ -68636,41 +66360,41 @@ aaa
 aaa
 aaa
 aaa
-cTr
-cTr
-cTB
-cRt
-cTN
-cRx
-cRx
-cRO
-cRt
-cRb
-cRC
-cRC
-cRC
-cTl
-cSq
-cTn
-cUJ
-iqA
-cUJ
-cTn
-cSq
-cTl
-cTl
-cTl
-cUe
-aak
-cVG
-cVG
-cVm
-cVm
-cVm
-cVC
-aak
-aak
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -68756,33 +66480,31 @@ akZ
 akZ
 aka
 hoJ
+hoJ
+ajO
+hoJ
+ssn
+hoJ
 aAc
+hoJ
+amL
 hoJ
 anf
-anI
-hoJ
-aAc
-aCP
-hoJ
-hoJ
-hoJ
 aux
-hoJ
+amL
 hoJ
 hoJ
 ssn
 hoJ
-hoJ
+ajO
 aCP
 aAq
 hoJ
+ajO
 hoJ
-hoJ
-axY
-alc
 edW
 alc
-aAP
+axY
 alc
 alc
 alc
@@ -68790,11 +66512,13 @@ alc
 alc
 alc
 alc
+aYB
+bgA
+alc
+alc
+alc
+aPl
 apd
-alc
-aIM
-alc
-alc
 aSC
 alc
 alc
@@ -68859,15 +66583,15 @@ duA
 bJe
 bJB
 bJe
-cug
-cug
-cug
-cug
-cug
+csI
+csI
+csI
+csI
 cxT
 cxT
 cxT
-cEP
+cxT
+cxT
 cxT
 cxT
 cxT
@@ -68880,54 +66604,54 @@ aOd
 aOd
 aOd
 cDy
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-cTr
-cRt
-cRt
-cRt
-cTR
-cRx
-cRx
-cUp
-cRS
-cTR
-cRC
-cRD
-cRC
-cVe
-cTn
-cUJ
-cUJ
-cTM
-cUJ
-cUJ
-cTn
-cVe
-cTl
-cTl
-aaa
-aaa
-cVG
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69013,22 +66737,22 @@ afu
 akZ
 akb
 alc
-aXu
-edW
-alc
-alc
-alc
-aXu
-apd
-aqO
-alc
-alc
-alc
-alc
-alc
-alc
 alc
 edW
+alc
+alc
+alc
+apd
+alc
+amP
+alc
+alc
+alc
+aXu
+alc
+alc
+alc
+edW
 aqO
 apd
 alc
@@ -69039,19 +66763,19 @@ alc
 alc
 alc
 alc
-aHU
+alc
 alc
 edW
 alc
 aJs
 alc
+aYH
+alc
+alc
+alc
 alc
 alc
 apd
-alc
-alc
-alc
-alc
 alc
 alc
 alc
@@ -69115,76 +66839,76 @@ bJe
 bJe
 bJe
 bJB
-csL
-cug
-cvo
-cwG
-cxV
-cza
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cAt
-cQk
-ckr
-cAt
-cAt
-cAt
-cAt
-ckr
-cAt
-cAt
-ckr
-cAt
-cQk
-cAt
-ckr
-cAt
-cTw
-cTy
-cTy
-cTG
-cRb
-cRx
-cRx
-cRj
-cRt
-cRL
-cVk
-cRE
-cRC
-cTn
-cUJ
-cUJ
-rvm
-cTl
-cTl
-cUJ
-cUJ
-cTn
-cTl
-cTl
+bJe
+cWe
+cxW
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
 aaa
 aaa
-cVm
-cVC
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69275,8 +66999,8 @@ aXu
 aXu
 aXu
 aXu
-aXu
 aCT
+aXu
 aXu
 aXu
 aXu
@@ -69294,21 +67018,21 @@ aXu
 aXu
 aXu
 aXu
-aXu
-aXu
-bHN
+alc
+alc
+alc
 aHe
 aXu
 aXu
 aXu
 aXu
-aXu
-aXu
-aAd
-aXu
+bal
 aXu
 aXu
 aXu
+aXu
+aXu
+aCT
 aXu
 aXu
 aXu
@@ -69372,76 +67096,76 @@ bJe
 bJe
 bJe
 crC
-csM
+bJe
 cWe
 cxW
-cxX
-cxX
-czc
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-cTr
-cTz
-cTC
-cRt
-cTS
-cRe
-cRL
-cRL
-cRq
-cRy
-uTy
-cVH
-cRQ
-cSx
-cSr
-cXG
-cTo
-cTQ
-cTl
-cTT
-cUf
-cVd
-cTl
-cTl
-cVz
-cVF
-cVm
-cVm
-cVm
-cVm
-cVm
-cVm
-cVC
-aak
-adJ
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69532,8 +67256,8 @@ alc
 alc
 alc
 alc
-alc
 apd
+alc
 aqV
 alc
 edW
@@ -69550,22 +67274,22 @@ alc
 alc
 alc
 alc
-aXu
 alc
 alc
-aHU
+alc
+alc
 alc
 alc
 alc
 aJU
 alc
+aYH
 alc
 alc
-apd
 alc
 alc
 alc
-edW
+aCU
 edW
 alc
 aXu
@@ -69629,76 +67353,76 @@ bJe
 bJe
 bJe
 bJB
-csL
-cug
-cvq
-cxX
-cxX
-czc
-czc
-czc
-czc
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-cTr
-cTr
-cTr
-cTr
-cRt
-cTJ
-cTY
-cRx
-cRx
-cRl
-cRt
-cRL
-cVk
-cRA
-cRC
-cTn
-cUJ
-cUJ
-hQG
-cTl
-cTl
-cUK
-cUK
-cTn
-cTl
-cTl
+bJe
+cWe
+cxW
+cxn
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
 aaa
 aaa
-cVm
-cVC
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -69784,12 +67508,12 @@ afb
 alW
 aXu
 aXu
+aiP
 amb
-amP
 aor
+akt
 alc
-alc
-amb
+apd
 aqa
 arj
 ask
@@ -69807,10 +67531,10 @@ alc
 alc
 aJi
 alc
-aXu
+alc
 alc
 aFQ
-aGB
+alc
 edW
 alc
 amb
@@ -69818,11 +67542,11 @@ alc
 alc
 buj
 alc
-apd
+alc
 aNN
 amb
 axG
-alc
+apd
 alc
 alc
 aXu
@@ -69886,76 +67610,76 @@ acS
 crZ
 crZ
 fqS
-rbo
-cug
-cvK
-cxn
+crZ
+cWe
 cxW
-czB
-cAJ
-cAJ
+cxn
 cWI
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cAu
-cTs
-cRS
-cRS
-cTA
-cRS
-cRS
-cUa
-cRx
-cRx
-cUq
-cRt
-cUO
-cRC
-cRG
-cRC
-cVe
-cTn
-cUK
-cUK
-vcn
-cUK
-cUK
-cTn
-cVe
-cTl
-cTl
-aaa
-aaa
-cVG
-cVC
-cVC
-cVC
-cVC
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
+cWI
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70143,76 +67867,76 @@ cuk
 cup
 cTk
 cup
-cuk
-cug
-cug
-cug
-cug
-cug
-cug
-cug
-cug
+cAI
+cEP
+cxZ
+cxZ
 cCZ
 cCZ
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
-cTr
-cTr
-cTr
-cTr
-cRt
-cRt
-cUd
-cRx
-cRx
-cRO
-cRt
-cRb
-cRC
-cRC
-cRC
-cTl
-vLD
-cTn
-cUK
-wUN
-cUK
-cTn
-vLD
-cTl
-cTl
-cTl
-cVA
-aak
-cVG
-cVG
-cVm
-cVm
-cVm
-cVC
-aak
-aak
-adJ
+cCZ
+cCZ
+cCZ
+cCZ
+cCZ
+cWI
+cWI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70392,7 +68116,7 @@ aak
 cnO
 cge
 chV
-bXN
+csM
 ckB
 cmc
 cnO
@@ -70436,41 +68160,41 @@ aaa
 aaa
 aaa
 aaa
-cTr
-cTr
-cTD
-cUg
-cRx
-cRx
-cUr
-cRu
-cUP
-cSt
-cRI
-cSt
-cSt
-cTl
-cTd
-cTn
-cTn
-cTn
-cTn
-cTl
-cTl
-cTl
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
-adJ
-epw
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70694,39 +68418,39 @@ aaa
 aaa
 aaa
 aaa
-cTr
-cRx
-cRx
-cSt
-cSt
-cSt
-cSt
-cUT
-cSt
-cVY
-cSt
-cSt
-cSt
-cTl
-cTl
-qIv
-cTl
-cTl
-cTl
-cTl
 aaa
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -70954,36 +68678,36 @@ aaa
 aaa
 aaa
 aaa
-cSt
-cSt
-cSt
-cUw
-cUV
-cVl
-cVl
-cRf
-sWZ
-eEO
-cSt
-cTl
-cTl
-cTl
-cTl
-cTl
-huR
 aaa
 aaa
 aaa
-cVG
-cVG
-cVG
-cVm
-cVm
-cVC
-aak
-aak
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71212,34 +68936,34 @@ aaa
 aaa
 aaa
 aaa
-cSt
-cSt
-cUy
-cUZ
-cVp
-cWn
-cSt
-cTq
-cSp
-cSt
-cTl
-cTl
-cTl
-cTl
 aaa
 aaa
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71468,35 +69192,35 @@ aaa
 aaa
 aaa
 aaa
-cUk
-cSt
-cSt
-cUB
-cVa
-cVq
-cUZ
-idi
-cSB
-cSN
-cSt
-cTl
-cTX
-cUW
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cVG
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71597,9 +69321,9 @@ awT
 ayr
 bXE
 awY
-akt
+ayg
 kNo
-aye
+apT
 aye
 aLg
 kcg
@@ -71613,7 +69337,7 @@ upj
 nye
 cgz
 cgz
-coV
+kGY
 coV
 cMH
 cMH
@@ -71726,34 +69450,34 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cRB
-cRB
-cRB
-cWo
-cRB
-cRB
-cRB
-cRB
-cRB
-cRB
-hJp
 aaa
 aaa
 aaa
 aaa
 aaa
-cVG
-cVG
-cVG
-cVm
-cVm
-cVC
-aak
-aak
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -71854,7 +69578,7 @@ avR
 avR
 avR
 aAE
-ayg
+aye
 aBM
 aye
 aye
@@ -71984,32 +69708,32 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cVb
-cVs
-cTP
-cVs
-cSK
-cUj
-cRB
-cRB
-cRB
-cRB
 aaa
 aaa
 aaa
 aaa
-cVG
-cVG
-cVC
-cVC
-cVC
-cVC
 aaa
 aaa
 aaa
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72147,7 +69871,7 @@ cgz
 coV
 cgz
 cgz
-aHB
+bVz
 cgz
 cgz
 cgz
@@ -72241,23 +69965,6 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cRB
-cVt
-cTP
-cTP
-nHB
-cSv
-cRB
-yeW
-cRB
-cRB
-cRB
-aaa
-aaa
-cVm
-sYf
 aaa
 aaa
 aaa
@@ -72265,8 +69972,25 @@ aaa
 aaa
 aaa
 aaa
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72368,7 +70092,7 @@ auD
 auD
 wmN
 aAp
-ayh
+apu
 aBM
 awL
 azV
@@ -72381,7 +70105,7 @@ cdA
 cij
 sAM
 coV
-coV
+aIP
 coV
 coV
 coV
@@ -72499,31 +70223,31 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cRB
-cWU
-cTP
-opP
-cVs
-cRB
-cVs
-cTt
-cRB
-cRB
-cRB
-cRB
-cUc
-cTZ
-pqA
-aak
-aak
-aak
-aak
-aak
-adJ
-adJ
-qGB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72636,9 +70360,9 @@ aHb
 aHb
 aWw
 cij
-apw
+aGj
 coV
-coV
+aIP
 coV
 coV
 coV
@@ -72757,28 +70481,28 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cRB
-djP
-cTP
-cTP
-odk
-cTF
-cTF
-kzE
-cRB
-cRB
-cRB
-cVu
-cTZ
 aaa
 aaa
 aaa
 aaa
 aaa
-adJ
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72882,9 +70606,9 @@ avR
 avR
 auE
 aAB
+apw
 aye
-aBM
-aye
+aqc
 azV
 aBE
 nSm
@@ -73015,26 +70739,26 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cRB
-oLK
-vQG
-cRB
-bWN
-cTv
-cTP
-cUl
-cRB
-cRB
-qnP
-cTZ
-cTZ
-aak
-aak
-aae
-aaj
-adJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73140,7 +70864,7 @@ avL
 awU
 awY
 awB
-aBM
+aye
 azy
 azV
 aBF
@@ -73150,7 +70874,7 @@ nSm
 nSm
 nSm
 cij
-apP
+aGr
 coV
 coV
 coV
@@ -73272,24 +70996,24 @@ aaa
 aaa
 aaa
 aaa
-cVv
-cRB
-cRB
-cRB
-cRB
-cRB
-oRh
-wPK
-jMk
-cTP
-cUl
-cUC
-cUN
-cTZ
-cTZ
-cTZ
-cTZ
-cTZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73396,8 +71120,8 @@ avR
 avR
 auE
 aAE
-ayk
-aBM
+aye
+aye
 aye
 aBD
 aHb
@@ -73408,10 +71132,10 @@ nSm
 nSm
 cij
 coV
-coV
-coV
-coV
-coV
+aGG
+aGJ
+kwV
+aIn
 coV
 cMH
 aNA
@@ -73532,19 +71256,19 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cRB
-cRB
-cRB
-wEP
-eYK
-fLV
-cRB
-cTZ
-cTZ
-cTZ
-cTZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73653,7 +71377,7 @@ axJ
 ays
 azA
 aAE
-ayl
+ayh
 aye
 aye
 aBD
@@ -73715,9 +71439,9 @@ byN
 byN
 bHV
 bxo
-bOe
+ckr
 dRQ
-bTJ
+cnV
 cvV
 oOI
 oOI
@@ -73792,15 +71516,15 @@ aaa
 aaa
 aaa
 aaa
-cRB
-cRB
-cRB
-cRB
-cRB
-cRB
-cTZ
 aaa
-nqr
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74050,7 +71774,7 @@ aaa
 aaa
 aaa
 aaa
-aQE
+aaa
 aaa
 aaa
 aaa
@@ -74428,13 +72152,13 @@ coV
 coV
 coV
 coV
-coV
-coV
+aqH
+asC
 cgz
 coV
 cgz
 coV
-coV
+ayk
 coV
 cgz
 aHo
@@ -74485,7 +72209,7 @@ bBZ
 bBZ
 bGF
 byN
-bDa
+bXN
 bKC
 byN
 byO
@@ -74686,12 +72410,12 @@ coV
 coV
 coV
 coV
-coV
+aZS
 cgz
 coV
 cgz
-coV
-coV
+aWL
+ayl
 coV
 cgz
 cgz
@@ -74947,12 +72671,12 @@ coV
 cgz
 coV
 cgz
-coV
-coV
+bkk
+aza
 coV
 cgz
 coV
-coV
+aHE
 cgz
 cgz
 cgz
@@ -75209,7 +72933,7 @@ cgz
 bVq
 cgz
 coV
-coV
+aHI
 cgz
 aEZ
 cgz
@@ -75457,7 +73181,7 @@ mJs
 mJs
 cgz
 coV
-coV
+aIP
 cgz
 coV
 bVq
@@ -75466,7 +73190,7 @@ coV
 coV
 coV
 coV
-coV
+aHE
 cgz
 cgz
 cgz
@@ -75702,7 +73426,7 @@ aaa
 aaa
 aaa
 cij
-coV
+aFV
 coV
 cgz
 hGt
@@ -75718,7 +73442,7 @@ coV
 coV
 coV
 cgz
-coV
+xjL
 coV
 coV
 coV
@@ -75970,7 +73694,7 @@ mJs
 coV
 mJs
 cgz
-bVq
+kwV
 cij
 cij
 cij
@@ -76224,10 +73948,10 @@ cgz
 cgz
 cgz
 cgz
+kwV
 cgz
 cgz
-cgz
-coV
+kwV
 cij
 aaa
 aaa
@@ -76473,18 +74197,18 @@ aaa
 aaa
 aaa
 cij
+amR
 coV
-coV
-coV
-coV
-coV
-coV
-coV
-coV
-coV
-coV
-coV
-coV
+kwV
+kwV
+kwV
+kwV
+kwV
+kwV
+kwV
+kwV
+kwV
+kwV
 cij
 aaa
 aaa
@@ -80860,15 +78584,15 @@ aaa
 aaa
 aak
 aQC
-apQ
+aGB
 aQC
 aQC
 aQC
 aQC
-aus
+aNx
 coV
 coV
-aGF
+bhY
 cMH
 coV
 cgz
@@ -81373,14 +79097,14 @@ aaa
 aaa
 aaa
 aak
-alS
+aAd
 aak
 cgz
 aHy
 bgk
 aDd
 aJD
-auv
+aOG
 cgz
 bkk
 cMH
@@ -81630,14 +79354,14 @@ aaa
 aaa
 aaa
 aak
-alT
+aAz
 aEV
 cgz
 ahU
 aIi
 aDh
 aJE
-aza
+aOX
 cgz
 aTe
 cMH
@@ -81894,7 +79618,7 @@ aHz
 aIj
 aDH
 aFp
-aCK
+aQl
 cgz
 coV
 cMH
@@ -81946,9 +79670,9 @@ ccr
 vFp
 bEZ
 xEZ
-bVz
-bVz
-bVz
+csL
+csL
+csL
 chf
 cix
 bZP
@@ -82152,7 +79876,7 @@ aIk
 aIV
 bba
 aOD
-aGE
+bfk
 cMH
 cMH
 coV
@@ -82406,11 +80130,11 @@ aak
 cgz
 ayj
 aIl
-aqc
+aIM
 jVy
-aGr
+aQA
 cgz
-aGG
+bie
 cMH
 cMH
 cMH
@@ -82665,9 +80389,9 @@ aHC
 aIm
 aEW
 aJH
-aGC
+aQE
 cgz
-aGH
+aHE
 cMH
 coV
 coV
@@ -82918,13 +80642,13 @@ aaa
 aaa
 aak
 cgz
-apT
+aGT
 aRF
 aEX
 aFT
-aGD
+aSG
 cgz
-aGH
+aHE
 cMH
 coV
 coV
@@ -83181,7 +80905,7 @@ cgz
 cgz
 cgz
 cgz
-aGI
+bis
 cMH
 cgz
 cgz
@@ -83960,7 +81684,7 @@ coV
 cgz
 aNg
 aSU
-aGJ
+bOf
 aPn
 bte
 aWZ
@@ -84791,7 +82515,7 @@ cNG
 cut
 jrk
 crc
-cnV
+cxi
 pAS
 rwY
 bVv
@@ -85310,7 +83034,7 @@ pAS
 drP
 bVv
 rwY
-cxi
+cIa
 cvV
 aak
 aaa
@@ -85561,13 +83285,13 @@ cnp
 cOv
 cut
 csn
-cjW
+cwy
 csn
 pAS
 pAS
 bVv
 bVv
-cAI
+cIc
 cvV
 aak
 aaa
@@ -85865,7 +83589,6 @@ aaa
 aaa
 aaa
 aaa
-bjf
 aaa
 aaa
 aaa
@@ -85883,7 +83606,8 @@ aaa
 aaa
 aaa
 aaa
-bjf
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86309,7 +84033,7 @@ cvV
 ayB
 aBq
 aLi
-bOf
+cmr
 wTg
 bPT
 bEY
@@ -86665,9 +84389,9 @@ aaa
 aaa
 aaa
 aaa
-bfA
-bTt
-bfA
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86727,9 +84451,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-aaa
-aKh
 aaa
 aaa
 aaa
@@ -86739,8 +84460,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-atC
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86823,7 +84547,7 @@ cvV
 aAr
 azv
 wJV
-bOf
+cmr
 hJe
 jYD
 ihC
@@ -86892,9 +84616,6 @@ aaa
 aaa
 aaa
 aaa
-bfA
-bjw
-bfA
 aaa
 aaa
 aaa
@@ -86910,9 +84631,6 @@ aaa
 aaa
 aaa
 aaa
-bfA
-bjw
-bfA
 aaa
 aaa
 aaa
@@ -86921,11 +84639,17 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-bVm
-nZK
-nZK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -86984,9 +84708,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-aaa
-aKh
 aaa
 aaa
 aaa
@@ -86996,8 +84717,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-anE
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87080,9 +84804,9 @@ cvV
 aAM
 jCM
 wJV
-bOf
-bOf
-bOf
+cmr
+cmr
+cmr
 xuU
 xuU
 ccJ
@@ -87148,11 +84872,6 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-xng
-nZK
-nZK
 aaa
 aaa
 aaa
@@ -87166,11 +84885,6 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-xng
-nZK
-nZK
 aaa
 aaa
 aaa
@@ -87178,11 +84892,21 @@ aaa
 aaa
 aaa
 aaa
-nZK
-bQO
-vIK
-bie
-nZK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87241,9 +84965,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-aaa
-aKh
 aaa
 aaa
 aaa
@@ -87253,8 +84974,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-auA
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87402,14 +85126,6 @@ aaa
 aaa
 aaa
 aaa
-cJP
-cJP
-cJP
-nZK
-bXz
-vIK
-fSs
-nZK
 aaa
 aaa
 aaa
@@ -87423,11 +85139,6 @@ aaa
 aaa
 aaa
 aaa
-nZK
-vro
-vIK
-bXz
-nZK
 aaa
 aaa
 aaa
@@ -87435,11 +85146,24 @@ aaa
 aaa
 aaa
 aaa
-nZK
-bQS
-vIK
-bVT
-nZK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87498,9 +85222,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-aaa
-aKh
 aaa
 aaa
 aaa
@@ -87510,8 +85231,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-cwy
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87660,14 +85384,6 @@ aaa
 aaa
 aaa
 aaa
-cJP
-nZK
-nZK
-nZK
-rbn
-nZK
-nZK
-nZK
 aaa
 aaa
 aaa
@@ -87679,24 +85395,32 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-nZK
-rbn
-nZK
-nZK
-nZK
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-bVR
-nZK
-nZK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87755,9 +85479,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-aaa
-aKh
 aaa
 aaa
 aaa
@@ -87767,8 +85488,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-auJ
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -87841,7 +85565,7 @@ btF
 btF
 btF
 btF
-aIn
+bVT
 cvV
 cvV
 cvV
@@ -87917,15 +85641,6 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-bJX
-mMY
-vIK
-mMY
-bJX
-nZK
-nZK
 aaa
 aaa
 aaa
@@ -87935,25 +85650,34 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-bJX
-mMY
-vIK
-mMY
-bJX
-nZK
-nZK
 aaa
 aaa
 aaa
 aaa
 aaa
-nZK
-vdY
-vIK
-hfp
-nZK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88012,9 +85736,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-aaa
-aKh
 aaa
 aaa
 aaa
@@ -88024,8 +85745,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-cwy
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88174,16 +85898,6 @@ aaa
 aaa
 aaa
 aaa
-nZK
-gKu
-vIK
-vIK
-vIK
-vIK
-vIK
-bNf
-nZK
-nZK
 aaa
 aaa
 aaa
@@ -88191,26 +85905,36 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vCJ
-nZK
 aaa
 aaa
 aaa
 aaa
 aaa
-nZK
-dZj
-vIK
-dhx
-nZK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88269,9 +85993,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-aaa
-aKh
 aaa
 aaa
 aaa
@@ -88281,8 +86002,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-cXk
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88429,17 +86153,6 @@ aaa
 aaa
 aaa
 aaa
-cJP
-cJP
-nZK
-pMb
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-hfp
 aaa
 aaa
 aaa
@@ -88449,25 +86162,36 @@ aaa
 aaa
 aaa
 aaa
-hfp
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-htT
-cVZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cVZ
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88526,9 +86250,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-cwy
-aKh
 aaa
 aaa
 aaa
@@ -88538,8 +86259,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-cXk
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88688,15 +86412,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-bfp
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-xRS
 aaa
 aaa
 aaa
@@ -88706,25 +86421,34 @@ aaa
 aaa
 aaa
 aaa
-xRS
-vIK
-vIK
-vIK
-vIK
-bvD
-vIK
-gky
-cVZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cVZ
-pzm
-xJs
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88783,9 +86507,6 @@ aaa
 aaa
 aaa
 aaa
-cXk
-cwy
-aKh
 aaa
 aaa
 aaa
@@ -88795,8 +86516,11 @@ aaa
 aaa
 aaa
 aaa
-aKh
-auX
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88942,18 +86666,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-cVZ
-cVZ
-oWr
-vIK
-xJs
-vIK
-vIK
-pHV
-cVZ
-cVZ
 aaa
 aaa
 aaa
@@ -88963,25 +86675,37 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-mHw
-vIK
-vIK
-vIK
-vIK
-htT
-cVZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cVZ
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89040,20 +86764,20 @@ aaa
 aaa
 aaa
 aaa
-cXk
-cwy
-aKh
-aKh
-aKh
-aKh
-aKh
-aKh
-aKh
-aKh
-aKh
-aKh
-aKh
-cwy
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89159,7 +86883,7 @@ css
 cPT
 bEm
 bQF
-cmr
+cwF
 bEo
 gwq
 bEo
@@ -89199,18 +86923,6 @@ aaa
 aaa
 aaa
 aaa
-cWb
-cwy
-cwy
-cXR
-vIK
-vIK
-vIK
-hPV
-nhV
-vIK
-bEq
-cwy
 aaa
 aaa
 aaa
@@ -89220,25 +86932,37 @@ aaa
 aaa
 aaa
 aaa
-cwy
-bEw
-vIK
-hPV
-nhV
-vIK
-vIK
-htT
-cVZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cVZ
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89297,20 +87021,20 @@ aaa
 aaa
 aaa
 aaa
-afl
-cXk
-cXk
-cXk
-cXk
-cXk
-cXk
-arr
-cXk
-cXk
-cXk
-aKh
-mzK
-cXk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89456,18 +87180,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-cVZ
-cVZ
-vIK
-vIK
-vIK
-lvv
-ajp
-pHV
-cVZ
-cVZ
 aaa
 aaa
 aaa
@@ -89477,25 +87189,37 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-mHw
-lvv
-ajp
-vIK
-vIK
-jtO
-nZK
 aaa
 aaa
 aaa
 aaa
 aaa
-nZK
-dZj
-nkf
-xXK
-nZK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89554,20 +87278,20 @@ aaa
 aaa
 aaa
 aaa
-aKh
-aKh
-aKh
-cwy
-cwy
-cwy
-cwy
-cwy
-cwy
-cwy
-cXk
-bEz
-cXk
-cXk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89647,7 +87371,7 @@ btH
 cvV
 cvV
 ctm
-aJG
+bWN
 ctm
 pAS
 pAS
@@ -89716,15 +87440,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-teE
-vIK
-vIK
-xev
-cIc
-vIK
-vIK
-xXK
 aaa
 aaa
 aaa
@@ -89734,26 +87449,35 @@ aaa
 aaa
 aaa
 aaa
-dZj
-vIK
-vIK
-xev
-cIc
-vIK
-vIK
-wyo
-nZK
 aaa
 aaa
 aaa
 aaa
 aaa
-nZK
-utP
-vIK
-vIK
-nZK
-cJP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89811,20 +87535,20 @@ aaa
 aaa
 aaa
 aaa
-ajO
-aqn
-cwy
-cwy
-cwy
-aKh
-aKh
-aKh
-aKh
-bKJ
-asc
-asC
-bIn
-cXk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89973,15 +87697,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-bfk
-vIK
-vIK
-oRd
-wAO
-vIK
-vIK
-var
 aaa
 aaa
 aaa
@@ -89991,25 +87706,34 @@ aaa
 aaa
 aaa
 aaa
-kcs
-vIK
-vIK
-fQB
-wAO
-vIK
-vIK
-htT
-cVZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cVZ
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90068,20 +87792,20 @@ aaa
 aaa
 aaa
 aaa
-apr
-cwy
-cwy
-cwy
-aqs
-anE
-anE
-anE
-aKh
-bXc
-aHv
-asC
-ate
-cwy
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90161,7 +87885,7 @@ boU
 aaa
 aaa
 ctm
-bal
+bXc
 ctm
 aaa
 aaa
@@ -90230,15 +87954,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-bfp
-vIK
-vIK
-voi
-pnE
-vIK
-vIK
-rqn
 aaa
 aaa
 aaa
@@ -90248,25 +87963,34 @@ aaa
 aaa
 aaa
 aaa
-dri
-vIK
-vIK
-voi
-pnE
-vIK
-vIK
-htT
-cVZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cVZ
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90325,20 +88049,20 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-nZK
-nZK
-nZK
-nZK
-nZK
-anE
-aKh
-aKh
-aKh
-aKh
-bIn
-cwy
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90487,15 +88211,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-bfp
-vIK
-vIK
-iMq
-nvB
-vIK
-vIK
-bQp
 aaa
 aaa
 aaa
@@ -90505,25 +88220,34 @@ aaa
 aaa
 aaa
 aaa
-fIL
-nqH
-vIK
-iMq
-nvB
-vIK
-vIK
-htT
-cVZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cVZ
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90741,18 +88465,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-cVZ
-cVZ
-vIK
-vIK
-vIK
-mYH
-iNk
-pHV
-cVZ
-cVZ
 aaa
 aaa
 aaa
@@ -90762,25 +88474,37 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-mHw
-mYH
-iNk
-vIK
-vIK
-htT
-cVZ
 aaa
-bfA
-exm
-bfA
 aaa
-cVZ
-vIK
-bNK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90998,18 +88722,6 @@ aaa
 aaa
 aaa
 aaa
-cWb
-cwy
-cwy
-cXR
-vIK
-vIK
-bNK
-vIK
-vIK
-vIK
-bEq
-cwy
 aaa
 aaa
 aaa
@@ -91019,26 +88731,38 @@ aaa
 aaa
 aaa
 aaa
-cwy
-bSz
-vIK
-vIK
-vIK
-cIa
-vIK
-qRX
-nZK
 aaa
-cVZ
-bhY
-cVZ
 aaa
-nZK
-dZj
-vIK
-gcJ
-nZK
-cJP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91255,18 +88979,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-cVZ
-cVZ
-klI
-vIK
-vIK
-vIK
-vIK
-pHV
-cVZ
-cVZ
 aaa
 aaa
 aaa
@@ -91276,25 +88988,37 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-cVZ
-mHw
-vIK
-vIK
-vIK
-vIK
-knb
-nZK
 aaa
-cVZ
-cwy
-cVZ
 aaa
-nZK
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91515,15 +89239,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-bfp
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-hfp
 aaa
 aaa
 aaa
@@ -91533,25 +89248,34 @@ aaa
 aaa
 aaa
 aaa
-hfp
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-ipz
-cVZ
-cVZ
-cVZ
-cwy
-cVZ
-cVZ
-cVZ
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -91772,15 +89496,6 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-bfp
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vNw
 aaa
 aaa
 aaa
@@ -91790,25 +89505,34 @@ aaa
 aaa
 aaa
 aaa
-vNw
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-cVZ
-diA
-cVZ
-vIK
-vIK
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92029,43 +89753,43 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-unv
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-jEv
-nZK
-nZK
-nZK
-cVZ
-cVZ
-cVZ
-nZK
-nZK
-nZK
-xyG
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-sjQ
-vIK
-sjQ
-vIK
-vIK
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92286,43 +90010,43 @@ aaa
 aaa
 aaa
 aaa
-cVZ
-bfp
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-tmp
-bJX
-btI
-bum
-bvi
-bvB
-bwI
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-cVZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92543,44 +90267,44 @@ aaa
 aaa
 aaa
 aaa
-nZK
-nUN
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
 aaa
 aaa
 aaa
 aaa
-knp
-ruZ
-bsd
-ffx
-vIK
-fHl
-hfp
-nZK
-cJP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92798,46 +90522,46 @@ aaa
 aaa
 aaa
 aaa
-cJP
-cJP
-nZK
-fKU
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-asC
-tFG
-cwF
-tFG
-asC
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
 aaa
 aaa
 aaa
 aaa
-nZK
-nZK
-nZK
-nZK
-nZK
-nZK
-nZK
-nZK
-cJP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93055,46 +90779,46 @@ aaa
 aaa
 aaa
 aaa
-cJP
-cXQ
-nZK
-aKh
-wmV
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-asC
-asC
-asC
-asC
-nWp
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
-vIK
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-cJP
 aaa
-cJP
 aaa
-cJP
-cJP
-cJP
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -539,6 +539,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "adh" = (
@@ -1076,9 +1079,10 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "ahn" = (
-/obj/item/stack/cable_coil,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/brig)
 "aho" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
@@ -1161,11 +1165,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "ahU" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/obj/item/stack/medical/suture,
-/turf/open/floor/plating,
+/obj/structure/table_frame,
+/obj/item/shard,
+/turf/open/floor/iron,
 /area/maintenance/starboard)
 "ahX" = (
 /obj/structure/table,
@@ -1451,11 +1453,21 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "akt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 30
 	},
 /turf/open/floor/iron,
-/area/maintenance/starboard/aft)
+/area/hallway/secondary/command)
 "akE" = (
 /obj/machinery/door/window/brigdoor/security/holding/eastleft,
 /obj/structure/chair,
@@ -1556,6 +1568,7 @@
 "alA" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
 "alB" = (
@@ -1631,9 +1644,9 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
 "alS" = (
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/space)
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "alT" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/airless,
@@ -2106,12 +2119,10 @@
 /turf/open/floor/iron,
 /area/security/warden)
 "apw" = (
-/obj/structure/cable,
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "apx" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -2175,19 +2186,18 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "apP" = (
-/obj/structure/closet/crate/internals,
-/turf/open/floor/plating,
-/area/space)
-"apQ" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/space)
-"apT" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard)
+"apQ" = (
+/obj/item/stack/sheet/mineral/wood,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"apT" = (
+/obj/machinery/vending/medical,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "apW" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -2206,11 +2216,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aqc" = (
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/item/bodypart/l_arm,
+/obj/item/stack/medical/gauze,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aqn" = (
 /obj/structure/chair{
 	dir = 1
@@ -2564,9 +2573,6 @@
 	name = "Cell 1";
 	pixel_x = 33
 	},
-/obj/structure/chair{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/security/brig)
 "atj" = (
@@ -2620,23 +2626,16 @@
 "aus" = (
 /obj/machinery/door/airlock/external{
 	name = "External Airlock";
-	req_access_txt = "13"
+	req_access_txt = "24"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/starboard)
 "auv" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/decal/cleanable/blood,
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
 "aux" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Fore Primary Hallway - Security";
@@ -3108,16 +3107,15 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ayi" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 30
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ayj" = (
-/obj/structure/fluff/broken_flooring,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/structure/table/glass,
+/obj/item/pen,
+/obj/item/hatchet,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron,
 /area/maintenance/starboard)
 "ayk" = (
 /obj/structure/cable,
@@ -3306,14 +3304,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "aza" = (
-/obj/machinery/power/apc{
-	areastring = "/area/service/theater";
-	dir = 1;
-	name = "Theatre APC";
-	pixel_y = 23
+/obj/structure/fluff/broken_flooring{
+	dir = 1
 	},
+/obj/effect/mapping_helpers/dead_body_placer,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/starboard)
 "azn" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -3779,12 +3775,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "aCK" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
+/obj/item/stack/medical/suture,
+/obj/item/stack/medical/gauze,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/starboard)
 "aCO" = (
 /obj/machinery/camera/motion/directional/south{
@@ -3819,12 +3815,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aDd" = (
-/obj/item/bodybag,
-/obj/structure/closet/crate/medical,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aDh" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
+/obj/item/bodypart/head,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aDq" = (
@@ -3858,8 +3854,8 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "aDH" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/obj/item/stack/medical/bruise_pack,
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aDI" = (
@@ -4078,16 +4074,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "aEW" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 1
-	},
-/obj/item/bodybag,
-/turf/open/floor/plating,
+/obj/item/stack/medical/suture,
+/turf/open/floor/iron,
 /area/maintenance/starboard)
 "aEX" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/bed/roller,
-/obj/item/wrench/medical,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aEY" = (
@@ -4137,11 +4130,8 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "aFp" = (
-/obj/item/stack/medical/suture,
-/obj/item/stack/medical/gauze,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/item/stack/medical/bruise_pack,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aFw" = (
@@ -4202,8 +4192,9 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
 "aFT" = (
-/obj/item/bodypart/r_leg,
+/obj/effect/decal/cleanable/blood,
 /obj/structure/bed/roller,
+/obj/item/wrench/medical,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aFU" = (
@@ -4253,14 +4244,12 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "aGr" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "24"
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/starboard)
 "aGt" = (
 /obj/machinery/light/directional/south,
@@ -4299,53 +4288,51 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aGC" = (
-/obj/item/reagent_containers/glass/rag,
-/obj/effect/decal/cleanable/blood,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aGD" = (
-/obj/structure/table_frame,
-/obj/item/shard,
+/obj/item/bodypart/r_leg,
+/obj/structure/bed/roller,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aGE" = (
-/obj/structure/table/glass,
-/obj/item/wirecutters,
-/obj/item/crowbar/red{
-	desc = "A small crowbar. This handy tool is useful for lots of things, such as romerol tumors or alien babies. ";
-	name = "medical crowbar"
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock{
+	name = "Abandoned Medical Aux Room"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aGF" = (
-/obj/structure/table_frame,
-/obj/item/bedsheet/random,
-/turf/open/floor/iron,
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aGG" = (
-/obj/structure/table/glass,
-/obj/item/pen,
-/obj/item/hatchet,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"aGH" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/bottle/absinthe{
-	desc = "Good disinfectant. Also good for getting drunk very fast.";
-	name = "medical-grade absinthe"
-	},
-/obj/item/lighter,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"aGI" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"aGJ" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"aGH" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"aGI" = (
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"aGJ" = (
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "aGP" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron,
@@ -4469,38 +4456,47 @@
 /turf/closed/wall,
 /area/security/checkpoint/science/research)
 "aHy" = (
-/obj/item/bodypart/l_leg/monkey,
-/obj/vehicle/ridden/wheelchair,
+/obj/item/reagent_containers/glass/rag,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aHz" = (
-/obj/item/shard{
-	icon_state = "small"
+/obj/structure/table/glass,
+/obj/item/wirecutters,
+/obj/item/crowbar/red{
+	desc = "A small crowbar. This handy tool is useful for lots of things, such as romerol tumors or alien babies. ";
+	name = "medical crowbar"
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aHA" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/structure/cable,
+/obj/structure/table_frame,
+/obj/item/bedsheet/random,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aHB" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance Access";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aHC" = (
-/obj/item/shard{
-	icon_state = "medium"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/bottle/absinthe{
+	desc = "Good disinfectant. Also good for getting drunk very fast.";
+	name = "medical-grade absinthe"
 	},
-/obj/item/stack/medical/bruise_pack,
-/obj/structure/cable,
+/obj/item/lighter,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aHE" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "aHI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -4581,36 +4577,39 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aIi" = (
-/obj/item/bodypart/head,
-/turf/open/floor/iron,
+/obj/structure/fluff/broken_flooring{
+	dir = 4
+	},
+/obj/item/stack/medical/suture,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aIj" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/landmark/blobstart,
+/obj/item/shard{
+	icon_state = "small"
+	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aIk" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/neck/stethoscope,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aIl" = (
-/obj/item/bodypart/l_arm,
-/obj/item/stack/medical/gauze,
-/turf/open/floor/iron,
+/obj/structure/fluff/broken_flooring,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aIm" = (
-/obj/item/stack/medical/suture,
+/obj/item/shard{
+	icon_state = "medium"
+	},
+/obj/item/stack/medical/bruise_pack,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aIn" = (
-/obj/item/storage/box/bodybags,
-/obj/machinery/light/small/directional/east,
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/maintenance/starboard)
+/turf/closed/wall,
+/area/hallway/secondary/exit)
 "aIp" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -4691,8 +4690,9 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aIV" = (
-/obj/effect/decal/cleanable/blood/innards,
-/obj/effect/decal/cleanable/blood/tracks,
+/obj/structure/table,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/neck/stethoscope,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
@@ -4747,28 +4747,30 @@
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "aJD" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/bodycontainer/morgue,
+/obj/item/bodybag,
+/obj/structure/closet/crate/medical,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "aJE" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/iron,
+/area/maintenance/starboard)
+"aJG" = (
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"aJH" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/dead_body_placer,
+/obj/item/bodybag,
 /turf/open/floor/plating,
-/area/maintenance/starboard)
-"aJG" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/machinery/iv_drip,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard)
-"aJH" = (
-/obj/machinery/iv_drip,
-/turf/open/floor/iron,
 /area/maintenance/starboard)
 "aJJ" = (
 /obj/item/storage/box/lights/mixed,
@@ -5461,13 +5463,10 @@
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "aOD" = (
+/obj/structure/fluff/broken_flooring,
 /obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/door/airlock{
-	name = "Abandoned Medical Aux Room"
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aOF" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
@@ -5668,7 +5667,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aPn" = (
-/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	name = "Medical blue corner"
@@ -7575,9 +7573,15 @@
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "bal" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bao" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/toxin{
@@ -7647,10 +7651,10 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "bba" = (
-/obj/structure/fluff/broken_flooring,
+/obj/effect/decal/cleanable/blood/innards,
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/starboard)
 "bbc" = (
 /obj/structure/table,
@@ -8437,8 +8441,8 @@
 /turf/closed/wall,
 /area/medical/morgue)
 "bgk" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/machinery/light/small/directional/west,
+/obj/item/bodypart/l_leg/monkey,
+/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "bgt" = (
@@ -9352,6 +9356,7 @@
 /area/security/checkpoint/medical)
 "blM" = (
 /obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "blN" = (
@@ -10387,16 +10392,11 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "bqY" = (
-/obj/structure/closet/bombcloset,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	color = "#4D0067";
-	name = "Science purple corner"
-	},
-/turf/open/floor/iron/white,
-/area/science/mixing)
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "bqZ" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=security";
@@ -10970,7 +10970,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "btV" = (
-/obj/machinery/disposal/bin,
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "btX" = (
@@ -11841,7 +11843,7 @@
 	},
 /area/service/hydroponics)
 "bxD" = (
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/hallway/primary/starboard)
 "bxE" = (
 /obj/machinery/door/firedoor,
@@ -12044,7 +12046,6 @@
 	desc = "Dead plant. I thought all office plants were fake.";
 	name = "Neglected Office Plant"
 	},
-/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
@@ -12519,7 +12520,6 @@
 "bzu" = (
 /obj/machinery/light_switch/directional/east,
 /obj/structure/table,
-/obj/machinery/cell_charger,
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	dir = 4;
@@ -12534,6 +12534,7 @@
 	dir = 1;
 	name = "Science purple corner"
 	},
+/obj/machinery/ecto_sniffer,
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "bzy" = (
@@ -13565,7 +13566,6 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "bCY" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/light/small/directional/west,
@@ -13579,10 +13579,13 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "bDa" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/commons/vacant_room/office)
+/obj/structure/table/wood,
+/obj/machinery/door/window/northright{
+	name = "Library Desk Door";
+	req_access_txt = "37"
+	},
+/turf/open/floor/carpet/green,
+/area/service/library)
 "bDb" = (
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13984,7 +13987,6 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/vomit,
-/obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/wood,
@@ -14114,6 +14116,7 @@
 	name = "Science purple corner"
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science)
 "bFa" = (
@@ -14130,7 +14133,6 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/decal/remains/human,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 30
 	},
@@ -14201,16 +14203,14 @@
 "bFm" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/railing{
-	dir = 1;
-	layer = 3.1
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "bFn" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/railing{
-	dir = 1;
-	layer = 3.1
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -14277,8 +14277,7 @@
 "bFy" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/railing{
-	dir = 1;
-	layer = 3.1
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
@@ -15065,6 +15064,7 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bJi" = (
@@ -15134,6 +15134,9 @@
 /area/service/library)
 "bJr" = (
 /obj/structure/table/wood,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/carpet/green,
 /area/service/library)
 "bJs" = (
@@ -15141,14 +15144,19 @@
 /obj/item/pen,
 /obj/item/pen/blue,
 /obj/item/pen/red,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/carpet/green,
 /area/service/library)
 "bJt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/obj/machinery/camera/directional/east{
-	c_tag = "Library Office";
-	name = "Library Office Camera"
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -15314,9 +15322,13 @@
 /area/service/library)
 "bKD" = (
 /obj/structure/table/wood,
-/obj/item/paper_bin,
 /obj/structure/sign/painting/library_secure{
 	pixel_x = 32
+	},
+/obj/machinery/computer/bookmanagement,
+/obj/machinery/camera/directional/east{
+	c_tag = "Library Office";
+	name = "Library Office Camera"
 	},
 /turf/open/floor/wood,
 /area/service/library)
@@ -15669,8 +15681,8 @@
 /area/service/hydroponics/garden)
 "bMx" = (
 /obj/structure/table/wood,
-/obj/item/toy/figure/curator,
 /obj/machinery/newscaster/directional/east,
+/obj/item/paper_bin,
 /turf/open/floor/wood,
 /area/service/library)
 "bMB" = (
@@ -15719,11 +15731,12 @@
 /turf/open/floor/iron,
 /area/space)
 "bNm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/disposal/bin,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "bNw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -15794,22 +15807,20 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bOe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"bOf" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement,
 /obj/structure/sign/painting/library_secure{
 	pixel_x = -32
 	},
+/obj/structure/railing,
+/obj/structure/table/wood,
+/obj/item/toy/figure/curator,
 /turf/open/floor/wood,
 /area/service/library)
+"bOf" = (
+/turf/closed/wall,
+/area/science/misc_lab/range)
 "bOg" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/light_switch/directional/south,
-/obj/machinery/libraryscanner,
 /turf/open/floor/wood,
 /area/service/library)
 "bOi" = (
@@ -16172,7 +16183,17 @@
 	dir = 1;
 	name = "emergency shower"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "bRw" = (
 /obj/structure/cable,
@@ -16217,7 +16238,17 @@
 	layer = 2.7;
 	pixel_y = -8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "bRQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -16420,20 +16451,15 @@
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
 "bTJ" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
+	},
+/obj/structure/railing{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
+/obj/machinery/libraryscanner,
+/turf/open/floor/wood,
+/area/service/library)
 "bTM" = (
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/engine,
@@ -16707,6 +16733,9 @@
 /area/maintenance/starboard)
 "bVu" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver{
+	pixel_x = -28
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bVv" = (
@@ -16722,9 +16751,8 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/private_investigators_office)
 "bVz" = (
-/obj/item/radio/intercom/directional/south,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
 /area/science/explab)
 "bVA" = (
 /turf/open/floor/iron/white,
@@ -16914,6 +16942,7 @@
 	dir = 8;
 	name = "Science purple corner"
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bXo" = (
@@ -16997,15 +17026,9 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bXN" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/sorting";
-	name = "Delivery Office APC";
-	pixel_x = 1;
-	pixel_y = -23
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/ore_silo,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/nuke_storage)
 "bXO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -17204,6 +17227,8 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "bZD" = (
@@ -17487,6 +17512,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science)
 "cbJ" = (
@@ -17543,12 +17569,14 @@
 /area/tcommsat/computer)
 "ccr" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science)
 "ccs" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/science)
 "ccu" = (
@@ -17580,12 +17608,6 @@
 /area/science)
 "ccB" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/camera{
-	c_tag = "Research Hall - West";
-	dir = 10;
-	name = "Research Camera";
-	network = list("ss13","rd")
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
@@ -17595,6 +17617,11 @@
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
 	name = "Science purple corner"
+	},
+/obj/machinery/camera/directional/south{
+	c_tag = "Research Hall - West";
+	name = "Research Camera";
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
 /area/science)
@@ -18379,6 +18406,8 @@
 	network = list("vault")
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/structure/closet/crate/goldcrate,
+/obj/item/toy/plush/nukeplushie,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "chd" = (
@@ -18732,10 +18761,6 @@
 /turf/open/floor/iron/white,
 /area/science)
 "cjb" = (
-/obj/structure/railing{
-	dir = 1;
-	layer = 3.1
-	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -18746,6 +18771,9 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science)
@@ -18904,9 +18932,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "cjW" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
+/turf/open/floor/engine,
+/area/science/mixing/chamber)
 "cjX" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -19171,10 +19200,6 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cle" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
-	req_access_txt = "7"
-	},
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
 	name = "Science purple corner"
@@ -19186,6 +19211,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Lab";
+	req_access_txt = "8"
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "clf" = (
@@ -19310,6 +19339,7 @@
 /area/engineering/lobby)
 "clG" = (
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "clI" = (
@@ -19397,11 +19427,12 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cmr" = (
-/obj/structure/closet/crate/goldcrate,
-/obj/item/toy/plush/nukeplushie,
-/obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/ordnance{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
-/area/ai_monitored/command/nuke_storage)
+/area/science/mixing)
 "cms" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/airalarm/directional/north,
@@ -19495,7 +19526,6 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cmM" = (
-/obj/structure/closet/bombcloset,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -19701,9 +19731,13 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cnV" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cnW" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -19999,6 +20033,7 @@
 /area/cargo/storage)
 "cpz" = (
 /obj/structure/closet/crate/silvercrate,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "cpA" = (
@@ -20465,6 +20500,9 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/construction)
 "csm" = (
@@ -20816,6 +20854,7 @@
 /area/engineering/atmos)
 "cto" = (
 /obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "ctp" = (
@@ -21744,7 +21783,7 @@
 "cwP" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Office";
-	req_one_access_txt = "31;48"
+	req_one_access_txt = "48"
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -21790,7 +21829,6 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cwU" = (
-/obj/structure/ore_box,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -21823,9 +21861,14 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cxi" = (
-/obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/aft)
 "cxj" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -22041,6 +22084,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cyo" = (
@@ -22541,9 +22585,6 @@
 /area/maintenance/disposal)
 "cAH" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/item/stack/sheet/mineral/sandbags{
-	amount = 25
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -22551,19 +22592,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cAI" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Mining Office";
-	req_one_access_txt = "31;48"
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cAJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -22903,14 +22938,12 @@
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
 "cCa" = (
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/shovel,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
@@ -24920,20 +24953,8 @@
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "cJN" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cJP" = (
@@ -25216,15 +25237,9 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "cLf" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
@@ -25413,17 +25428,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cMb" = (
-/obj/structure/closet/firecloset,
+/obj/structure/closet/secure_closet/miner,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown{
-	dir = 4
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cMc" = (
@@ -25432,14 +25444,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cMd" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -25710,15 +25716,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cNt" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48";
-	shuttledocked = 1
+/obj/machinery/door/airlock/mining/glass{
+	name = "Mining Office";
+	req_one_access_txt = "48"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cNv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -25787,7 +25789,17 @@
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "cNP" = (
-/turf/open/floor/plating,
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cNQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -25848,17 +25860,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel)
-"cOe" = (
-/obj/machinery/door/airlock/external{
-	name = "Mining Dock Airlock";
-	req_access_txt = "48";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/cargo/miningoffice)
 "cOn" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply,
 /obj/effect/turf_decal/tile/purple{
@@ -25870,18 +25871,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"cOo" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 3;
-	height = 5;
-	id = "mining_home";
-	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/delta;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "cOp" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -25948,35 +25937,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/engineering/main)
-"cOC" = (
-/obj/structure/closet/crate,
-/obj/item/stack/ore/glass,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/silver,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/obj/item/stack/ore/iron,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
-"cOD" = (
-/obj/machinery/computer/shuttle/mining{
-	dir = 1
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "cOE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
 	dir = 1
@@ -26193,13 +26153,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"cQe" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cQk" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube,
@@ -26216,25 +26169,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/commons/fitness)
-"cQu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
-"cQL" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
-"cQM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "cQO" = (
 /obj/structure/rack,
 /obj/item/electronics/firelock,
@@ -26242,25 +26176,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cQS" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
-"cQW" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "cRb" = (
 /obj/structure/cable,
 /obj/machinery/status_display/ai/directional/south,
@@ -26604,10 +26519,6 @@
 /area/engineering/storage/tech)
 "cSZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/circuit,
-/area/ai_monitored/command/nuke_storage)
-"cTa" = (
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "cTd" = (
@@ -27567,13 +27478,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
-"cWY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "cWZ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -27584,12 +27488,6 @@
 	},
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cXc" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency,
-/obj/item/flashlight,
-/turf/open/floor/iron/dark,
 /area/maintenance/starboard/aft)
 "cXe" = (
 /obj/machinery/meter,
@@ -27837,16 +27735,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"dac" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "daC" = (
 /obj/structure/rack,
 /obj/item/storage/box/shipping,
@@ -27876,12 +27764,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"ddJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "deu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 1
@@ -27892,6 +27774,7 @@
 "deB" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/poddoor/massdriver_ordnance,
 /turf/open/floor/plating,
 /area/science/mixing)
 "dgK" = (
@@ -28270,21 +28153,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
-"dSK" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/rglass,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
-"dTO" = (
-/obj/machinery/power/shieldwallgen,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "dWC" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue{
@@ -28329,10 +28197,10 @@
 /turf/open/floor/iron,
 /area/space)
 "dZV" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "eab" = (
@@ -28386,12 +28254,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
-"ehC" = (
-/obj/structure/rack,
-/obj/item/tank/jetpack,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "ejg" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -28413,10 +28275,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
-"ekq" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "els" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -28425,29 +28283,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"ene" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "eog" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -28499,12 +28334,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"eqD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "eqU" = (
 /obj/machinery/power/apc{
 	areastring = "/area/ai_monitored/turret_protected/aisat/service";
@@ -28519,11 +28348,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
-"erc" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "esy" = (
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = 30
@@ -28696,9 +28520,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"eVH" = (
-/turf/open/floor/wood,
-/area/security/detectives_office/private_investigators_office)
 "eWL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -28803,7 +28624,17 @@
 /area/maintenance/starboard/aft)
 "feF" = (
 /obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "feI" = (
 /obj/structure/window/reinforced{
@@ -28821,7 +28652,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/detectives_office/private_investigators_office)
+/area/security/detectives_office)
 "ffi" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -28882,33 +28713,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"fpK" = (
-/obj/structure/rack,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "fqq" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -29144,21 +28948,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/private_investigators_office)
-"fMQ" = (
-/obj/structure/cable,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"fNj" = (
-/obj/machinery/door/airlock/command{
-	name = "Auxiliary E.V.A. Storage";
-	req_access_txt = "18"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "fNz" = (
 /turf/open/floor/plating,
 /area/engineering/atmos)
@@ -29252,16 +29041,6 @@
 "gam" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"gaH" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/cable_coil,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/turf/open/floor/iron/dark,
 /area/maintenance/starboard/aft)
 "gbK" = (
 /obj/structure/table,
@@ -29393,7 +29172,7 @@
 	alpha = 255
 	},
 /turf/open/floor/iron/dark,
-/area/security/detectives_office/private_investigators_office)
+/area/security/detectives_office)
 "gpv" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -29561,29 +29340,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/engineering/main)
-"gLt" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "gMJ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -29605,33 +29361,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
-"gRT" = (
-/obj/structure/rack,
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "gSf" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Morgue";
@@ -29709,12 +29438,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/engine_smes)
-"hcE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "hcM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -29731,10 +29454,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hdk" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "hdt" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -29769,12 +29488,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/space)
-"hfS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "hgf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -29881,14 +29594,6 @@
 "hob" = (
 /turf/closed/wall,
 /area/security/brig)
-"hoq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -30
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "hoD" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -30215,7 +29920,7 @@
 	alpha = 255
 	},
 /turf/open/floor/iron/dark,
-/area/security/detectives_office/private_investigators_office)
+/area/security/detectives_office)
 "hXT" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -30223,11 +29928,6 @@
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hZw" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "ibK" = (
 /obj/structure/tank_holder/extinguisher,
 /obj/machinery/firealarm/directional/south,
@@ -30332,24 +30032,13 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"inh" = (
-/obj/effect/turf_decal/stripes/corner{
+"inx" = (
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
-"inx" = (
-/obj/structure/rack,
-/obj/item/shovel,
-/obj/item/shovel,
-/obj/item/pickaxe,
-/obj/item/pickaxe,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
@@ -30436,7 +30125,17 @@
 /area/science/explab)
 "ivL" = (
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "ivM" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -30533,7 +30232,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/detectives_office/private_investigators_office)
+/area/security/detectives_office)
 "iLu" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -30604,9 +30303,6 @@
 /area/cargo/warehouse)
 "iYa" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/item/stack/sheet/mineral/sandbags{
-	amount = 25
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -30830,15 +30526,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/bar/atrium)
-"juU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_y = 30
-	},
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "juV" = (
 /turf/open/floor/carpet,
 /area/service/chapel)
@@ -31085,7 +30772,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/area/security/detectives_office/private_investigators_office)
 "jSw" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -31337,7 +31024,7 @@
 	c_tag = "Detective's Interrogation"
 	},
 /turf/open/floor/iron/dark,
-/area/maintenance/starboard)
+/area/security/detectives_office/private_investigators_office)
 "kBU" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/radio/intercom/directional/south,
@@ -31491,11 +31178,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
-"kTl" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "kTC" = (
 /obj/machinery/modular_computer/console/preset/cargochat/service,
 /turf/open/floor/wood,
@@ -31587,10 +31269,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"leP" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "leY" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -31611,7 +31289,7 @@
 	icon_state = "small"
 	},
 /turf/open/floor/iron/dark,
-/area/security/detectives_office/private_investigators_office)
+/area/security/detectives_office)
 "lfw" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -31723,11 +31401,6 @@
 /obj/item/trash/chips,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"lDr" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/security/detectives_office)
 "lFU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -31853,18 +31526,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"lUO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "lUY" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light/directional/south,
@@ -31977,10 +31638,6 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "mhX" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Lab";
-	req_access_txt = "7"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -31995,6 +31652,10 @@
 	name = "Science purple corner"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Launch Room";
+	req_access_txt = "8"
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "mjr" = (
@@ -32016,20 +31677,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"mjQ" = (
-/obj/structure/ore_box,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "mkc" = (
 /turf/closed/wall/r_wall,
 /area/construction)
@@ -32082,6 +31729,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "mrE" = (
@@ -32098,10 +31746,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"msL" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "mtB" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -32282,6 +31926,7 @@
 /area/medical/medbay/lobby)
 "mIb" = (
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/research/glass/incinerator/ordmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "mIS" = (
@@ -32405,13 +32050,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"nau" = (
-/obj/structure/closet/crate,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/cargo/miningoffice)
 "nbH" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -32582,11 +32220,15 @@
 /area/space)
 "nye" = (
 /obj/structure/closet/secure_closet/detective,
+/obj/machinery/light/directional/south,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
 "nzd" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
 /turf/open/floor/plating,
-/area/security/detectives_office/private_investigators_office)
+/area/maintenance/starboard)
 "nzM" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -32672,12 +32314,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"nKg" = (
-/obj/structure/sign/painting/library_secure{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/service/library)
 "nLu" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -32720,7 +32356,7 @@
 "nSe" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
-/area/security/detectives_office/private_investigators_office)
+/area/security/detectives_office)
 "nSk" = (
 /obj/item/radio/intercom/directional/east{
 	freerange = 1;
@@ -32744,11 +32380,6 @@
 /obj/item/stock_parts/subspace/analyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"nTS" = (
-/obj/structure/closet/l3closet,
-/obj/item/toy/mecha/mauler,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "nUN" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -32961,8 +32592,8 @@
 /turf/open/floor/iron/white,
 /area/science/misc_lab/range)
 "oBH" = (
-/obj/effect/spawner/random/maintenance/two,
 /obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oCF" = (
@@ -33095,21 +32726,6 @@
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
-"oRA" = (
-/obj/structure/rack,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/item/radio/off,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "oRH" = (
 /obj/structure/table,
 /obj/item/surgicaldrill,
@@ -33118,11 +32734,11 @@
 /area/medical/surgery)
 "oSk" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/obj/machinery/door/airlock/engineering{
-	name = "Security Auxiliary Air Supply";
-	req_one_access_txt = "1;10;24"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_access_txt = "63"
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/port)
 "oSW" = (
@@ -33179,20 +32795,12 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"oYi" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "oZZ" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pao" = (
-/obj/machinery/door/airlock/research{
-	name = "Toxins Launch Room";
-	req_access_txt = "7"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -33206,6 +32814,10 @@
 	name = "Science purple corner"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/research{
+	name = "Ordnance Launch Room";
+	req_access_txt = "8"
+	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "pbq" = (
@@ -33371,7 +32983,17 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "pAS" = (
 /turf/closed/wall/r_wall,
@@ -33461,10 +33083,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"pJt" = (
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/security/detectives_office/private_investigators_office)
 "pKq" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -33560,13 +33178,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
-"pXG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "qay" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/operating,
@@ -33814,10 +33425,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"qGF" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "qIv" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom/directional/south,
@@ -33988,6 +33595,8 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "qWB" = (
@@ -34116,10 +33725,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/service)
-"rmV" = (
-/obj/machinery/power/shieldwallgen,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "ror" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -34359,12 +33964,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"rVj" = (
-/obj/structure/rack,
-/obj/item/tank/jetpack,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "rVW" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -34552,13 +34151,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
-"syt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
 "sAM" = (
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plating,
@@ -35097,7 +34689,17 @@
 	network = list("ss13","medbay")
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "tYN" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -35413,16 +35015,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/circuit,
 /area/maintenance/solars)
-"uWD" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 3"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "uXd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -35534,9 +35126,6 @@
 /area/maintenance/starboard/aft)
 "vfU" = (
 /obj/structure/closet/secure_closet/miner,
-/obj/item/stack/sheet/mineral/sandbags{
-	amount = 25
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -35961,15 +35550,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"wbs" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/cargo/warehouse";
-	name = "Cargo Warehouse APC";
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "weY" = (
 /obj/structure/cable,
 /obj/structure/closet/emcloset,
@@ -36060,14 +35640,7 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "wqh" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/door/airlock/mining{
-	name = "Mining Dock";
-	req_access_txt = "48"
-	},
+/obj/structure/stairs/south,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "wse" = (
@@ -36169,15 +35742,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"wHO" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/maintenance/starboard/aft)
-"wIT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark,
-/area/maintenance/starboard/aft)
 "wJV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
@@ -36258,7 +35822,17 @@
 	departmentType = 1;
 	name = "Medbay RC"
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "wRf" = (
 /obj/effect/turf_decal/tile/brown,
@@ -36381,7 +35955,7 @@
 	},
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
-/area/security/detectives_office/private_investigators_office)
+/area/security/detectives_office)
 "xjf" = (
 /obj/machinery/door/window/southleft{
 	name = "Test Chamber";
@@ -36493,11 +36067,13 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "xqk" = (
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "xqE" = (
@@ -36556,6 +36132,7 @@
 	dir = 4;
 	name = "Science purple corner"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/explab)
 "xFO" = (
@@ -51247,8 +50824,8 @@ bdS
 qTU
 bLw
 bLw
-bLw
-bLw
+aHE
+aHE
 bLw
 aVh
 aVi
@@ -51258,8 +50835,8 @@ aVi
 aVi
 aVh
 bLw
-bLw
-bLw
+aHE
+aHE
 bLw
 bLw
 qTU
@@ -55629,7 +55206,7 @@ bwM
 bxR
 bzJ
 bBq
-bDa
+bzJ
 bEI
 bwU
 bHq
@@ -57656,7 +57233,7 @@ aQa
 aNi
 aQa
 aTi
-aMt
+bmV
 kId
 tsg
 kId
@@ -57913,7 +57490,7 @@ kId
 kId
 kId
 kId
-bmV
+aMt
 kId
 tsg
 bmV
@@ -58740,7 +58317,7 @@ cjo
 bXp
 clG
 cmU
-cnV
+caU
 knY
 aaa
 aaa
@@ -65142,7 +64719,7 @@ byq
 bFb
 byq
 blM
-byq
+bqY
 btV
 bLX
 bOd
@@ -65400,7 +64977,7 @@ byq
 byq
 kxR
 bJo
-bxa
+bNm
 bLX
 vkV
 bOd
@@ -66687,12 +66264,12 @@ byv
 byv
 bKo
 bMf
-jZh
+bLX
 bLX
 ngu
 vkV
 bwU
-aza
+bEL
 bGh
 cjG
 bXv
@@ -66869,7 +66446,7 @@ alD
 alD
 alD
 alD
-akT
+ahn
 alD
 aoW
 aog
@@ -67126,7 +66703,7 @@ alD
 ycR
 alD
 alD
-akT
+ahn
 akT
 akT
 akT
@@ -67646,7 +67223,7 @@ auN
 aol
 auN
 apc
-apw
+akT
 ath
 alD
 akT
@@ -67715,7 +67292,7 @@ bMd
 byx
 bKX
 oOD
-jZh
+bLX
 bLX
 ngu
 vkV
@@ -69970,7 +69547,7 @@ aqV
 aCU
 alc
 alc
-aXu
+alc
 alc
 alc
 aXu
@@ -70227,7 +69804,7 @@ bbo
 aDw
 alc
 alc
-aXu
+alc
 aJi
 alc
 aXu
@@ -70489,10 +70066,10 @@ aFx
 bhd
 aXu
 bWg
-sYz
-sYz
-sYz
-sYz
+aFx
+aFx
+aFx
+aFx
 sYz
 sYz
 sYz
@@ -70746,7 +70323,7 @@ aFx
 vco
 bKn
 vco
-sYz
+aFx
 iLb
 xiS
 goj
@@ -70815,7 +70392,7 @@ aak
 cnO
 cge
 chV
-cjO
+bXN
 ckB
 cmc
 cnO
@@ -70831,7 +70408,7 @@ cCZ
 cwT
 cAH
 vfU
-cAH
+cMb
 cDA
 cCZ
 aaa
@@ -71003,7 +70580,7 @@ qJN
 rPB
 nZG
 aEO
-sYz
+aFx
 leY
 hVJ
 feI
@@ -71027,8 +70604,8 @@ cgz
 coV
 coV
 coV
-coV
-coV
+cMH
+cMH
 cgz
 dyd
 bhh
@@ -71263,7 +70840,7 @@ nZG
 wse
 rPB
 rPB
-eVH
+rPB
 sYz
 ivM
 jRv
@@ -71285,7 +70862,7 @@ coV
 coV
 coV
 coV
-coV
+cMH
 cgz
 lWz
 bhi
@@ -71330,8 +70907,8 @@ cnO
 cgq
 ckS
 ckd
-cTa
-cmr
+ckS
+ckC
 cTg
 cTh
 cTm
@@ -71519,8 +71096,8 @@ nIY
 bWn
 nZG
 jAq
-lDr
-pJt
+nZG
+nZG
 tHS
 buy
 kBz
@@ -71542,7 +71119,7 @@ coV
 coV
 coV
 coV
-cgz
+cMH
 cgz
 gOU
 bMw
@@ -71601,9 +71178,9 @@ jcn
 cVW
 cwU
 cEs
-cEs
-cEs
-iYa
+cJN
+cMd
+cNP
 cCZ
 aaa
 aaa
@@ -71778,8 +71355,8 @@ hzS
 fqJ
 fqJ
 nSe
-sYz
-sYz
+cgz
+cgz
 cgz
 cgz
 cMH
@@ -71799,7 +71376,7 @@ coV
 coV
 coV
 coV
-cgz
+cMH
 cgz
 vEI
 bhk
@@ -71843,7 +71420,7 @@ aak
 cnO
 chd
 chL
-cjW
+ckS
 cnA
 cqS
 cnO
@@ -71858,15 +71435,15 @@ fVa
 cVW
 cye
 cEs
-cEs
-urD
-iYa
+cLf
+cVW
+cVW
 cCZ
 cCZ
-cCZ
-cCZ
-cCZ
-cCZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72020,7 +71597,7 @@ awT
 ayr
 bXE
 awY
-ayg
+akt
 kNo
 aye
 aye
@@ -72034,9 +71611,9 @@ dyr
 upj
 upj
 nye
-sYz
-sYz
-nzd
+cgz
+cgz
+coV
 coV
 cMH
 cMH
@@ -72056,7 +71633,7 @@ coV
 coV
 coV
 coV
-cgz
+cMH
 cgz
 vhV
 bMw
@@ -72112,18 +71689,18 @@ vAh
 cpl
 vnE
 vAh
-vHB
+cCZ
 cyn
 cEs
-cEs
-cEs
+cLf
+cVW
 xqk
+wqh
 cCZ
-cJN
-mjQ
-mjQ
-bTJ
-cCZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72290,10 +71867,10 @@ abI
 hsZ
 bgc
 bgY
-aFx
-sYz
+cgz
+cgz
 nzd
-nzd
+coV
 coV
 cMH
 coV
@@ -72313,7 +71890,7 @@ coV
 coV
 coV
 coV
-cgz
+cMH
 cgz
 srS
 bhq
@@ -72369,18 +71946,18 @@ cua
 cuG
 kJy
 fHA
-vAh
+cVW
 cyx
 cEs
-cEs
-cEs
+cLf
+cNt
 dZV
 wqh
-lUO
-cEs
-cEs
-cOC
 cCZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72544,11 +72121,11 @@ kRm
 kRm
 kRm
 kRm
-kRm
-aFx
-aFx
-aFx
-coV
+cij
+cgz
+cgz
+cgz
+ckq
 coV
 coV
 coV
@@ -72570,7 +72147,7 @@ cgz
 coV
 cgz
 cgz
-cgz
+aHB
 cgz
 cgz
 cgz
@@ -72608,7 +72185,7 @@ gzx
 eIT
 pAS
 rwY
-bXN
+bVv
 pAS
 pAS
 aaa
@@ -72626,18 +72203,18 @@ csV
 cqE
 jEj
 wZc
-vAh
+cVW
 cze
 moA
 cCa
-cCa
+cVW
 inx
+wqh
 cCZ
-cLf
-cEs
-cEs
-nau
-cCZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -72802,7 +72379,7 @@ bgd
 aTV
 cdA
 cij
-coV
+sAM
 coV
 coV
 coV
@@ -72884,17 +72461,17 @@ cqE
 jEj
 cwO
 vHB
-vAh
-cAI
-vAh
+vHB
+vHB
+vHB
 vHB
 cCZ
 cCZ
-cMb
-cMd
-dac
-cOD
 cCZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73059,7 +72636,7 @@ aHb
 aHb
 aWw
 cij
-coV
+apw
 coV
 coV
 coV
@@ -73144,14 +72721,14 @@ crH
 csN
 jYt
 csP
-vHB
+vAh
 aaa
-cCZ
-cVW
-cVW
-cNt
-cVW
-cCZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73316,7 +72893,7 @@ nSm
 nSm
 aWH
 cij
-coV
+aMb
 coV
 coV
 coV
@@ -73405,9 +72982,9 @@ vHB
 aaa
 aaa
 aaa
-cVW
-cNP
-cVW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73573,7 +73150,7 @@ nSm
 nSm
 nSm
 cij
-coV
+apP
 coV
 coV
 coV
@@ -73662,9 +73239,9 @@ vAh
 aaa
 aaa
 aaa
-cVW
-cNP
-cVW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -73919,9 +73496,9 @@ vAh
 aaa
 aaa
 aaa
-cVW
-cOe
-cVW
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74138,9 +73715,9 @@ byN
 byN
 bHV
 bxo
-bxo
+bOe
 dRQ
-bxo
+bTJ
 cvV
 oOI
 oOI
@@ -74176,9 +73753,9 @@ vAh
 aaa
 aaa
 aaa
-aaP
-cOo
-aaP
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -74395,9 +73972,9 @@ bBZ
 byN
 byO
 bJq
-nKg
+byO
 oCO
-bOf
+byO
 cvV
 oOI
 oOI
@@ -74661,7 +74238,7 @@ oOI
 oOI
 cdX
 cvV
-rwY
+cvV
 rwY
 rwY
 bVv
@@ -74908,7 +74485,7 @@ bBZ
 bBZ
 bGF
 byN
-bJr
+bDa
 bKC
 byN
 byO
@@ -74922,7 +74499,7 @@ rwY
 rwY
 rwY
 bVv
-wbs
+rwY
 pAS
 aaa
 aaa
@@ -75178,7 +74755,7 @@ cvV
 rwY
 rwY
 bVv
-rwY
+bVv
 rwY
 pAS
 aaa
@@ -75436,7 +75013,7 @@ bVv
 bVv
 bVv
 rwY
-fMQ
+lnh
 pAS
 aaa
 aaa
@@ -75692,7 +75269,7 @@ cvV
 cit
 rwY
 ckb
-lnh
+cvV
 cvV
 pAS
 aaa
@@ -75950,8 +75527,8 @@ tyZ
 cWZ
 cXb
 cvV
-cvV
-cvV
+bUc
+pAS
 aaa
 aaa
 aaa
@@ -76208,7 +75785,7 @@ cvV
 cvV
 cvV
 cvV
-cvV
+pAS
 pAS
 pAS
 fNZ
@@ -77774,7 +77351,7 @@ chn
 chn
 cHW
 uTN
-aaa
+aak
 aaa
 aaa
 aaa
@@ -78031,7 +77608,7 @@ chn
 chn
 cIh
 ckf
-aaa
+aak
 aaa
 aaa
 aaa
@@ -78288,7 +77865,7 @@ cDz
 cET
 cIT
 ckf
-aaa
+aak
 aaa
 aaa
 aaa
@@ -78545,7 +78122,7 @@ cvV
 cvV
 cvV
 cvV
-aaa
+aak
 aaa
 aaa
 aaa
@@ -78802,8 +78379,8 @@ rwY
 rwY
 rwY
 cvV
-aaa
-aaa
+aak
+aak
 aaa
 aaa
 aaa
@@ -79274,7 +78851,7 @@ aeJ
 bCk
 aht
 aiv
-bMN
+pAS
 pAS
 bxJ
 bVv
@@ -80566,7 +80143,7 @@ bJy
 bKP
 cvV
 rwY
-rwY
+bVv
 rwY
 pAS
 cbG
@@ -81023,7 +80600,7 @@ aaa
 aaa
 aaa
 aaa
-aak
+aaa
 aak
 aak
 aak
@@ -81280,18 +80857,18 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 aQC
-bal
+apQ
 aQC
 aQC
 aQC
 aQC
-aCK
+aus
 coV
 coV
-aGr
-coV
+aGF
 cMH
 coV
 cgz
@@ -81345,7 +80922,7 @@ cfR
 ccY
 cfR
 cfR
-bVz
+cfR
 bZP
 jPH
 bPT
@@ -81374,13 +80951,13 @@ bVv
 cvV
 cvV
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81537,6 +81114,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 aQC
 aak
@@ -81548,7 +81126,6 @@ cgz
 cgz
 cgz
 cgz
-aIe
 cMH
 coV
 cgz
@@ -81628,16 +81205,16 @@ cPj
 cvV
 rwY
 bVv
-rwY
-cvV
-cvV
-cvV
-cvV
-cvV
-cvV
-cvV
+bUc
 cvV
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81794,18 +81371,18 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
-ahn
+alS
 aak
 cgz
-aGC
 aHy
 bgk
 aDd
 aJD
+auv
 cgz
 bkk
-coV
 cMH
 coV
 cgz
@@ -81885,16 +81462,16 @@ cPp
 cvV
 rwY
 bVv
-rwY
-cvV
-hZw
-cQL
-ehC
-dSK
-hdk
-qGF
+hoD
 cvV
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82051,18 +81628,18 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 alT
 aEV
 cgz
-aGD
 ahU
 aIi
 aDh
 aJE
+aza
 cgz
 aTe
-coV
 cMH
 coV
 cgz
@@ -82140,18 +81717,18 @@ cOz
 cOW
 cPw
 cvV
-rwY
+hoD
 bVv
 rwY
-ctm
-wIT
-cQM
-hfS
-hfS
-hcE
-msL
 cvV
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82308,17 +81885,17 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 aak
 aak
 cgz
-aGE
 aHz
 aIj
 aDH
 aFp
+aCK
 cgz
-coV
 coV
 cMH
 coV
@@ -82369,9 +81946,9 @@ ccr
 vFp
 bEZ
 xEZ
-bVA
-bVA
-bVA
+bVz
+bVz
+bVz
 chf
 cix
 bZP
@@ -82400,17 +81977,17 @@ cvV
 bxJ
 bVv
 rwY
-ctm
-nTS
-ddJ
-oOI
-ekq
-inh
-cQu
 cvV
 aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82567,15 +82144,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 cgz
-aGF
 aHA
 aIk
 aIV
 bba
 aOD
-cMH
+aGE
 cMH
 cMH
 coV
@@ -82658,16 +82235,16 @@ bXF
 bVv
 rwY
 cvV
-juU
-cQS
-gLt
-ene
-cdX
-hoq
-bOe
-bOe
-bOe
-bOe
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82824,16 +82401,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 cgz
-aGG
 ayj
 aIl
+aqc
 jVy
-aJG
+aGr
 cgz
-aGJ
-coV
+aGG
 cMH
 cMH
 cMH
@@ -82914,17 +82491,17 @@ cvV
 aGi
 bVv
 bVv
-fNj
-cWY
-cdX
-oRA
-erc
-cdX
-wHO
-cQe
-rwY
-rwY
-uWD
+cvV
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83081,16 +82658,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 cgz
-aGH
 aHC
 aIm
 aEW
 aJH
+aGC
 cgz
-aHB
-coV
+aGH
 cMH
 coV
 coV
@@ -83172,16 +82749,16 @@ rwY
 rwY
 bVv
 cvV
-pXG
-cQW
-gRT
-fpK
-cdX
-hoq
-bOe
-bOe
-bOe
-bOe
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83338,16 +82915,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 cgz
-aGI
+apT
 aRF
-aIn
 aEX
 aFT
+aGD
 cgz
-aHB
-coV
+aGH
 cMH
 coV
 coV
@@ -83428,17 +83005,17 @@ whV
 bVv
 bVv
 bVv
-ctm
-rmV
-cWY
-cdX
-cdX
-kTl
-syt
 cvV
 aak
-aak
-aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83595,6 +83172,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aak
 cgz
 cgz
@@ -83603,8 +83181,7 @@ cgz
 cgz
 cgz
 cgz
-aHE
-coV
+aGI
 cMH
 cgz
 cgz
@@ -83685,15 +83262,15 @@ cvV
 rwY
 rwY
 bVv
-ctm
-rmV
-eqD
-bNm
-bNm
-akt
-oYi
 cvV
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83852,7 +83429,7 @@ aaa
 aaa
 aaa
 aaa
-aak
+aaa
 aak
 aak
 cgz
@@ -83943,14 +83520,14 @@ mCk
 rwY
 bVv
 cvV
-dTO
-cXc
-rVj
-gaH
-leP
-qGF
-cvV
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84200,14 +83777,14 @@ cvV
 cvV
 cvV
 cvV
-cvV
-cvV
-cvV
-cvV
-cvV
-cvV
-cvV
 aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -84383,7 +83960,7 @@ coV
 cgz
 aNg
 aSU
-aTW
+aGJ
 aPn
 bte
 aWZ
@@ -84454,10 +84031,10 @@ aak
 aak
 aak
 aak
-aaa
-aaa
-aaa
-aaa
+aak
+aak
+aak
+aak
 aaa
 aaa
 aaa
@@ -85214,7 +84791,7 @@ cNG
 cut
 jrk
 crc
-crc
+cnV
 pAS
 rwY
 bVv
@@ -85694,12 +85271,12 @@ btU
 bIQ
 btU
 aJu
-pAS
-pAS
-pAS
+cvV
+cvV
+cvV
 bCR
-pAS
-pAS
+cvV
+cvV
 pAS
 bIW
 aBf
@@ -85708,8 +85285,8 @@ hiM
 wTg
 bPT
 jxa
-bxx
-bxx
+caw
+caw
 bWS
 cbB
 cbB
@@ -85733,7 +85310,7 @@ pAS
 drP
 bVv
 rwY
-qXe
+cxi
 cvV
 aak
 aaa
@@ -85966,7 +85543,7 @@ wTg
 bPT
 jxa
 bph
-bxx
+caw
 bTR
 cbB
 cfD
@@ -85984,13 +85561,13 @@ cnp
 cOv
 cut
 csn
-mIb
+cjW
 csn
 pAS
 pAS
 bVv
-rwY
-qXe
+bVv
+cAI
 cvV
 aak
 aaa
@@ -86208,8 +85785,8 @@ btm
 btm
 btm
 aGu
-pAS
-pAS
+cvV
+cvV
 rwY
 bVv
 rwY
@@ -86223,7 +85800,7 @@ wTg
 bPT
 vKB
 brT
-bxx
+caw
 bcj
 cbB
 cbB
@@ -86466,7 +86043,7 @@ btm
 btm
 jUy
 aGP
-pAS
+cvV
 rwY
 bVv
 rwY
@@ -86479,8 +86056,8 @@ bEA
 aPD
 bPT
 ccE
-bxx
-bxx
+caw
+caw
 ccW
 cfX
 cfX
@@ -86723,30 +86300,30 @@ btm
 btm
 jUy
 aGP
-pAS
+cvV
 rwY
 bVv
 rwY
 qXe
-pAS
+cvV
 ayB
 aBq
 aLi
-xuU
+bOf
 wTg
 bPT
 bEY
 aXk
-bxx
+caw
 ccX
 met
 ccX
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
+cvV
+cvV
+cvV
+cvV
+cvV
+cvV
 pAS
 coQ
 iwI
@@ -86980,12 +86557,12 @@ btm
 btm
 jUy
 aGP
-pAS
+cvV
 rwY
 bVv
 rwY
 bXF
-pAS
+cvV
 ozo
 azv
 wJV
@@ -86994,11 +86571,11 @@ llS
 bPT
 bEY
 aXk
-bxx
+caw
 bYu
 ces
 che
-pAS
+cvV
 blv
 blK
 bqy
@@ -87151,7 +86728,7 @@ aaa
 aaa
 aaa
 cXk
-apP
+aaa
 aKh
 aaa
 aaa
@@ -87237,25 +86814,25 @@ btm
 btm
 bwD
 bxD
-pAS
+cvV
 rwY
 bVv
 rwY
 aGk
-pAS
+cvV
 aAr
 azv
 wJV
-xuU
+bOf
 hJe
 jYD
 ihC
 aXk
-bxx
+caw
 bGP
 bXu
 bKd
-pAS
+cvV
 cay
 cbK
 cit
@@ -87266,7 +86843,7 @@ cpK
 cmI
 bpW
 cmM
-bqY
+lip
 eUZ
 jXs
 crd
@@ -87408,7 +86985,7 @@ aaa
 aaa
 aaa
 cXk
-apQ
+aaa
 aKh
 aaa
 aaa
@@ -87494,18 +87071,18 @@ btm
 bvu
 btm
 bzr
-pAS
+cvV
 rwY
 bVv
 rwY
 aqY
-pAS
+cvV
 aAM
 jCM
 wJV
-xuU
-xuU
-xuU
+bOf
+bOf
+bOf
 xuU
 xuU
 ccJ
@@ -87665,7 +87242,7 @@ aaa
 aaa
 aaa
 cXk
-alS
+aaa
 aKh
 aaa
 aaa
@@ -87751,13 +87328,13 @@ btm
 btm
 btm
 bzy
-pAS
+cvV
 rwY
 bVv
-pAS
-pAS
-pAS
-pAS
+cvV
+cvV
+cvV
+cvV
 aBx
 yaZ
 fUG
@@ -87922,7 +87499,7 @@ aaa
 aaa
 aaa
 cXk
-anE
+aaa
 aKh
 aaa
 aaa
@@ -88008,13 +87585,13 @@ btm
 bvI
 btm
 bzH
-pAS
+cvV
 ckb
 bVv
 whV
 bVv
 rwY
-pAS
+cvV
 aBP
 nTn
 beM
@@ -88179,7 +87756,7 @@ aaa
 aaa
 aaa
 cXk
-apT
+aaa
 aKh
 aaa
 aaa
@@ -88264,14 +87841,14 @@ btF
 btF
 btF
 btF
-bmm
-pAS
-pAS
-pAS
-pAS
+aIn
+cvV
+cvV
+cvV
+cvV
 bVv
 rwY
-pAS
+cvV
 aCb
 nTn
 aOp
@@ -88436,7 +88013,7 @@ aaa
 aaa
 aaa
 cXk
-cxi
+aaa
 aKh
 aaa
 aaa
@@ -88525,10 +88102,10 @@ bGC
 bzB
 bBh
 bCN
-pAS
+cvV
 bVv
 rwY
-pAS
+cvV
 aFo
 nTn
 aOV
@@ -88693,7 +88270,7 @@ aaa
 aaa
 aaa
 cXk
-aqc
+aaa
 aKh
 aaa
 aaa
@@ -88782,10 +88359,10 @@ bst
 bst
 bst
 bCO
-pAS
+cvV
 bVv
 rwY
-pAS
+cvV
 aGw
 nTn
 azv
@@ -89039,10 +88616,10 @@ bst
 bst
 bst
 bst
-pAS
+cvV
 bVv
 rwY
-pAS
+cvV
 aIN
 gpP
 bnc
@@ -89296,14 +88873,14 @@ bst
 bst
 bBi
 ahu
-pAS
+cvV
 bVv
 rwY
-pAS
-pAS
+cvV
+cvV
 aMH
-pAS
-pAS
+cvV
+cvV
 pAS
 pAS
 pAS
@@ -89582,7 +89159,7 @@ css
 cPT
 bEm
 bQF
-bQF
+cmr
 bEo
 gwq
 bEo
@@ -89810,7 +89387,7 @@ bst
 bst
 bst
 bCP
-pAS
+cvV
 bVv
 bVv
 bVv
@@ -90067,15 +89644,15 @@ bst
 btH
 bst
 btH
-pAS
-aus
+cvV
+cvV
+ctm
+aJG
 ctm
 pAS
 pAS
 pAS
 pAS
-pAS
-pAS
 rwY
 pAS
 rwY
@@ -90084,7 +89661,7 @@ rwY
 rwY
 rwY
 rwY
-rwY
+pAS
 pAS
 aaa
 aaa
@@ -90324,25 +89901,25 @@ cVT
 boU
 bss
 boU
-pAS
+cvV
+aaa
+ctm
 rwY
 ctm
 aaa
 aaa
 aaa
+pAS
+pAS
+pAS
+pAS
+pAS
+pAS
+pAS
+pAS
+pAS
+pAS
 aaa
-aaa
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
 aaa
 aaa
 aaa
@@ -90581,11 +90158,11 @@ bVQ
 boU
 bHT
 boU
-pAS
-rwY
+aaa
+aaa
 ctm
-aaa
-aaa
+bal
+ctm
 aaa
 aaa
 aaa
@@ -90838,9 +90415,9 @@ bst
 boU
 bst
 boU
-pAS
-auv
-ctm
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
Moves disco room to the top floor
Moves abandoned bridge more to the right
Adds roofs to the whole station so it doesn't depressurize roundstart
Reworks arrivals entirely, with the arrivals shuttle being inside the station
Moves northwest solars
Makes aux base smaller, with it being viewable from arrivals
Fixes all elevator IDs so they work

Moves AI sat up
reworks brig (again)
Fixes AI sat access
Increases the size of Virology
Moves HoS office around

A ton more things big and small that I didn't keep track of.

I left some circuit floors on the bottom Z level (where transit pod was) to know that there's a roof over those tiles, I was hoping I can maybe move some of the turbine there, but gave up.