### PR TITLE
Engineering improvements

### DIFF
--- a/HelioStation2_upper.dmm
+++ b/HelioStation2_upper.dmm
@@ -982,8 +982,7 @@
 /turf/open/floor/plating,
 /area/engineering/atmos/upper)
 "aCS" = (
-/obj/item/toy/plush/ratplush,
-/obj/structure/closet/crate/engineering,
+/obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "aCW" = (
@@ -1705,23 +1704,9 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "bcY" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/maintenance/department/chapel)
 "bdb" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -2597,6 +2582,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"bFu" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "bFG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -2758,6 +2748,9 @@
 "bMJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "bOj" = (
@@ -3041,7 +3034,7 @@
 /turf/open/floor/iron/white,
 /area/maintenance/department/science/xenobiology)
 "bWb" = (
-/obj/structure/reagent_dispensers/virusfood/directional/south,
+/obj/structure/reagent_dispensers/wall/virusfood/directional/south,
 /obj/machinery/computer/pandemic,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
@@ -3063,6 +3056,9 @@
 	},
 /obj/effect/turf_decal/stripes/end,
 /obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/transit_tube)
 "bWR" = (
@@ -3346,10 +3342,8 @@
 /turf/open/floor/iron/white,
 /area/science/breakroom)
 "cjd" = (
-/obj/machinery/power/emitter,
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/turf/open/floor/carpet,
+/area/maintenance/department/chapel)
 "cjj" = (
 /obj/structure/chair/office/light{
 	color = "#990099";
@@ -3978,8 +3972,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cDS" = (
-/obj/structure/closet/crate/solarpanel_small,
-/turf/open/floor/iron,
+/turf/open/openspace,
 /area/engineering/storage_shared)
 "cDZ" = (
 /obj/structure/chair/sofa/right{
@@ -5982,10 +5975,8 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "dQR" = (
-/obj/machinery/field/generator,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
+/obj/machinery/power/emitter,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "dQY" = (
@@ -6084,6 +6075,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/security/office)
 "dUL" = (
@@ -6116,7 +6108,7 @@
 /turf/open/openspace,
 /area/cargo/office)
 "dVR" = (
-/obj/structure/reagent_dispensers/peppertank/directional/east,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -6133,10 +6125,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
-"dXr" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+"dXu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "dXC" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer's Office";
@@ -8104,10 +8098,8 @@
 /turf/open/floor/carpet/green,
 /area/service/library/upper)
 "fjG" = (
-/obj/machinery/newscaster/directional/west,
 /obj/structure/table,
 /obj/item/screwdriver,
-/obj/item/radio/off,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 4;
@@ -8335,6 +8327,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"foR" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "fpE" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -8951,6 +8950,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"fFX" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "fGa" = (
 /obj/structure/closet,
 /obj/item/clothing/under/costume_2021/cp2077_rockerboy,
@@ -9127,14 +9132,9 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "fMl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "celock";
-	name = "CE Office Lockdown Door"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/command/heads_quarters/ce)
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/grass/jungle,
+/area/medical/virology)
 "fMq" = (
 /obj/structure/railing,
 /obj/structure/chair/stool/bar/directional/west,
@@ -9232,6 +9232,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison/safe)
+"fNT" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "fNV" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -9887,6 +9893,16 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"giV" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "gjc" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -10145,6 +10161,7 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "gsO" = (
@@ -10477,6 +10494,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "gLk" = (
@@ -10543,13 +10564,9 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "gMA" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
+/obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
 "gMD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance";
@@ -10633,10 +10650,6 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel)
 "gPE" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
@@ -11037,12 +11050,12 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/space)
 "hgj" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/camera/directional/north{
 	c_tag = "Secure Power Storage";
 	name = "Engineering Camera";
 	network = list("ss13","engineering")
 	},
+/obj/machinery/field/generator,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "hhb" = (
@@ -11334,7 +11347,6 @@
 /turf/closed/wall,
 /area/service/lawoffice/upper)
 "hqa" = (
-/obj/structure/table/wood,
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/command/bridge";
@@ -11342,7 +11354,7 @@
 	name = "Bridge APC";
 	pixel_x = -24
 	},
-/obj/item/restraints/legcuffs,
+/obj/machinery/recharge_station,
 /turf/open/floor/vault,
 /area/command/bridge)
 "hqd" = (
@@ -11387,6 +11399,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "hqI" = (
+/turf/open/floor/engine,
+/area/engineering/main)
+"hqK" = (
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/engine,
 /area/engineering/main)
 "hqO" = (
@@ -11711,7 +11727,8 @@
 /area/cargo/qm)
 "hCh" = (
 /obj/item/clothing/glasses/eyepatch,
-/turf/open/floor/eighties/red,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
 /area/maintenance/department/chapel)
 "hCQ" = (
 /obj/structure/chair/office{
@@ -12192,7 +12209,7 @@
 /area/command/heads_quarters/captain)
 "hWV" = (
 /obj/machinery/computer/pandemic,
-/obj/structure/reagent_dispensers/virusfood/directional/west,
+/obj/structure/reagent_dispensers/wall/virusfood/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/virology)
 "hWX" = (
@@ -12747,7 +12764,7 @@
 "ilA" = (
 /obj/structure/curtain/cloth/fancy,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/eighties/red,
+/turf/open/floor/carpet,
 /area/maintenance/department/chapel)
 "ilF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
@@ -12783,6 +12800,10 @@
 /obj/machinery/computer/cargo,
 /turf/open/floor/wood,
 /area/cargo/qm)
+"ioH" = (
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "ioN" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -13055,7 +13076,7 @@
 /turf/open/floor/engine,
 /area/maintenance/department/science/xenobiology)
 "iBW" = (
-/obj/machinery/suit_storage_unit/ce,
+/obj/machinery/disposal/bin,
 /turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/ce)
 "iCi" = (
@@ -13442,7 +13463,7 @@
 /area/maintenance/department/medical)
 "iPo" = (
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
 /turf/open/space/basic,
@@ -13963,14 +13984,18 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "jfU" = (
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office";
+	req_access_txt = "56"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jfZ" = (
@@ -14098,6 +14123,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
+"jjM" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "jke" = (
 /obj/machinery/flasher/directional/south{
 	id = "Cell 2"
@@ -14431,11 +14462,13 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "juv" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "juK" = (
 /obj/effect/turf_decal/sand/plating,
@@ -15264,6 +15297,12 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"jUi" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "jUs" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -15410,6 +15449,13 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/plating/grass/jungle,
 /area/medical/virology)
+"jXI" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "jXK" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium,
@@ -15660,9 +15706,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos/upper)
 "kdM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "kfu" = (
@@ -16088,14 +16132,13 @@
 /turf/open/floor/wood,
 /area/service/library/upper)
 "ktA" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/turf/open/floor/iron,
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
 /area/engineering/lobby)
 "ktI" = (
 /obj/machinery/vending/coffee,
@@ -16284,8 +16327,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 30
 	},
-/obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/light/directional/east,
 /turf/open/floor/engine,
 /area/engineering/main)
 "kBw" = (
@@ -17239,6 +17281,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
+"ljO" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "ljR" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -17261,10 +17307,7 @@
 /turf/open/openspace,
 /area/hallway/primary/upper)
 "lkB" = (
-/obj/machinery/door/poddoor{
-	id = "engstorage";
-	name = "Engineering Secure Storage Lockdown"
-	},
+/obj/machinery/field/generator,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "lkD" = (
@@ -17441,7 +17484,10 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "lrv" = (
-/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/field/generator,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "lry" = (
@@ -17944,7 +17990,6 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
 "lIn" = (
-/obj/effect/landmark/secequipment,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17956,6 +18001,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/l3closet/security,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "lIo" = (
@@ -18234,6 +18280,10 @@
 /obj/structure/rack,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"lRX" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "lRZ" = (
 /obj/structure/sign/warning/firingrange{
 	pixel_x = -30
@@ -18531,6 +18581,9 @@
 /obj/structure/cable/multilayer/multiz,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/transit_tube)
@@ -18926,8 +18979,12 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "mpt" = (
-/turf/open/space/basic,
-/area/engineering/atmos/upper)
+/obj/machinery/door/poddoor{
+	id = "engstorage";
+	name = "Engineering Secure Storage Lockdown"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "mpx" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/tile/yellow{
@@ -19221,7 +19278,7 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "mBz" = (
-/obj/machinery/field/generator,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "mBC" = (
@@ -19256,6 +19313,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/openspace,
 /area/hallway/primary/upper)
+"mCQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "mDe" = (
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -20502,6 +20565,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"nmW" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "noY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -21003,6 +21073,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"nDq" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "nDx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green{
@@ -21102,6 +21178,15 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat/hallway)
+"nIk" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room";
+	req_access_txt = "19;23"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plating/airless,
+/area/engineering/gravity_generator)
 "nIo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -21236,8 +21321,11 @@
 	dir = 4;
 	name = "Security red corner"
 	},
+/obj/machinery/newscaster/directional/west,
+/obj/structure/table,
+/obj/item/radio/off,
 /turf/open/floor/iron,
-/area/maintenance/department/cargo)
+/area/security/checkpoint/supply)
 "nNh" = (
 /obj/structure/cable,
 /obj/structure/railing{
@@ -22220,6 +22308,11 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos/upper)
+"ozR" = (
+/obj/structure/filingcabinet/chestdrawer,
+/mob/living/simple_animal/parrot/poly,
+/turf/open/floor/iron/dark,
+/area/command/heads_quarters/ce)
 "oAm" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/prisoner,
@@ -23326,8 +23419,8 @@
 /turf/open/floor/vault,
 /area/command/bridge)
 "pjH" = (
-/turf/open/openspace,
-/area/engineering/storage_shared)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "pjJ" = (
 /obj/structure/cable,
 /obj/structure/reflector/double/anchored{
@@ -23464,7 +23557,6 @@
 /turf/open/floor/iron/white,
 /area/medical/psychology)
 "ppT" = (
-/obj/structure/closet/l3closet/security,
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23476,6 +23568,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/landmark/secequipment,
 /turf/open/floor/iron/showroomfloor,
 /area/security/office)
 "pqv" = (
@@ -23919,7 +24012,7 @@
 /area/service/library/private)
 "pHA" = (
 /obj/structure/railing/corner,
-/obj/structure/reagent_dispensers/peppertank/directional/east,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 4;
@@ -24160,9 +24253,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "pPy" = (
-/obj/machinery/power/energy_accumulator/tesla_coil,
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/turf/open/openspace,
+/area/engineering/gravity_generator)
 "pPF" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron,
@@ -26025,6 +26117,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"rcz" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "rcW" = (
 /obj/structure/table/wood,
 /obj/item/toy/mecha/ripley,
@@ -26654,18 +26750,11 @@
 /turf/open/floor/wood,
 /area/cargo/qm)
 "rup" = (
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 4;
-	name = "dark corner"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
 "rvv" = (
 /obj/machinery/computer/security/qm,
 /obj/machinery/status_display/supply{
@@ -27305,16 +27394,13 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/upper)
 "rQZ" = (
-/obj/structure/filingcabinet/chestdrawer,
-/mob/living/simple_animal/parrot/poly,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "rRv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27938,13 +28024,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "sjD" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "celock";
-	name = "CE Office Lockdown Door"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/glass/reinforced,
 /area/command/heads_quarters/ce)
 "sjW" = (
 /obj/structure/chair{
@@ -28120,7 +28201,7 @@
 /area/maintenance/solars)
 "ssy" = (
 /obj/machinery/rnd/production/techfab/department/security,
-/obj/structure/reagent_dispensers/peppertank/directional/south,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/south,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -29096,8 +29177,13 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/science/xenobiology)
 "teO" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "celock";
+	name = "CE Office Lockdown Door"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
 /area/engineering/lobby)
 "teT" = (
 /obj/machinery/door/window/westleft{
@@ -29433,6 +29519,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"trj" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "tru" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
@@ -30237,6 +30328,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"tSh" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "tSw" = (
 /obj/structure/training_machine,
 /obj/item/target/syndicate,
@@ -31613,20 +31710,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/upper)
 "uDO" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office";
-	req_access_txt = "56"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
 	dir = 1;
-	name = "Engineering yellow corner"
+	name = "dark corner"
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/dark,
-/area/command/heads_quarters/ce)
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 4;
+	name = "dark corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "uDS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
@@ -32392,6 +32487,13 @@
 "vfb" = (
 /turf/open/floor/iron/dark,
 /area/science/server)
+"vfm" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/transit_tube)
 "vfL" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/engine,
@@ -32404,7 +32506,6 @@
 /turf/open/floor/plating/airless,
 /area/maintenance/department/security/upper)
 "vgp" = (
-/obj/machinery/disposal/bin,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -32413,6 +32514,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "vgZ" = (
@@ -33809,6 +33911,12 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/lobby)
+"waY" = (
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "wbh" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/vending/games,
@@ -34415,9 +34523,9 @@
 /turf/open/floor/plating,
 /area/command/bridge)
 "wxE" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle,
-/area/medical/virology)
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "wxJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34799,7 +34907,7 @@
 /area/engineering/atmos/upper)
 "wLC" = (
 /obj/structure/filingcabinet,
-/obj/structure/reagent_dispensers/peppertank/directional/north,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 4;
@@ -35829,6 +35937,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xzD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "xzR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Virology Access";
@@ -36455,22 +36570,8 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "xWt" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
 "xWE" = (
 /obj/structure/table,
 /obj/item/stack/wrapping_paper,
@@ -36521,13 +36622,17 @@
 /turf/open/openspace,
 /area/hallway/primary/starboard)
 "xYR" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
+/obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
+"xYV" = (
+/obj/machinery/camera/directional/east{
+	c_tag = "Gravity Generator";
+	name = "Gravity Camera";
+	network = list("ss13","engineer")
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "xZe" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -56472,8 +56577,8 @@ unr
 unr
 unr
 unr
+unr
 rVz
-qoL
 qoL
 xCi
 qoL
@@ -56723,13 +56828,13 @@ xCi
 xCi
 unr
 aCS
-pPy
-pPy
+fzu
+vli
 cAi
-pjH
-pjH
+vli
+vli
+xYR
 unr
-xCi
 xCi
 qoL
 xCi
@@ -56980,13 +57085,13 @@ xCi
 xCi
 unr
 qAQ
-pPy
 fzu
-cAi
-pjH
-pjH
+vli
+mpt
+vli
+vli
+vli
 unr
-xCi
 xCi
 qoL
 xCi
@@ -57181,11 +57286,11 @@ pGV
 pGV
 fyK
 fyK
-kys
+bcY
 hCh
-kys
-kys
-kys
+bcY
+cjd
+cjd
 fyK
 fyK
 pGV
@@ -57236,14 +57341,14 @@ qoL
 qoL
 qoL
 unr
+aCS
 fzu
-fzu
-fzu
-cAi
+vli
+mpt
 kdM
-kdM
+rup
+rup
 unr
-xCi
 xCi
 qoL
 rVz
@@ -57437,13 +57542,13 @@ pGV
 pGV
 pGV
 fyK
-kys
-kys
-kys
-kys
-kys
-kys
-kys
+bcY
+cjd
+bcY
+bcY
+bcY
+bcY
+bcY
 fyK
 pGV
 pGV
@@ -57494,13 +57599,13 @@ xCi
 bDh
 unr
 hgj
+gMA
 vli
-vli
-lkB
-vli
-vli
+cAi
+mBz
+cDS
+cDS
 unr
-xCi
 xCi
 qoL
 xCi
@@ -57751,14 +57856,14 @@ xCi
 ooE
 unr
 lrv
-vli
-vli
 lkB
 vli
+cAi
+mBz
+cDS
 cDS
 unr
 xCi
-qoL
 qoL
 xCi
 qoL
@@ -57776,7 +57881,7 @@ vof
 aqF
 qAl
 hqI
-hqI
+hqK
 kBk
 aKH
 oNm
@@ -58008,14 +58113,14 @@ rMI
 xCi
 unr
 dQR
+jTR
+vli
+cAi
 mBz
-mBz
-unr
-bzr
-unr
+cDS
+cDS
 unr
 xCi
-qoL
 xCi
 xCi
 qoL
@@ -58264,15 +58369,15 @@ xCi
 xCi
 nrs
 unr
-cjd
 jTR
-mBz
+jTR
+vli
 unr
 xCi
+unr
+unr
+unr
 xCi
-xCi
-xCi
-qoL
 xCi
 xCi
 qoL
@@ -58521,20 +58626,20 @@ xCi
 cTl
 xCi
 unr
-jTR
-jTR
-jTR
+unr
+unr
+unr
 unr
 xCi
 xCi
-qoL
-xCi
-qoL
 xCi
 xCi
-qoL
+unr
+unr
+unr
+unr
 oBN
-mDe
+vOO
 dvJ
 mkP
 pGV
@@ -58552,7 +58657,7 @@ pGV
 pGV
 pGV
 pGV
-mpt
+pGV
 oBy
 gPn
 aBs
@@ -58778,20 +58883,20 @@ xCi
 xCi
 sXK
 unr
+xCi
+xCi
+xCi
+xCi
+xCi
+xCi
+xCi
 unr
 unr
-unr
-unr
-xCi
-xCi
-qoL
-xCi
-qoL
-xCi
-xCi
-qoL
-oBN
-mDe
+pjH
+pjH
+xWt
+xWt
+vOO
 dvJ
 mkP
 kDk
@@ -59038,17 +59143,17 @@ qoL
 xCi
 xCi
 xCi
-xCi
-xCi
-xCi
-qoL
-xCi
-qoL
-xCi
-xCi
-qoL
-oBN
-mDe
+unr
+unr
+unr
+unr
+unr
+bFu
+ljO
+xzD
+jXI
+xWt
+vOO
 dSv
 syf
 kDk
@@ -59295,17 +59400,17 @@ xCi
 xCi
 xCi
 xCi
-xCi
-xCi
-xCi
-qoL
-xCi
-qoL
-xCi
-xCi
-qoL
-oBN
-mDe
+unr
+pjH
+pjH
+lRX
+dXu
+pjH
+pjH
+pjH
+nmW
+xWt
+vOO
 mDe
 iUx
 kDk
@@ -59551,18 +59656,18 @@ xCi
 xCi
 xCi
 xCi
-qoL
-qoL
-qoL
-qoL
-qoL
-rVz
-qoL
-qoL
-qoL
-qoL
-oBN
-mDe
+xCi
+unr
+pjH
+pjH
+pjH
+pjH
+jUi
+jjM
+nDq
+ljO
+xWt
+vOO
 mDe
 sKc
 kDk
@@ -59808,18 +59913,18 @@ xCi
 xCi
 xCi
 xCi
-qoL
 xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-jWK
-wXb
-mDe
+unr
+pjH
+pjH
+pjH
+pjH
+fFX
+ioH
+trj
+ljO
+nIk
+vOO
 mDe
 iUx
 kDk
@@ -60065,17 +60170,17 @@ xCi
 xCi
 xCi
 xCi
-qoL
 xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-qoL
-oBN
+unr
+pPy
+pPy
+pPy
+pjH
+tSh
+fNT
+waY
+pjH
+xWt
 mDe
 mDe
 iUx
@@ -60322,19 +60427,19 @@ xCi
 xCi
 xCi
 xCi
-qoL
 xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-xCi
-qoL
+unr
+pPy
+pPy
+pPy
+pjH
+pjH
+xYV
+pjH
+pjH
 xWt
 gPE
-gMA
+mDe
 iUx
 kDk
 vcf
@@ -60578,20 +60683,20 @@ xCi
 xCi
 xCi
 xCi
-xCi
 qoL
-xCi
+rVz
 unr
 unr
-unr
-unr
-unr
-unr
-unr
-unr
-mfm
+xWt
+xWt
+xWt
+xWt
+xWt
+xWt
+xWt
 mfm
 wrF
+mDe
 kwr
 kDk
 vsi
@@ -60836,8 +60941,8 @@ qoL
 qoL
 qoL
 qoL
-qoL
-rVz
+xCi
+xCi
 unr
 pPY
 atO
@@ -60847,8 +60952,8 @@ dpK
 meW
 vgp
 rQZ
-fMl
 wrF
+mDe
 iUx
 kDk
 vsi
@@ -61104,8 +61209,8 @@ ugY
 yfT
 gLa
 juv
-sjD
 wrF
+mDe
 iUx
 kDk
 luy
@@ -61362,7 +61467,7 @@ yfT
 bMJ
 jfU
 uDO
-rup
+mDe
 iUx
 kDk
 eoy
@@ -61618,8 +61723,8 @@ yfT
 lDq
 hed
 wbV
-wbV
 wrF
+mDe
 iUx
 tdY
 wBe
@@ -61873,10 +61978,10 @@ ugY
 oBz
 nUX
 yjh
-lcP
+ozR
 wbV
-bcY
-xYR
+wrF
+mDe
 iUx
 kDk
 wCR
@@ -62124,14 +62229,14 @@ xCi
 xCi
 xCi
 unr
-lcP
-lcP
-lcP
+sjD
+ugY
+lzl
 dXC
 lcP
 lzl
 lcP
-mkP
+teO
 wrF
 mDe
 iUx
@@ -62382,7 +62487,7 @@ qoL
 qoL
 qoL
 teO
-dXr
+teO
 ktA
 mDe
 mDe
@@ -62638,14 +62743,14 @@ qoL
 mkP
 ott
 rfU
-mDe
-mDe
-mDe
+wxE
+rcz
+giV
 mDe
 rWu
 fPt
 nvH
-rHu
+mkP
 wrF
 mDe
 iUx
@@ -69849,7 +69954,7 @@ oXh
 spU
 ybm
 ybm
-jYc
+mCQ
 jYc
 jYc
 xGn
@@ -70106,7 +70211,7 @@ kFt
 spU
 ybm
 ybm
-jYc
+mCQ
 jYc
 jYc
 xGn
@@ -70363,7 +70468,7 @@ vzA
 spU
 ybm
 ybm
-jYc
+mCQ
 jYc
 oZk
 njQ
@@ -70620,7 +70725,7 @@ uaV
 spU
 ybm
 ybm
-oZk
+vfm
 oZk
 oZk
 xGn
@@ -70877,7 +70982,7 @@ fVF
 diF
 mcw
 bWs
-oZk
+foR
 jYc
 oZk
 xGn
@@ -87001,7 +87106,7 @@ pGV
 xuk
 xuk
 xaE
-wxE
+xaE
 xuk
 lMG
 saw
@@ -87257,7 +87362,7 @@ pGV
 pGV
 pGV
 xuk
-xaE
+fMl
 xaE
 rrS
 msR

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -2037,10 +2037,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/brig)
-"ajV" = (
-/obj/machinery/telecomms/server/presets/supply,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "aka" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/red{
@@ -2295,6 +2291,17 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ame" = (
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Security Engineering monitor";
+	network = list("engineering","atmos");
+	pixel_y = -30
+	},
+/obj/structure/chair/office,
+/turf/open/floor/iron/dark,
+/area/security/checkpoint/engineering)
 "ami" = (
 /obj/structure/cable,
 /obj/machinery/door/window/brigdoor/security/cell{
@@ -2581,6 +2588,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/warden)
+"anO" = (
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
+"anY" = (
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "aoa" = (
 /obj/machinery/camera/motion/directional/east{
 	c_tag = "Outer Armory N";
@@ -3546,10 +3560,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"ati" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "atj" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "briglockdown";
@@ -6631,12 +6641,6 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/commons/fitness)
-"aOl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "aOo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -7866,18 +7870,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
-"aUs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/requests_console/directional/west{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC"
-	},
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "aUt" = (
 /obj/structure/sign/poster/official/science{
 	pixel_y = -30
@@ -8133,6 +8125,10 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"aVM" = (
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "aVP" = (
 /obj/effect/landmark/start/depsec/medical,
 /obj/structure/cable,
@@ -8442,11 +8438,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
-"aYf" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "aYi" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -10553,15 +10544,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"blj" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/status_display/ai/directional/east,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "blk" = (
 /obj/structure/chair{
 	dir = 8;
@@ -17639,12 +17621,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"bUp" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "bUr" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -17879,10 +17855,6 @@
 "bVN" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"bVQ" = (
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "bVR" = (
 /obj/structure/railing{
 	dir = 8
@@ -18010,6 +17982,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"bXd" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "bXe" = (
 /obj/structure/rack,
 /obj/item/multitool/circuit{
@@ -18384,16 +18360,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science)
+"bZQ" = (
+/obj/machinery/space_heater,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"bZR" = (
+/obj/machinery/door/airlock{
+	id_tag = "commissarydoor";
+	name = "Commissary"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bZU" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "bZY" = (
-/obj/machinery/space_heater,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/space/basic,
+/area/maintenance/starboard/aft)
 "cad" = (
 /obj/structure/window{
 	dir = 8
@@ -18409,13 +18399,18 @@
 /obj/effect/spawner/random/techstorage/engineering_all,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"caf" = (
+/turf/closed/wall,
+/area/commons/vacant_room/commissary)
 "cag" = (
-/obj/machinery/door/airlock{
-	id_tag = "commissarydoor";
-	name = "Commissary"
+/obj/machinery/button/door/directional/north{
+	id = "commissaryshutter";
+	name = "Commisary Shutter Control"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cai" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -18443,12 +18438,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cau" = (
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
-/turf/open/space/basic,
-/area/maintenance/starboard/aft)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "caw" = (
 /turf/closed/wall,
 /area/science)
@@ -18503,15 +18495,17 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "caJ" = (
-/turf/closed/wall,
+/obj/machinery/power/apc{
+	areastring = "/area/commons/vacant_room/commissary";
+	dir = 1;
+	name = "Vacant Commissary APC";
+	pixel_y = 25
+	},
+/turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "caK" = (
-/obj/machinery/button/door/directional/north{
-	id = "commissaryshutter";
-	name = "Commisary Shutter Control"
-	},
+/obj/machinery/newscaster/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "caO" = (
@@ -18664,7 +18658,11 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cce" = (
-/obj/machinery/airalarm/directional/north,
+/obj/structure/rack,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/circuitboard/machine/vendor,
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "ccl" = (
@@ -18900,12 +18898,8 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "cdl" = (
-/obj/machinery/power/apc{
-	areastring = "/area/commons/vacant_room/commissary";
-	dir = 1;
-	name = "Vacant Commissary APC";
-	pixel_y = 25
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "cdm" = (
@@ -18928,8 +18922,7 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cdo" = (
-/obj/machinery/newscaster/directional/north,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "cdp" = (
@@ -18965,10 +18958,11 @@
 /area/engineering/storage_shared)
 "cdu" = (
 /obj/structure/rack,
-/obj/item/circuitboard/machine/vendor,
-/obj/item/circuitboard/machine/vendor,
-/obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/east,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
 "cdA" = (
@@ -19005,10 +18999,12 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cdF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cdM" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -19200,9 +19196,14 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "ceY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/circuitboard/computer/arcade,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cfc" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Gravity Generator Room";
@@ -19217,14 +19218,12 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "cfg" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/cable_coil,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/structure/frame/machine,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cfh" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow{
@@ -19346,21 +19345,17 @@
 /turf/open/floor/plating,
 /area/construction)
 "cgl" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cgm" = (
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/circuitboard/computer/arcade,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cgp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -19401,12 +19396,16 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cgs" = (
-/obj/structure/frame/machine,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/machinery/camera/directional/east{
+	c_tag = "Commissary";
+	name = "Commissary camera";
+	network = list("ss13","cargo")
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cgt" = (
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
@@ -19581,11 +19580,11 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "chx" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/chair/stool/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "chz" = (
 /obj/structure/sink{
 	dir = 8;
@@ -19617,22 +19616,15 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "chB" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/structure/frame/machine,
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "chC" = (
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/machinery/camera/directional/east{
-	c_tag = "Commissary";
-	name = "Commissary camera";
-	network = list("ss13","cargo")
-	},
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "chD" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -19877,11 +19869,8 @@
 /turf/open/floor/iron/white,
 /area/science)
 "ciJ" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/engineering/gravity_generator)
 "ciK" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
@@ -19953,15 +19942,17 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cje" = (
-/obj/structure/frame/machine,
-/obj/item/stack/sheet/iron/five,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cjf" = (
-/obj/structure/frame/machine,
+/obj/item/radio/intercom/directional/south,
+/obj/structure/table,
+/obj/item/circuitboard/machine/paystand,
 /obj/item/stack/cable_coil/five,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cji" = (
 /obj/structure/rack,
 /obj/item/stock_parts/cell/high/plus,
@@ -20094,8 +20085,11 @@
 /turf/open/floor/plating,
 /area/construction)
 "cjB" = (
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/obj/item/storage/secure/safe/directional/south,
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/random/bureaucracy/briefcase,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cjC" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Gravity Generator Lower";
@@ -20152,9 +20146,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cjX" = (
-/obj/effect/spawner/random/structure/crate,
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/crowbar,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/starboard/aft)
 "cjY" = (
 /obj/item/stack/sheet/cardboard,
 /obj/structure/rack,
@@ -20269,13 +20265,11 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ckx" = (
-/obj/item/radio/intercom/directional/south,
 /obj/structure/table,
-/obj/item/circuitboard/machine/paystand,
-/obj/item/stack/cable_coil/five,
-/obj/item/stack/sheet/iron/five,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cky" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -20539,11 +20533,11 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "clu" = (
-/obj/item/storage/secure/safe/directional/south,
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/spawner/random/bureaucracy/briefcase,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "clw" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -20605,15 +20599,14 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "clG" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/crowbar,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "clI" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/chair{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "clV" = (
@@ -20704,9 +20697,9 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cml" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cmm" = (
@@ -20835,10 +20828,10 @@
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
 "cmQ" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/cable,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "cmU" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -20996,18 +20989,15 @@
 /turf/open/floor/iron/dark,
 /area/science/cytology)
 "cnN" = (
-/obj/structure/chair{
-	dir = 1
-	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cnO" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "cnP" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cnT" = (
@@ -21175,9 +21165,9 @@
 /area/science/xenobiology)
 "coG" = (
 /obj/structure/cable,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "coH" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -21272,9 +21262,9 @@
 /turf/open/floor/iron/dark,
 /area/science/cytology)
 "cpk" = (
-/obj/machinery/light/small/directional/north,
+/obj/structure/closet/crate,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/port/aft)
 "cpl" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -21390,7 +21380,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cqe" = (
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -21577,9 +21569,13 @@
 /area/hallway/primary/aft)
 "crE" = (
 /obj/structure/cable,
-/obj/effect/spawner/random/structure/crate,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "crF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -21761,9 +21757,12 @@
 /turf/closed/wall,
 /area/science/mixing)
 "csv" = (
-/obj/structure/closet/crate,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/starboard/aft)
 "csx" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/turf_decal/tile/blue{
@@ -21879,10 +21878,9 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "csV" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/storage/cans/sixbeer,
+/obj/effect/spawner/random/decoration/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "csW" = (
@@ -21927,14 +21925,12 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cta" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ctb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -22010,12 +22006,24 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "ctw" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "ctx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -22150,11 +22158,12 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cub" = (
-/obj/structure/table,
-/obj/item/storage/cans/sixbeer,
-/obj/effect/spawner/random/decoration/glowstick,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/camera/directional/west{
+	c_tag = "Aft Primary Hallway - Central";
+	name = "Hallway Camera"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "cud" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -22197,10 +22206,9 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "cuj" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
-/obj/structure/cable,
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cuk" = (
@@ -22221,17 +22229,12 @@
 "cuq" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
 	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
 	name = "Engineering yellow corner"
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -22293,12 +22296,9 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cuv" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Aft Primary Hallway - Central";
-	name = "Hallway Camera"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cuw" = (
 /obj/structure/table/optable,
 /turf/open/floor/iron/dark,
@@ -22353,9 +22353,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cuJ" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/costume,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cuK" = (
@@ -22378,17 +22377,15 @@
 "cuL" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 8;
+	dir = 4;
 	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
 "cuR" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
@@ -22427,9 +22424,24 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cve" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/stairs/north,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cvh" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -22462,10 +22474,23 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cvk" = (
-/obj/structure/closet/cardboard,
-/obj/effect/spawner/costume,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cvl" = (
 /obj/structure/cable,
 /obj/structure/chair/office,
@@ -22548,15 +22573,21 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cvz" = (
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 4;
+	dir = 8;
 	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
+	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cvC" = (
@@ -22613,24 +22644,16 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/structure/stairs/north,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cvV" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cvW" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
@@ -22639,38 +22662,30 @@
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cwh" = (
-/obj/item/clothing/gloves/color/yellow,
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cwi" = (
+/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cwk" = (
@@ -22710,13 +22725,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cwr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 4;
+	dir = 8;
 	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -22724,16 +22735,17 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/iron,
-/area/engineering/storage_shared)
+/area/engineering/lobby)
 "cws" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cwx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -22748,17 +22760,20 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "cwz" = (
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 4;
+	dir = 8;
 	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
+	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cwA" = (
@@ -23062,23 +23077,9 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "cxB" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
 "cxI" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/turf_decal/arrows/white{
@@ -23207,9 +23208,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cyA" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cyC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -23872,22 +23882,10 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cBG" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "cBJ" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -24078,7 +24076,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "cCs" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cCF" = (
@@ -24157,16 +24155,21 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cDN" = (
+/obj/structure/rack,
+/obj/item/stock_parts/cell/emproof,
+/obj/item/stock_parts/cell/emproof,
+/obj/item/stock_parts/cell/emproof,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 4;
+	dir = 8;
 	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cDO" = (
@@ -24189,10 +24192,25 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cDQ" = (
+/obj/structure/rack,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cDT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24272,13 +24290,24 @@
 /area/cargo/office)
 "cEQ" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cES" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/emproof,
-/obj/item/stock_parts/cell/emproof,
-/obj/item/stock_parts/cell/emproof,
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -24286,10 +24315,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
+	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/obj/structure/cable,
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cET" = (
@@ -24298,25 +24326,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cEV" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cFk" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -24445,6 +24457,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"cHv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
 "cHG" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -24791,11 +24810,6 @@
 "cMv" = (
 /turf/open/floor/engine/airless,
 /area/engineering/atmos)
-"cMD" = (
-/obj/structure/cable,
-/obj/machinery/power/terminal,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "cMH" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -25185,17 +25199,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cSM" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Storage";
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cSQ" = (
@@ -25208,23 +25225,11 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cSW" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cSX" = (
 /obj/structure/rack,
 /obj/item/storage/box/halloween/edition_21/pucci,
@@ -25269,10 +25274,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"cVJ" = (
-/obj/machinery/newscaster/directional/west,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "cVL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -25334,9 +25335,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cXb" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/vending/modularpc,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "cXf" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -25345,22 +25347,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cXn" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Storage";
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/cable,
+/obj/machinery/vending/engivend,
 /turf/open/floor/iron,
-/area/engineering/storage_shared)
+/area/engineering/lobby)
 "cXo" = (
 /obj/structure/sign/directions/command{
 	dir = 1;
@@ -25476,11 +25465,24 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cXC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 4;
+	name = "dark corner"
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "cXI" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
@@ -25545,6 +25547,10 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
+"cXX" = (
+/obj/machinery/telecomms/processor/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "cZG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -25632,6 +25638,10 @@
 /obj/item/reagent_containers/glass/beaker,
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"dkm" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "dng" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
@@ -25685,8 +25695,19 @@
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "dtb" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/machinery/vending/modularpc,
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "duA" = (
@@ -25717,6 +25738,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"dvc" = (
+/obj/machinery/telecomms/bus/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "dvt" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
@@ -25769,14 +25794,6 @@
 /obj/item/stock_parts/subspace/crystal,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"dyB" = (
-/obj/structure/closet/firecloset,
-/obj/item/radio/off,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "dzf" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/bluespace_vendor/directional/south,
@@ -25793,9 +25810,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dEZ" = (
-/obj/machinery/vending/engivend,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/geiger_counter,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "dFZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -25876,40 +25895,35 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dJT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 4;
-	name = "dark corner"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 8;
+	dir = 4;
 	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering Hall - CE Office";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "dKk" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 30
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "dKI" = (
 /turf/closed/indestructible{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
@@ -25939,17 +25953,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/lab)
-"dMU" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	req_one_access_txt = "10;24";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space)
 "dNd" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -25980,11 +25983,9 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "dQj" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/geiger_counter,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "dQJ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron/dark/textured_large,
@@ -26085,6 +26086,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"edo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "edW" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -26118,6 +26125,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
+"ela" = (
+/obj/machinery/ntnet_relay,
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "els" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -26147,15 +26159,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"epe" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "epN" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -26179,6 +26182,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"eru" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "esy" = (
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = 30
@@ -26219,6 +26227,19 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"evq" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "evw" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate,
@@ -26308,6 +26329,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"eNW" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/south{
+	c_tag = "Solar Control - Port Aft";
+	name = "Solars Camera";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
 "eQC" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -26321,6 +26352,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"eRd" = (
+/obj/machinery/telecomms/broadcaster/preset_left,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "eRf" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -26332,15 +26367,7 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering Hall - CE Office";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "eUZ" = (
@@ -26451,13 +26478,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "feF" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
+/obj/docking_port/stationary{
+	dwidth = 4;
+	height = 6;
+	id = "supply_home";
+	name = "Cargo Bay";
+	width = 12
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/space/basic,
+/area/space)
 "feI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -26489,14 +26518,20 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/brig)
-"fji" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+"fgQ" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/engineering/atmos)
 "fju" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "fjL" = (
 /obj/machinery/smartfridge/organ,
 /obj/machinery/camera/directional/north{
@@ -26536,6 +26571,10 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/starboard)
+"fny" = (
+/obj/machinery/telecomms/server/presets/engineering,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "foS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -26549,10 +26588,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"fpN" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "fqq" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -26599,19 +26634,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"fte" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fvM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -26720,6 +26742,15 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"fCn" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "fCL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26751,6 +26782,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"fEs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "fEA" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#990099";
@@ -26787,10 +26823,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"fIr" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "fIK" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -26932,20 +26964,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"gel" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room";
-	req_access_txt = "61"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/tcommsat/server)
 "ghO" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
@@ -26980,19 +26998,15 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
 "gkA" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
+/obj/machinery/door/poddoor{
+	id = "cargounload";
+	name = "supply dock unloading door"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
+/obj/machinery/conveyor{
+	id = "QMLoad"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/space)
 "gmY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -27086,27 +27100,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"grQ" = (
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "Security red corner"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
 "gsC" = (
 /turf/open/floor/iron,
 /area/commons/storage/tools)
@@ -27121,11 +27114,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
-"gup" = (
-/obj/machinery/blackbox_recorder,
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "guA" = (
 /obj/machinery/button/door/directional/north{
 	id = "solitary";
@@ -27165,14 +27153,11 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "gzx" = (
-/obj/docking_port/stationary{
-	dwidth = 4;
-	height = 6;
-	id = "supply_home";
-	name = "Cargo Bay";
-	width = 12
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/space)
 "gBc" = (
 /obj/effect/mob_spawn/corpse/human,
@@ -27192,6 +27177,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gFJ" = (
+/obj/machinery/telecomms/server/presets/command,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "gGa" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner,
@@ -27247,10 +27236,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"gOi" = (
-/obj/machinery/telecomms/hub/preset,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "gOU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/directional/north{
@@ -27387,8 +27372,15 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "heb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/door/poddoor{
+	id = "cargoload";
+	name = "supply dock loading door"
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad2"
+	},
+/turf/open/floor/iron,
 /area/space)
 "hek" = (
 /obj/structure/bodycontainer/morgue{
@@ -27402,6 +27394,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
+"hfg" = (
+/obj/machinery/telecomms/server/presets/common,
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "hhm" = (
 /obj/structure/rack,
 /obj/item/tape,
@@ -27492,10 +27489,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"htf" = (
-/obj/machinery/telecomms/receiver/preset_right,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "hug" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -27804,15 +27797,10 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "hXT" = (
-/obj/machinery/door/poddoor{
-	id = "cargounload";
-	name = "supply dock unloading door"
-	},
-/obj/machinery/conveyor{
-	id = "QMLoad"
-	},
-/turf/open/floor/iron,
-/area/space)
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/maintenance/solars/port/aft)
 "hYF" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -27831,15 +27819,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/construction)
-"ibO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "ich" = (
 /obj/structure/window{
 	dir = 1
@@ -27896,14 +27875,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
-"iiV" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Internal Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "ijl" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
@@ -27937,6 +27908,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"ipk" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/space/basic,
+/area/space)
 "iro" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/optable,
@@ -27985,6 +27967,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"isu" = (
+/obj/machinery/telecomms/bus/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "ivL" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
@@ -28031,13 +28017,15 @@
 /obj/structure/stairs/south,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"iAk" = (
-/obj/machinery/door/airlock/external{
-	name = "Supply Dock Airlock";
-	req_access_txt = "31"
-	},
+"iyT" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/space)
+/area/hallway/primary/aft)
+"iAk" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil,
+/turf/open/space/basic,
+/area/maintenance/solars/port/aft)
 "iBu" = (
 /obj/item/toy/plush/nukeplushie,
 /obj/effect/turf_decal/tile/red{
@@ -28104,10 +28092,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/construction)
-"iLx" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "iNH" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -28126,9 +28110,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"iSu" = (
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/circuit/telecomms/mainframe,
+"iSY" = (
+/obj/machinery/telecomms/receiver/preset_right,
+/turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "iUc" = (
 /obj/machinery/power/apc{
@@ -28171,6 +28155,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"iZy" = (
+/obj/machinery/computer/telecomms/monitor{
+	dir = 1;
+	network = "tcommsat"
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "jaJ" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/lobby)
@@ -28351,6 +28344,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"jvQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "jwz" = (
 /obj/structure/table/reinforced,
 /obj/item/biopsy_tool{
@@ -28367,10 +28366,6 @@
 /obj/structure/stairs/east,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"jwR" = (
-/obj/machinery/telecomms/server/presets/science,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "jxa" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -28398,16 +28393,29 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jzb" = (
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "supply dock loading door"
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
 	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	color = "#000000";
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/space)
+/area/engineering/lobby)
 "jAq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -28503,14 +28511,47 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"jKK" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
 "jKP" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/cargo/office)
-"jNN" = (
-/obj/machinery/power/tracker,
+"jLb" = (
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
+"jNN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "jOz" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -28533,6 +28574,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"jPp" = (
+/obj/machinery/blackbox_recorder,
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jPE" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -28600,13 +28646,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"jRF" = (
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"jSm" = (
-/obj/machinery/telecomms/processor/preset_two,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "jSw" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -28652,11 +28691,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"jYs" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/machinery/light/directional/west,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "jYt" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -28775,16 +28809,23 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"kjk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "kjN" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
+"kpo" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "kpF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance";
@@ -28835,6 +28876,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"kzE" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/radio/off,
+/obj/item/folder/blue,
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "kBz" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -28867,10 +28915,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"kEI" = (
-/obj/machinery/telecomms/bus/preset_three,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "kFa" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -28891,6 +28935,12 @@
 "kId" = (
 /turf/open/floor/plating,
 /area/maintenance/port)
+"kJu" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "kJy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -29034,11 +29084,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"kVG" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "kWd" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -29074,24 +29119,13 @@
 "lan" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
 	color = "#000000";
 	dir = 8;
 	name = "dark corner"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	alpha = 255;
 	color = "#000000";
 	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -29172,6 +29206,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
+"llD" = (
+/obj/machinery/computer/message_monitor{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "llR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -29260,13 +29301,6 @@
 /obj/item/trash/chips,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"lzN" = (
-/obj/machinery/computer/message_monitor{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
 "lzP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -29283,13 +29317,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"lCd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+"lAl" = (
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
-/area/tcommsat/computer)
+/area/hallway/primary/aft)
 "lFU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -29341,6 +29372,20 @@
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lLK" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/tcommsat/server)
 "lOk" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -29397,16 +29442,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lPW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/space)
 "lSC" = (
 /obj/structure/rack,
 /obj/item/stock_parts/micro_laser/high,
@@ -29612,11 +29650,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
-"msa" = (
-/obj/item/kirbyplants/random,
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "mtB" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -29822,18 +29855,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mLq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad2"
 	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/space)
 "mOd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -29870,18 +29898,8 @@
 /turf/open/floor/iron/white,
 /area/science)
 "mUd" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	name = "dark corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/turf/closed/wall/r_wall,
+/area/tcommsat/computer)
 "mVE" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -29890,6 +29908,10 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/commons/storage/tools)
+"mYx" = (
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "nbH" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -29975,6 +29997,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"nkr" = (
+/obj/machinery/telecomms/processor/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "nkN" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -30082,6 +30108,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/bar/atrium)
+"nvF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "nye" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/machinery/light/directional/south,
@@ -30119,6 +30154,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"nBl" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/cargo/storage)
 "nBG" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/command_all,
@@ -30175,15 +30214,33 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nGJ" = (
-/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/airlock/engineering,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/tcommsat/computer)
 "nIY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"nLi" = (
+/obj/structure/closet/firecloset,
+/obj/item/radio/off,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "nLu" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -30226,13 +30283,14 @@
 /turf/open/floor/iron/white,
 /area/science)
 "nQl" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad2"
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	req_one_access_txt = "10;24";
+	safety_mode = 1
 	},
-/turf/open/floor/iron,
-/area/space)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "nSe" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
@@ -30251,6 +30309,22 @@
 /obj/item/stock_parts/subspace/analyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"nUi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
+"nUk" = (
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "nVI" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -30261,11 +30335,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"nVV" = (
-/obj/machinery/announcement_system,
-/obj/machinery/status_display/ai/directional/west,
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
 "nYG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -30297,10 +30366,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"occ" = (
-/obj/machinery/telecomms/server/presets/command,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "odg" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
@@ -30334,8 +30399,22 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "ogY" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/computer)
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Engineering";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "ogZ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
@@ -30348,13 +30427,30 @@
 /obj/item/storage/box/masks,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"olb" = (
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "omY" = (
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"opd" = (
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "oqb" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
@@ -30384,6 +30480,12 @@
 "osl" = (
 /turf/open/floor/white,
 /area/service/library)
+"osD" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "owj" = (
 /obj/machinery/duct,
 /obj/machinery/door/airlock{
@@ -30421,6 +30523,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"oAJ" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "oBH" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -30482,39 +30592,14 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "oJL" = (
-/obj/machinery/door/airlock/engineering,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/space)
 "oLR" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"oNx" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room";
-	req_access_txt = "61"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "oOD" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -30544,23 +30629,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"oRh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"oRy" = (
-/obj/machinery/telecomms/bus/preset_four,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "oRH" = (
 /obj/structure/table,
 /obj/item/surgicaldrill,
@@ -30585,6 +30653,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"oTA" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "oVs" = (
 /obj/structure/table,
 /obj/item/toy/eightball,
@@ -30620,6 +30697,12 @@
 /obj/item/stock_parts/manipulator,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"oXv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "oZi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -30708,14 +30791,9 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "pjg" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	req_one_access_txt = "10;24";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "pjm" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
@@ -30767,6 +30845,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"ppt" = (
+/obj/machinery/telecomms/server/presets/supply,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
+"prm" = (
+/obj/machinery/telecomms/processor/preset_one,
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "prN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -30786,6 +30873,9 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"psN" = (
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "ptC" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -30928,10 +31018,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"pHJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"pHC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "pHK" = (
@@ -30979,10 +31071,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"pOK" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "pOX" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -31017,34 +31105,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"pVq" = (
-/obj/machinery/power/solar_control{
-	dir = 8;
-	id = "aftport";
-	name = "Aft Port Solars Control"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
-"pVt" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/space)
 "pXf" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
@@ -31054,20 +31114,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"pXm" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "pXD" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
-"pYO" = (
-/obj/structure/cable,
-/obj/machinery/camera/directional/south{
-	c_tag = "Solar Control - Port Aft";
-	name = "Solars Camera";
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
 "qay" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/operating,
@@ -31098,6 +31152,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"qeJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "qiL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 9
@@ -31117,22 +31177,11 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "qlV" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Engineering";
-	req_access_txt = "63"
+/obj/item/radio/intercom/directional/north{
+	freerange = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "qna" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue{
@@ -31185,8 +31234,12 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "qsO" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/door/airlock/command{
+	name = "Telecomms Control Room";
+	req_access_txt = "19; 61"
+	},
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "qsQ" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell,
@@ -31277,6 +31330,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"qHs" = (
+/obj/structure/chair/office/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "qIF" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -31290,8 +31355,13 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qJp" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/tcommsat/computer)
 "qJs" = (
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -31318,6 +31388,16 @@
 "qKl" = (
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
+"qNp" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Telecomms Server";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "qNB" = (
 /obj/structure/grille/broken,
 /obj/effect/spawner/random/structure/crate,
@@ -31343,6 +31423,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"qPI" = (
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "qPM" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
@@ -31352,10 +31435,11 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "qQD" = (
-/obj/item/radio/intercom/directional/north{
-	freerange = 1
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/tcommsat/computer)
 "qQK" = (
 /obj/structure/sign/warning/securearea{
@@ -31369,6 +31453,19 @@
 /obj/item/stack/cable_coil,
 /turf/open/space/basic,
 /area/maintenance/solars/starboard/aft)
+"qRE" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -30
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qRY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -31425,11 +31522,13 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "qVC" = (
-/obj/machinery/door/airlock/command{
-	name = "Telecomms Control Room";
-	req_access_txt = "19; 61"
+/obj/structure/table,
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/multitool,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/tcommsat/computer)
 "qWj" = (
 /obj/effect/turf_decal/tile/purple,
@@ -31483,6 +31582,10 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"reZ" = (
+/obj/machinery/telecomms/receiver/preset_left,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "rfx" = (
 /obj/item/target,
 /obj/structure/window/reinforced,
@@ -31678,11 +31781,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"rzc" = (
-/obj/machinery/ntnet_relay,
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "rCw" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/south{
@@ -31718,10 +31816,22 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "rGv" = (
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/screwdriver,
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/corner{
+/turf/open/floor/iron,
+/area/tcommsat/computer)
+"rHh" = (
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = -30
+	},
+/obj/structure/closet/emcloset,
+/obj/item/radio/off,
+/obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -31736,12 +31846,6 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"rMU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "rOd" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -31778,15 +31882,6 @@
 "rPB" = (
 /turf/open/floor/wood,
 /area/security/detectives_office)
-"rRA" = (
-/obj/machinery/computer/telecomms/monitor{
-	dir = 1;
-	network = "tcommsat"
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/stripes/end,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "rTh" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -31814,6 +31909,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"rXN" = (
+/obj/structure/cable,
+/obj/machinery/power/smes{
+	charge = 500000
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "rYx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -31856,22 +31958,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
-"scT" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/space)
 "sgG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -31923,14 +32009,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"sjr" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "sjz" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/west,
@@ -31983,11 +32061,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"spw" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/server)
 "sqQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -32082,25 +32155,9 @@
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"sCF" = (
-/obj/structure/chair/office/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "sEl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/floor/plating,
+/area/space)
 "sKe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -32111,17 +32168,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/cargo/office)
-"sLU" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/space/basic,
-/area/space)
 "sMi" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -32181,22 +32227,6 @@
 /obj/item/electronics/airalarm,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"sVp" = (
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_x = -30
-	},
-/obj/structure/closet/emcloset,
-/obj/item/radio/off,
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
-"sWv" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/machinery/light/directional/east,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "sWy" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
@@ -32235,16 +32265,11 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"tfu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"tbj" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "tgU" = (
@@ -32257,14 +32282,34 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "tiZ" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/multitool,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
 	},
 /turf/open/floor/iron,
-/area/tcommsat/computer)
+/area/security/checkpoint/engineering)
+"tjV" = (
+/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "tkj" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/purple{
@@ -32386,26 +32431,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/processing)
-"tsX" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_one_access_txt = "10;24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
 "ttL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -32523,17 +32548,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
-"tBQ" = (
-/obj/structure/cable,
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Security Engineering monitor";
-	network = list("engineering","atmos");
-	pixel_y = -30
-	},
-/obj/structure/chair/office,
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/engineering)
 "tET" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -32556,26 +32570,34 @@
 /area/security/detectives_office/private_investigators_office)
 "tIB" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/item/screwdriver,
-/obj/machinery/light_switch/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/item/paper_bin,
+/obj/machinery/requests_console/directional/north{
+	department = "Cargo Bay";
+	departmentType = 2;
+	name = "Cargo Bay Requests Console"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/obj/item/stamp{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 7;
+	pixel_y = 4
 	},
 /turf/open/floor/iron,
-/area/tcommsat/computer)
+/area/space)
 "tIW" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/medical/coldroom)
-"tLo" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "tMk" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -32588,7 +32610,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tMy" = (
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/photocopier,
+/turf/open/floor/iron,
 /area/space)
 "tMB" = (
 /obj/effect/turf_decal/tile/brown,
@@ -32598,13 +32627,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
-"tNC" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/radio/off,
-/obj/item/folder/blue,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "tQm" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -32685,43 +32707,33 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"tZQ" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	req_one_access_txt = "10;24";
+	safety_mode = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "uav" = (
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "ucH" = (
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/west,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 4;
-	name = "Security red corner"
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/checkpoint/engineering)
+/area/space)
 "ucU" = (
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
-"udC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "uef" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/siding/white,
@@ -32768,6 +32780,19 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"uiP" = (
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
+"ujT" = (
+/obj/machinery/telecomms/hub/preset,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
+"ulp" = (
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "ulE" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -32814,11 +32839,6 @@
 "upj" = (
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"urk" = (
-/obj/machinery/telecomms/server/presets/medical,
-/obj/machinery/light/directional/west,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "urD" = (
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
@@ -32828,6 +32848,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
+"usV" = (
+/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "utc" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -32850,16 +32875,10 @@
 /obj/machinery/defibrillator_mount/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
-"uvz" = (
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "uwc" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/machinery/requests_console/directional/north{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo Bay Requests Console"
+/obj/machinery/conveyor_switch/oneway{
+	dir = 1;
+	id = "QMLoad"
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -32867,23 +32886,22 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/obj/item/stamp{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/stamp/denied{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/space)
-"uxA" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"uxO" = (
+/obj/machinery/announcement_system,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "uys" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/requests_console/directional/north{
@@ -32990,6 +33008,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"uVy" = (
+/obj/machinery/telecomms/server/presets/science,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "uXd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -33064,13 +33086,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/detectives_office)
-"vcD" = (
-/obj/machinery/computer/telecomms/server{
-	dir = 1;
-	network = "tcommsat"
-	},
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
 "vdZ" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/radio/intercom/directional/north,
@@ -33095,14 +33110,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library)
-"veP" = (
-/obj/machinery/telecomms/bus/preset_two,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"veT" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "vfs" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4;
@@ -33162,9 +33169,14 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/photocopier,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/storage)
 "vnE" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -33195,10 +33207,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"vqA" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/cargo/storage)
 "vrF" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -33215,6 +33223,18 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"vtS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC"
+	},
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "vvv" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -33262,12 +33282,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
+"vyX" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "vyZ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"vzn" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 1;
+	network = "tcommsat"
+	},
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "vzH" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -33304,9 +33336,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"vCp" = (
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "vCx" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/door/firedoor,
@@ -33317,14 +33346,36 @@
 /turf/open/space/basic,
 /area/maintenance/solars/port/fore)
 "vEC" = (
+/obj/machinery/computer/cargo,
+/obj/machinery/button/door/directional/east{
+	id = "cargounload";
+	layer = 3.3;
+	name = "Unloading Doors";
+	pixel_x = -8;
+	pixel_y = 24;
+	req_access_txt = "31"
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cargoload";
+	layer = 3.3;
+	name = "Loading Doors";
+	pixel_x = 8;
+	pixel_y = 24;
+	req_access_txt = "31"
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/storage)
 "vED" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -33348,10 +33399,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
-"vFo" = (
-/obj/machinery/telecomms/processor/preset_four,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "vFp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -33378,10 +33425,6 @@
 /turf/open/floor/iron/white,
 /area/science)
 "vKS" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 1;
-	id = "QMLoad"
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -33389,12 +33432,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -33448,6 +33485,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vSn" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
@@ -33455,12 +33496,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/cargo/storage)
 "vUt" = (
 /obj/effect/turf_decal/stripes/line,
@@ -33493,15 +33531,9 @@
 /obj/item/food/grown/garlic,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"vXL" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Telecomms Server";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/telecomms,
+"vXG" = (
+/obj/machinery/telecomms/bus/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "vXO" = (
 /obj/structure/cable,
@@ -33587,33 +33619,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"whZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
 "wiH" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wjW" = (
-/obj/machinery/computer/cargo,
-/obj/machinery/button/door/directional/east{
-	id = "cargounload";
-	layer = 3.3;
-	name = "Unloading Doors";
-	pixel_x = -8;
-	pixel_y = 24;
-	req_access_txt = "31"
-	},
-/obj/machinery/button/door/directional/east{
-	id = "cargoload";
-	layer = 3.3;
-	name = "Loading Doors";
-	pixel_x = 8;
-	pixel_y = 24;
-	req_access_txt = "31"
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -33624,14 +33636,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/cargo/storage)
-"wkc" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/turf/open/floor/iron/dark,
+/area/space)
 "wmN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -33710,10 +33716,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"wyG" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
 "wzd" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -33735,6 +33737,9 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"wDH" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/server)
 "wGo" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -33746,6 +33751,11 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"wIN" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "wJV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
@@ -33844,11 +33854,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"wSL" = (
-/obj/machinery/telecomms/processor/preset_one,
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "wTg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -33881,6 +33886,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
+"wWf" = (
+/obj/machinery/telecomms/broadcaster/preset_right,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "wXz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -33900,18 +33909,36 @@
 "wZO" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"xbN" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "xbW" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/space)
 "xca" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/security_all,
@@ -33922,11 +33949,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"xdu" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/machinery/light/directional/east,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "xfJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -33936,10 +33958,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/iron,
 /area/commons/lounge)
-"xhl" = (
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "xiS" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
@@ -33968,6 +33986,11 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"xjQ" = (
+/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "xkb" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -34006,9 +34029,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xkJ" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/server)
 "xlx" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -34069,13 +34089,6 @@
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
-"xwc" = (
-/obj/structure/cable,
-/obj/machinery/power/smes{
-	charge = 500000
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "xxQ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -34092,6 +34105,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"xzZ" = (
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "aftport";
+	name = "Aft Port Solars Control"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
 "xAF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -34131,21 +34156,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xIH" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
-/area/cargo/storage)
+/area/tcommsat/computer)
 "xPk" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -34187,10 +34201,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"xWB" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "xXO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -34295,16 +34305,6 @@
 /obj/item/storage/bag/trash,
 /turf/open/floor/iron,
 /area/commons/vacant_room/commissary)
-"yhK" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Internal Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/engineering/atmos)
 "yhT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46048,7 +46048,7 @@ aaa
 aaa
 aaa
 aak
-jNN
+hXT
 aak
 aaa
 aaa
@@ -49110,7 +49110,7 @@ qTU
 oFl
 lFU
 bGh
-bZY
+bZQ
 bGh
 cjG
 cjG
@@ -49389,7 +49389,7 @@ aae
 aae
 aaa
 aak
-kjN
+iAk
 cmO
 cgj
 cgj
@@ -50142,11 +50142,11 @@ bwU
 bLy
 bGh
 bEM
-cgl
+cdF
 bEL
-cjX
+cje
 bEL
-cnP
+cml
 cjG
 aaa
 aaa
@@ -50659,15 +50659,15 @@ cjG
 cjG
 cjG
 cjG
-cml
+clu
 bKg
 cjG
-csv
-cub
-cuJ
-cve
-cve
-cyA
+cpk
+csV
+cuj
+cuv
+cuv
+cws
 cjG
 aak
 aaa
@@ -50914,7 +50914,7 @@ bGh
 bEL
 cjG
 bQv
-ciJ
+chx
 bEM
 bGh
 bGh
@@ -51684,8 +51684,8 @@ bwU
 bLD
 bEL
 cjG
-cgm
-cje
+ceY
+chB
 cjG
 bGh
 bPf
@@ -51941,8 +51941,8 @@ bwU
 ceP
 bEL
 cjG
-cgs
-cjf
+cfg
+chC
 cjG
 bGh
 bEM
@@ -51950,7 +51950,7 @@ cjG
 bGh
 bEL
 bEL
-cvk
+cuJ
 cjG
 bUB
 cjG
@@ -51963,7 +51963,7 @@ aaa
 aaa
 aaa
 ctu
-tsX
+jKK
 ctu
 aaa
 aaa
@@ -52204,7 +52204,7 @@ pOX
 bGh
 bVY
 cjG
-csV
+cqe
 bGh
 bEL
 bEL
@@ -52463,7 +52463,7 @@ bGh
 cjG
 bEL
 bGh
-cjX
+cje
 bEL
 cjG
 bHu
@@ -52976,11 +52976,11 @@ bwU
 bGh
 cjG
 cSL
-cuj
+cta
 bGh
 bGh
 cjG
-cml
+clu
 bEL
 bEL
 cjG
@@ -52991,7 +52991,7 @@ coe
 haR
 cwx
 cuW
-whZ
+cHv
 haR
 aaa
 aaa
@@ -53248,7 +53248,7 @@ cAX
 haR
 cxm
 ctz
-pYO
+eNW
 haR
 aaa
 aaa
@@ -53505,18 +53505,18 @@ nlF
 cCo
 cxp
 cBh
-pVq
+xzZ
 haR
 aaa
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
 aaa
 aaa
 aaa
@@ -53750,8 +53750,8 @@ bwU
 cjG
 cdm
 ceX
-cwh
-cBG
+cvz
+cwz
 cgp
 cji
 bXo
@@ -53764,16 +53764,16 @@ haR
 haR
 haR
 haR
-ogY
-xkJ
-vCp
-jYs
-jSm
-vXL
-xhl
-urk
-vCp
-xkJ
+mUd
+wDH
+psN
+xjQ
+nkr
+qNp
+nUk
+tjV
+psN
+wDH
 aaa
 aaa
 aaa
@@ -54009,28 +54009,28 @@ bKA
 cjd
 cjd
 cjd
-cEQ
+cCs
 cjj
 bXo
 cvh
 caU
 cmV
 cBc
-ogY
-qJp
-msa
-cVJ
-aUs
-nVV
-kjk
-vCp
-ajV
-ati
-fIr
-fpN
-jwR
-opd
-xkJ
+mUd
+pjg
+xIH
+mYx
+vtS
+uxO
+fEs
+psN
+ppt
+reZ
+bXd
+eRd
+uVy
+aVM
+wDH
 aaa
 aaa
 aaa
@@ -54263,8 +54263,8 @@ bEL
 bEL
 cjG
 cdp
-cvz
-cwi
+cuL
+cvT
 cjd
 cgB
 chG
@@ -54273,21 +54273,21 @@ clz
 caU
 cmU
 cBd
-ogY
-qQD
-uvz
-uvz
-wyG
-lzN
-kjk
-vCp
-jRF
-veP
-fIr
-wSL
-bVQ
-fIr
-xkJ
+mUd
+qlV
+anO
+anO
+dkm
+llD
+fEs
+psN
+qPI
+dvc
+bXd
+prm
+anY
+bXd
+wDH
 aaa
 aaa
 aaa
@@ -54521,30 +54521,30 @@ bEL
 cjG
 cjG
 bXo
-cwr
+cvW
 cjd
-cES
+cDN
 bXo
 bXo
-eRf
+dJT
 caU
 cmW
 lJc
-ogY
-qVC
+mUd
+qsO
 cCq
-tNC
-aOl
-vcD
-kjk
-vCp
-jRF
-vCp
-vCp
-vCp
-jRF
-gup
-xkJ
+kzE
+edo
+vzn
+fEs
+psN
+qPI
+psN
+psN
+psN
+qPI
+jPp
+wDH
 aaa
 aaa
 aaa
@@ -54777,12 +54777,12 @@ bEL
 bEL
 bEL
 cjG
-cvT
-cws
+cve
+cwh
 cjd
-cEV
+cDQ
 bXo
-dtb
+cXb
 cmc
 caU
 cmU
@@ -54793,15 +54793,15 @@ cEi
 cEi
 cEi
 cCq
-kjk
-vCp
-jRF
-gOi
-jRF
-rzc
-cMD
-xwc
-xkJ
+fEs
+psN
+qPI
+ujT
+qPI
+ela
+vyX
+rXN
+wDH
 aaa
 aaa
 aaa
@@ -55036,29 +55036,29 @@ bEL
 cjG
 bYp
 cjd
-cCs
-cSM
+cxB
+cEQ
 bXo
-dEZ
+cXn
 cBe
 caU
 cmU
 cBe
 cCq
-rGv
-ibO
-dyB
+qJp
+nvF
+nLi
 cEi
-sVp
-spw
-vCp
-bVQ
-fIr
-fIr
-fIr
-jRF
-veT
-xkJ
+rHh
+eru
+psN
+anY
+bXd
+bXd
+bXd
+qPI
+pXm
+wDH
 aaa
 aaa
 aaa
@@ -55295,27 +55295,27 @@ bYp
 cjd
 cjd
 caH
-cXn
-dJT
+cSM
+cXC
 bXp
 cmU
 cmU
-lan
-oJL
-sEl
-kVG
-tLo
-oNx
-tfu
-gel
-fIr
-bVQ
-vFo
-vCp
-kEI
-jRF
-vCp
-xkJ
+jzb
+nGJ
+qQD
+ulp
+tbj
+xbN
+nUi
+lLK
+bXd
+anY
+cXX
+psN
+isu
+qPI
+psN
+wDH
 aaa
 aaa
 aaa
@@ -55559,20 +55559,20 @@ caU
 cmU
 cmc
 cCq
-tiZ
-lCd
-aYf
+qVC
+jLb
+wIN
 cEi
-spw
-spw
-vCp
-iLx
-fji
-vCp
-htf
-occ
-opd
-xkJ
+eru
+eru
+psN
+fny
+wWf
+psN
+iSY
+gFJ
+aVM
+wDH
 aaa
 aaa
 aaa
@@ -55816,20 +55816,20 @@ caU
 cmU
 cmc
 cCq
-tIB
-blj
-sCF
-rRA
-spw
-vCp
-vCp
-sWv
-oRy
-pOK
-iSu
-xdu
-vCp
-xkJ
+rGv
+fCn
+qHs
+iZy
+eru
+psN
+psN
+hfg
+vXG
+kpo
+uiP
+usV
+psN
+wDH
 aaa
 aaa
 aaa
@@ -56062,31 +56062,31 @@ bEL
 bEL
 bEL
 cjG
-cvW
-cwz
-cDN
-cSW
+cvk
+cwi
+cyA
+cES
 bXo
-dKk
+dtb
 caU
-fju
+dQj
 cmU
 cmc
-ogY
-ogY
-ogY
-ogY
-ogY
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
-xkJ
+mUd
+mUd
+mUd
+mUd
+mUd
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
+wDH
 aaa
 aaa
 aaa
@@ -56854,7 +56854,7 @@ fNz
 fNz
 fNz
 fNz
-oRh
+qRE
 cKk
 cKk
 cKk
@@ -57093,9 +57093,9 @@ cjG
 cjG
 cjG
 cjG
-cXb
-cXb
-dQj
+cEV
+cEV
+dEZ
 ckR
 cnW
 cmX
@@ -57112,10 +57112,10 @@ fNz
 fNz
 fNz
 cyG
-iiV
+oAJ
 fNz
 fNz
-yhK
+fgQ
 aaa
 aaa
 aaa
@@ -57345,11 +57345,11 @@ bUJ
 bGh
 bEL
 bEL
-ckR
+cjG
 djJ
 djJ
 djJ
-cDQ
+cBG
 cgt
 chE
 cjq
@@ -57368,7 +57368,7 @@ fNz
 fNz
 fNz
 fNz
-oRh
+qRE
 cKk
 cKk
 cKk
@@ -57602,7 +57602,7 @@ bEM
 bGh
 bEL
 bEL
-ckR
+cjG
 cgt
 cgt
 cgt
@@ -57610,8 +57610,8 @@ cfc
 cjr
 cjr
 cjr
-feF
-gkA
+dKk
+eRf
 cmU
 cBg
 coW
@@ -57859,13 +57859,13 @@ bwU
 pOX
 cjG
 bEL
-ckR
+cjG
 cgt
 cgt
 cgt
 cgQ
 cgt
-cXC
+cSW
 cjC
 ckR
 cdE
@@ -57882,7 +57882,7 @@ coZ
 cro
 crj
 cBs
-fte
+evq
 coW
 aaa
 aaa
@@ -58116,7 +58116,7 @@ bUK
 bGh
 cjG
 cjG
-ckR
+cjG
 ckR
 ckR
 ckR
@@ -58371,12 +58371,12 @@ bGh
 bwU
 bUL
 bGh
-cqe
+cnP
 cjG
+ctw
 cuq
-cuL
-cuL
-cxB
+cuq
+cwr
 ckR
 ckR
 ckR
@@ -58898,7 +58898,7 @@ cmc
 bXs
 czm
 cmU
-lPW
+jNN
 coW
 ttL
 crj
@@ -63524,10 +63524,10 @@ cJP
 eAq
 cvh
 cmU
-mLq
+kjN
 coW
-qsO
-qsO
+oJL
+oJL
 aaa
 aaa
 aaa
@@ -63782,10 +63782,10 @@ eAq
 czK
 cmW
 cBg
-pjg
-tMy
-dMU
-sLU
+nQl
+sEl
+tZQ
+ipk
 aaa
 aaa
 aaa
@@ -64038,10 +64038,10 @@ cJP
 bXv
 clE
 cmU
-mLq
+kjN
 coW
-qsO
-qsO
+oJL
+oJL
 aaa
 aaa
 aaa
@@ -64552,7 +64552,7 @@ cjE
 bXv
 clF
 cmU
-lPW
+jNN
 coW
 aaa
 aaa
@@ -65066,9 +65066,9 @@ fVT
 bXv
 clV
 cmU
-mUd
-qlV
-ucH
+lan
+ogY
+tiZ
 cDO
 csK
 cvj
@@ -65327,7 +65327,7 @@ cBZ
 cxS
 cqO
 crJ
-grQ
+olb
 cud
 cFr
 cwB
@@ -65843,7 +65843,7 @@ jjw
 sxx
 gth
 cFp
-tBQ
+ame
 cwN
 cxS
 aaa
@@ -66854,7 +66854,7 @@ bJe
 bJB
 cjO
 bXy
-cuv
+cub
 bJe
 rOd
 rOd
@@ -66869,7 +66869,7 @@ cma
 duA
 bJe
 bJB
-xWB
+lAl
 csI
 csI
 csI
@@ -67126,7 +67126,7 @@ bJe
 bJe
 bJe
 bJB
-wkc
+iyT
 cWe
 cxW
 aaa
@@ -67383,7 +67383,7 @@ bJe
 bJe
 bJe
 crC
-wkc
+iyT
 cWe
 cxW
 aaa
@@ -67640,7 +67640,7 @@ bJe
 bJe
 bJe
 bJB
-wkc
+iyT
 cWe
 cxW
 aaa
@@ -67879,9 +67879,9 @@ qJs
 bJe
 bJe
 bJe
-coG
+cmQ
 ccD
-cta
+crE
 bqh
 ccD
 cbs
@@ -67897,7 +67897,7 @@ acS
 crZ
 crZ
 fqS
-epe
+oTA
 cWe
 cxW
 aaa
@@ -68130,11 +68130,11 @@ bxk
 cvV
 pHK
 cvV
-caJ
+caf
 bLY
 bLY
 bLY
-caJ
+caf
 cvV
 cvV
 ceu
@@ -68387,9 +68387,9 @@ bYz
 cvV
 rwY
 cvV
-caK
+cag
 wUZ
-chx
+cgl
 uez
 ygU
 cvV
@@ -68644,8 +68644,8 @@ bYC
 cvV
 rwY
 cvV
-cce
-cdF
+cau
+cdl
 vnH
 vnH
 jfo
@@ -68901,11 +68901,11 @@ bYZ
 cvV
 rwY
 cvV
-cdl
+caJ
 wUZ
-chB
+cgm
 wUZ
-ckx
+cjf
 cvV
 rwY
 bVv
@@ -69157,12 +69157,12 @@ bjW
 bYD
 cvV
 rwY
-cag
+bZR
 vnH
-ceY
+cdo
 vnH
 wUZ
-clu
+cjB
 cvV
 rwY
 bVv
@@ -69415,7 +69415,7 @@ bZa
 cvV
 rwY
 cvV
-cdo
+caK
 wUZ
 wUZ
 wUZ
@@ -69672,9 +69672,9 @@ bYV
 cvV
 rwY
 cvV
+cce
 cdu
-cfg
-chC
+cgs
 wUZ
 hJt
 cvV
@@ -70185,11 +70185,11 @@ bYt
 bZp
 cvV
 rwY
-cau
+bZY
 rwY
 rwY
 rwY
-cjB
+ciJ
 bTC
 rwY
 rwY
@@ -70207,8 +70207,8 @@ aaa
 aaa
 aaa
 aaa
-qsO
-uwc
+oJL
+tIB
 cqE
 cqE
 cqE
@@ -70446,7 +70446,7 @@ cvV
 rwY
 rwY
 rwY
-cjB
+ciJ
 bTC
 rwY
 rwY
@@ -70464,8 +70464,8 @@ aaa
 aaa
 aaa
 aaa
-heb
-vlV
+fju
+tMy
 cqE
 jEj
 jEj
@@ -70721,8 +70721,8 @@ aaa
 aaa
 aaa
 aaa
-heb
-vEC
+fju
+ucH
 cqE
 jEj
 cqE
@@ -70976,11 +70976,11 @@ aaa
 aaa
 aaa
 aaa
-heb
-heb
+fju
+fju
 vAh
-vKS
-udC
+uwc
+qeJ
 cvy
 cqE
 cqE
@@ -71219,7 +71219,7 @@ rwY
 rwY
 rwY
 cvV
-cmQ
+clG
 rwY
 bVv
 pAS
@@ -71232,12 +71232,12 @@ aaa
 aaa
 aaa
 aaa
-gzx
-hXT
+feF
+gkA
 acT
 cpu
 cnx
-vqA
+nBl
 cok
 czo
 cqE
@@ -71477,7 +71477,7 @@ rwY
 cvV
 cvV
 cvV
-cpk
+cnN
 bVv
 pAS
 aaa
@@ -71490,11 +71490,11 @@ aaa
 aaa
 aaa
 aaa
-iAk
-nGJ
+gzx
+lPW
 crP
-vSn
-pHJ
+vlV
+oXv
 uTo
 czo
 cqE
@@ -71732,8 +71732,8 @@ cnV
 cvV
 oOI
 cvV
-clG
-cnN
+cjX
+clI
 rwY
 bVv
 pAS
@@ -71747,10 +71747,10 @@ aaa
 aaa
 aaa
 aaa
-heb
-heb
+fju
+fju
 vAh
-wjW
+vEC
 uLc
 jEj
 czo
@@ -71989,8 +71989,8 @@ byO
 cvV
 oOI
 cvV
+ckx
 clI
-cnN
 rwY
 bVv
 pAS
@@ -72004,13 +72004,13 @@ aaa
 aaa
 aaa
 aaa
-iAk
-nGJ
+gzx
+lPW
 crP
-xbW
+vKS
 cqE
 jEj
-sjr
+pHC
 cqE
 czo
 cqE
@@ -72261,8 +72261,8 @@ aaa
 aaa
 aaa
 aaa
-jzb
-nQl
+heb
+mLq
 cmD
 cqK
 crQ
@@ -72506,7 +72506,7 @@ cvV
 bUc
 rwY
 bVv
-crE
+coG
 pAS
 aaa
 aaa
@@ -72518,11 +72518,11 @@ aaa
 aaa
 aaa
 aaa
-heb
-heb
+fju
+fju
 vAh
-xIH
-uxA
+vSn
+jvQ
 jEj
 cqE
 cqE
@@ -72777,9 +72777,9 @@ aaa
 aaa
 aaa
 aaa
-heb
-scT
-uxA
+fju
+wjW
+jvQ
 jEj
 jxV
 cqE
@@ -73021,7 +73021,7 @@ bVv
 bVv
 bVv
 ckb
-ctw
+csv
 pAS
 aaa
 aaa
@@ -73034,13 +73034,13 @@ aaa
 aaa
 aaa
 aaa
-heb
-scT
-uxA
+fju
+wjW
+jvQ
 jEj
 czo
 cqE
-bUp
+kJu
 cqE
 czo
 cqE
@@ -73291,9 +73291,9 @@ aaa
 aaa
 aaa
 aaa
-qsO
-scT
-uxA
+oJL
+wjW
+jvQ
 jEj
 czo
 cqE
@@ -73548,9 +73548,9 @@ aaa
 aaa
 aaa
 aaa
-qsO
-pVt
-rMU
+oJL
+xbW
+osD
 jEj
 czo
 cqE

--- a/Heliostation2.dmm
+++ b/Heliostation2.dmm
@@ -641,14 +641,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "acT" = (
-/obj/docking_port/stationary{
-	dwidth = 4;
-	height = 6;
-	id = "supply_home";
-	name = "Cargo Bay";
-	width = 12
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor{
+	id = "QMLoad"
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/space)
 "acU" = (
 /obj/machinery/door/poddoor{
@@ -2040,6 +2037,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/brig)
+"ajV" = (
+/obj/machinery/telecomms/server/presets/supply,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "aka" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/red{
@@ -3545,6 +3546,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"ati" = (
+/obj/machinery/telecomms/receiver/preset_left,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "atj" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "briglockdown";
@@ -6609,23 +6614,29 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aOj" = (
+/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue{
-	dir = 8
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
 	},
-/obj/machinery/airalarm/unlocked{
-	frequency = 1450;
-	pixel_y = -30
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "aOk" = (
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/commons/fitness)
+"aOl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "aOo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -6679,14 +6690,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aOC" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/button/door/directional/north{
-	id = "commissaryshutter";
-	name = "Commisary Shutter Control"
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 9
+	},
+/obj/machinery/computer/cargo/request{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "aOD" = (
 /obj/structure/fluff/broken_flooring,
 /obj/effect/decal/cleanable/blood/tracks,
@@ -7245,10 +7256,12 @@
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aRy" = (
-/obj/machinery/disposal/bin,
-/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "aRz" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -7853,6 +7866,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
+"aUs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/requests_console/directional/west{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC"
+	},
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "aUt" = (
 /obj/structure/sign/poster/official/science{
 	pixel_y = -30
@@ -8333,15 +8358,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "aXE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/power/apc{
-	areastring = "/area/commons/vacant_room/commissary";
-	dir = 1;
-	name = "Vacant Commissary APC";
-	pixel_y = 25
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/machinery/computer/atmos_alert{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "aXF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -8418,6 +8442,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
+"aYf" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "aYi" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -8606,9 +8635,22 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "aZf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "aZh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8620,68 +8662,36 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "aZn" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
+/obj/machinery/shower{
 	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
+	name = "emergency shower"
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/area/medical/treatment_center)
 "aZo" = (
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access_txt = "5"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
+/obj/effect/landmark/start/paramedic,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 8;
 	name = "Command blue corner"
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/area/medical/medbay/central)
 "aZp" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -8704,21 +8714,11 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "aZQ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medbay Reception";
-	req_access_txt = "5"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/obj/structure/frame/machine,
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/defibrillator_mount/directional/east,
+/turf/open/floor/iron/dark,
+/area/medical/treatment_center)
 "aZR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plating,
@@ -8742,32 +8742,18 @@
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
 "aZW" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/evac/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
+/obj/structure/sign/departments/examroom{
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "aZX" = (
-/obj/machinery/computer/med_data{
+/obj/structure/bed/roller,
+/obj/structure/window{
 	dir = 8
 	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Medbay - Lobby E";
-	network = list("ss13","medbay")
-	},
 /turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
+/area/medical/medbay/central)
 "aZY" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/box/syringes,
@@ -8854,8 +8840,6 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "bag" = (
-/obj/structure/chair/office/light,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "bah" = (
@@ -8871,14 +8855,16 @@
 /area/science)
 "baj" = (
 /obj/structure/cable,
-/obj/machinery/button/door/directional/east{
-	desc = "A door remote control switch for the medbay foyer.";
-	id = "MedbayFoyer";
-	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
-	pixel_x = 32;
-	req_access_txt = "5"
+/obj/structure/chair/office/light{
+	dir = 4
 	},
+/obj/machinery/power/apc{
+	areastring = "/area/medical/medbay/lobby";
+	dir = 1;
+	name = "Medbay Lobby APC";
+	pixel_y = 24
+	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "bal" = (
@@ -8962,16 +8948,14 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "bbc" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/britcup,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
+/obj/structure/cable,
+/obj/machinery/button/door/directional/east{
+	desc = "A door remote control switch for the medbay foyer.";
+	id = "MedbayFoyer";
+	name = "Medbay Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = 32;
+	req_access_txt = "5"
 	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
@@ -9021,11 +9005,12 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "bbk" = (
-/obj/structure/sign/departments/psychology{
-	pixel_x = -32
-	},
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
+/obj/machinery/camera/directional/west{
+	c_tag = "Medbay - Lobby W";
+	network = list("ss13","medbay")
+	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 1;
@@ -9035,6 +9020,9 @@
 	color = "#73c2fb";
 	dir = 8;
 	name = "Medical blue corner"
+	},
+/obj/structure/sign/departments/psychology{
+	pixel_x = -32
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -9159,7 +9147,7 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bck" = (
-/obj/item/kirbyplants/random,
+/obj/machinery/disposal/bin,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 1;
@@ -9168,6 +9156,11 @@
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 8;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
@@ -10034,8 +10027,22 @@
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "bhW" = (
-/turf/closed/wall/r_wall,
-/area/medical/medbay/lobby)
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "bhY" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -10186,45 +10193,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "biP" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/medbay/lobby)
 "biU" = (
-/mob/living/simple_animal/bot/cleanbot{
-	name = "C.L.E.A.N."
-	},
-/obj/machinery/vending/wallmed/directional/north,
+/obj/structure/bed/roller,
 /turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
+/area/medical/medbay/central)
 "biW" = (
 /obj/structure/cable,
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/structure/sign/departments/examroom{
+	pixel_y = 30
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/lobby";
-	dir = 1;
-	name = "Medbay Lobby APC";
-	pixel_y = 24
-	},
-/obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "biX" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -10241,21 +10223,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/maintenance/starboard)
-"bjd" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/area/medical/pharmacy)
 "bje" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/customs)
@@ -10483,10 +10451,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bkv" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Medbay - Lobby E";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
@@ -10583,6 +10553,15 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"blj" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/machinery/status_display/ai/directional/east,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "blk" = (
 /obj/structure/chair{
 	dir = 8;
@@ -10706,13 +10685,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/starboard)
 "blR" = (
-/obj/item/radio/intercom/directional/west,
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/machinery/camera/directional/west{
-	c_tag = "Medbay - Lobby W";
-	network = list("ss13","medbay")
-	},
+/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 1;
@@ -10723,6 +10696,7 @@
 	dir = 8;
 	name = "Medical blue corner"
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "blS" = (
@@ -10742,20 +10716,10 @@
 /area/science)
 "blU" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 8;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/dark,
@@ -11025,18 +10989,24 @@
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "bnj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
-	dir = 4;
 	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "bno" = (
 /obj/effect/landmark/start/depsec/medical,
@@ -11085,32 +11055,17 @@
 /turf/open/floor/plating,
 /area/security/courtroom)
 "bnD" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
 /obj/machinery/newscaster/directional/north,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bnE" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
+/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 4;
 	name = "Command blue corner"
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bnF" = (
@@ -11254,12 +11209,27 @@
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "boE" = (
-/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "boG" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "boJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -11689,14 +11659,11 @@
 /turf/closed/wall,
 /area/service/lawoffice)
 "bqS" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/vendor,
-/obj/item/circuitboard/machine/vendor,
-/obj/item/circuitboard/machine/paystand,
-/obj/machinery/light/directional/north,
-/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/siding/wideplating/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "bqT" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=neutral";
@@ -12197,11 +12164,6 @@
 	dir = 1;
 	name = "Command blue corner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 4;
-	name = "Command blue corner"
-	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -12596,7 +12558,6 @@
 /area/hallway/primary/central)
 "bwm" = (
 /obj/structure/cable,
-/obj/machinery/light/directional/south,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -13041,10 +13002,12 @@
 	},
 /area/service/hydroponics)
 "bxE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "bxI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -13406,11 +13369,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "byG" = (
-/obj/structure/closet/firecloset,
-/obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 9
 	},
+/obj/structure/closet/firecloset,
+/obj/item/storage/box/lights/mixed,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -13426,7 +13389,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating/corner,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "byJ" = (
@@ -13643,18 +13605,7 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bzo" = (
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "bzp" = (
 /obj/structure/chair/stool,
@@ -13708,7 +13659,10 @@
 /turf/open/floor/iron/white,
 /area/science/robotics/lab)
 "bzy" = (
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bzz" = (
 /obj/machinery/navbeacon/wayfinding,
@@ -13886,37 +13840,42 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "bAr" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
 	},
+/obj/structure/closet/emcloset,
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bAs" = (
-/obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bAt" = (
-/obj/structure/chair/office,
-/obj/machinery/camera/directional/west{
-	c_tag = "Central Primary Hallway - Computers";
-	name = "Hallway Camera"
-	},
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
 	},
 /obj/machinery/light/small/directional/west,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bAu" = (
-/obj/structure/chair/office,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "bAv" = (
 /obj/structure/table,
 /obj/item/storage/box/shipping,
@@ -14359,42 +14318,44 @@
 /turf/open/floor/wood,
 /area/hallway/secondary/service)
 "bBQ" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 10
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bBR" = (
-/obj/machinery/space_heater,
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 6
 	},
+/obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bBS" = (
-/obj/machinery/computer/warrant{
-	dir = 1
-	},
 /obj/effect/turf_decal/siding/wideplating{
-	dir = 10
+	dir = 8
 	},
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bBT" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 1
+/obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
 	},
-/obj/effect/turf_decal/siding/wideplating,
-/obj/machinery/bounty_board/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "bBU" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bBV" = (
 /obj/structure/table,
 /obj/item/camera,
@@ -14574,18 +14535,11 @@
 /turf/open/floor/iron/textured_large,
 /area/science/robotics/lab)
 "bCG" = (
-/obj/machinery/firealarm/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
+/obj/structure/bed/roller,
+/obj/structure/window{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/central)
 "bCH" = (
 /obj/structure/chair,
@@ -15078,12 +15032,18 @@
 /turf/open/floor/carpet/purple,
 /area/service/lawoffice)
 "bEw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
 	dir = 1;
-	frequency = 1450
+	name = "Command blue corner"
 	},
-/turf/open/floor/engine/airless,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bEz" = (
 /obj/structure/chair/sofa{
 	desc = "Made of very expensive furs, probably from an endangered animal.";
@@ -15601,18 +15561,19 @@
 /turf/open/floor/carpet,
 /area/service/bar/atrium)
 "bGD" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters{
-	id = "commissaryshutter";
-	name = "Vacant Commissary Shutter"
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bGE" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -15844,10 +15805,24 @@
 /turf/open/floor/carpet,
 /area/service/bar)
 "bHM" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/item/kirbyplants/random,
+/obj/machinery/bounty_board/directional/north,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bHN" = (
 /obj/structure/chair/sofa/left{
 	desc = "Made of very expensive furs, probably from an endangered animal.";
@@ -16193,32 +16168,49 @@
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bJj" = (
-/obj/machinery/shower{
-	pixel_y = 16
-	},
-/obj/item/soap/nanotrasen,
-/turf/open/floor/iron/white,
-/area/engineering/lobby)
 "bJk" = (
-/obj/machinery/shower{
-	pixel_y = 16
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/engineering/lobby)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bJm" = (
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
 /area/engineering/lobby)
 "bJn" = (
-/obj/structure/mirror/directional/east,
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 14
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
-/obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/iron,
 /area/engineering/lobby)
 "bJo" = (
 /obj/structure/stairs/south,
@@ -16413,10 +16405,7 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
+/obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "bKC" = (
@@ -16723,8 +16712,18 @@
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "bLY" = (
-/turf/closed/wall/r_wall,
-/area/engineering/gravity_generator)
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "commissaryshutter";
+	name = "Vacant Commissary Shutter"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "bMc" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -16998,9 +16997,8 @@
 /turf/open/floor/iron/white,
 /area/science)
 "bOA" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bOI" = (
 /obj/machinery/computer/warrant{
 	dir = 8
@@ -17037,8 +17035,15 @@
 /turf/open/floor/wood/large,
 /area/hallway/secondary/service)
 "bPA" = (
-/turf/open/floor/iron/white,
-/area/engineering/lobby)
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "bPB" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/event_spawn,
@@ -17107,6 +17112,9 @@
 	c_tag = "Aft Primary Hallway - Entrance";
 	name = "Hallway Camera"
 	},
+/obj/structure/sign/directions/supply{
+	pixel_x = 30
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bQp" = (
@@ -17122,13 +17130,29 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "bQr" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
 	},
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bQs" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/britcup,
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/dark,
+/area/medical/medbay/lobby)
+"bQt" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/sign/poster/official/random{
@@ -17136,37 +17160,39 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bQt" = (
+"bQu" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"bQv" = (
 /obj/item/stack/rods/ten,
 /obj/item/stack/sheet/plasteel,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bQu" = (
+"bQw" = (
 /obj/item/stack/sheet/iron/five,
 /obj/item/stack/cable_coil/five,
 /obj/item/circuitboard/computer/slot_machine,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bQv" = (
+"bQx" = (
 /obj/item/stack/rods/ten,
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 30
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bQw" = (
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/circuitboard/computer/arcade,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bQx" = (
-/obj/structure/frame/machine,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -17242,30 +17268,23 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"bRi" = (
-/turf/closed/wall,
-/area/engineering/lobby)
 "bRj" = (
-/obj/structure/curtain,
-/turf/open/floor/iron/white,
-/area/engineering/lobby)
-"bRm" = (
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
-	},
+/obj/effect/landmark/start/paramedic,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
-	dir = 8;
+	dir = 1;
 	name = "Command blue corner"
 	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
+"bRm" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/medbay/lobby)
 "bRw" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -17305,14 +17324,10 @@
 /turf/open/space/basic,
 /area/space)
 "bRP" = (
-/obj/structure/sink{
-	dir = 1;
-	layer = 2.7;
-	pixel_y = -8
-	},
+/obj/machinery/holopad,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
-	dir = 8;
+	dir = 1;
 	name = "Command blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -17321,7 +17336,7 @@
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/area/medical/medbay/lobby)
 "bRQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -17337,12 +17352,23 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bRS" = (
-/obj/item/stack/sheet/cardboard{
-	amount = 14
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bRT" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/starboard)
+"bRU" = (
 /obj/item/stack/sheet/glass{
 	amount = 20;
 	pixel_x = -3;
@@ -17351,16 +17377,14 @@
 /obj/item/stack/rods/ten,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bRU" = (
-/obj/structure/frame/machine,
-/obj/item/stack/sheet/iron/five,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bRV" = (
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/five,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bSh" = (
 /obj/structure/table,
 /obj/item/pipe_dispenser,
@@ -17496,17 +17520,8 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/lawoffice)
-"bTB" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
 "bTC" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall,
 /area/engineering/gravity_generator)
 "bTJ" = (
 /obj/machinery/door/airlock{
@@ -17624,6 +17639,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
+"bUp" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "bUr" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -17656,16 +17677,20 @@
 /turf/open/floor/plating,
 /area/construction)
 "bUB" = (
-/obj/structure/sign/poster/contraband/random{
+/obj/structure/sign/poster/official/random{
 	pixel_y = 30
 	},
+/obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUC" = (
-/obj/item/stack/cable_coil/five,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bUD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17719,23 +17744,32 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bVh" = (
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bVi" = (
-/obj/effect/turf_decal/trimline/blue/line{
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
+"bVj" = (
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"bVj" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Gravity Generator";
-	name = "Gravity Camera";
-	network = list("ss13","engineer")
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "bVl" = (
 /obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
@@ -17845,6 +17879,10 @@
 "bVN" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"bVQ" = (
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "bVR" = (
 /obj/structure/railing{
 	dir = 8
@@ -17865,11 +17903,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bVW" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/hallway/primary/starboard)
 "bVY" = (
 /obj/structure/cable,
 /obj/structure/reagent_dispensers/watertank,
@@ -17933,10 +17968,15 @@
 /turf/open/floor/iron,
 /area/science)
 "bWy" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/machinery/door/airlock/external{
+	name = "External Airlock";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/starboard)
 "bWD" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -17992,11 +18032,19 @@
 /turf/closed/wall/r_wall,
 /area/engineering/storage_shared)
 "bXp" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/server)
-"bXq" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/computer)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "bXs" = (
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
@@ -18078,15 +18126,11 @@
 /turf/open/floor/carpet/green,
 /area/service/library)
 "bXO" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
 "bXP" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -18100,67 +18144,102 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "bYp" = (
-/obj/machinery/blackbox_recorder,
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"bYq" = (
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"bYr" = (
-/obj/machinery/telecomms/server/presets/medical,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"bYs" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/server";
-	dir = 1;
-	name = "Telecomms Server APC";
-	pixel_y = 23
+/obj/structure/stairs/north,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/plating,
+/area/engineering/storage_shared)
+"bYq" = (
+/obj/effect/turf_decal/siding/wideplating/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"bYr" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"bYs" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 5
+	},
+/obj/machinery/computer/warrant{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bYt" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/machinery/light/directional/north,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bYu" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/grass,
 /area/science/genetics)
 "bYv" = (
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "bYx" = (
-/obj/machinery/announcement_system,
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
-"bYy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/siding/wideplating{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
-"bYz" = (
-/obj/structure/filingcabinet,
-/obj/item/radio/intercom/directional/north{
-	freerange = 1
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"bYy" = (
+/obj/item/toy/plush/bubbleplush,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"bYz" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 10
+	},
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bYC" = (
-/obj/machinery/telecomms/bus/preset_two,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bYD" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/computer/arcade/battle{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bYM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemical Storage";
@@ -18190,36 +18269,30 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "bYV" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Aft Primary Hallway - Central";
-	name = "Hallway Camera"
-	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/table,
+/obj/item/folder/blue,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/primary/central)
 "bYX" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/stack/cable_coil,
-/obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/bounty_board/directional/south,
+/obj/structure/table,
+/obj/item/taperecorder,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "bYZ" = (
-/obj/effect/landmark/xeno_spawn,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/light/directional/south,
+/obj/structure/chair/stool/directional/east,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "bZa" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/machinery/camera/directional/east{
-	c_tag = "Commissary";
-	name = "Commissary camera";
-	network = list("ss13","cargo")
-	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/structure/table,
+/obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "bZc" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -18247,9 +18320,10 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "bZp" = (
-/obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/area/hallway/primary/central)
 "bZt" = (
 /obj/structure/rack,
 /obj/item/clothing/glasses/sunglasses,
@@ -18289,46 +18363,37 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "bZL" = (
-/obj/machinery/telecomms/processor/preset_one,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bZM" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
-"bZN" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+/obj/item/toy/plush/narplush,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bZO" = (
-/obj/machinery/telecomms/receiver/preset_right,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "bZP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science)
-"bZQ" = (
-/obj/machinery/computer/message_monitor{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
-"bZR" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
 "bZU" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
 "bZY" = (
-/obj/machinery/telecomms/processor/preset_two,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/space_heater,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cad" = (
 /obj/structure/window{
 	dir = 8
@@ -18344,17 +18409,13 @@
 /obj/effect/spawner/random/techstorage/engineering_all,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"caf" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "cag" = (
-/obj/item/storage/secure/safe/directional/south,
-/turf/open/floor/iron,
-/area/commons/vacant_room/commissary)
+/obj/machinery/door/airlock{
+	id_tag = "commissarydoor";
+	name = "Commissary"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cai" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -18382,15 +18443,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cau" = (
-/obj/machinery/door/airlock/mining{
-	name = "Commissary";
-	req_one_access_txt = "12;31"
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/space/basic,
 /area/maintenance/starboard/aft)
 "caw" = (
 /turf/closed/wall,
@@ -18419,34 +18476,44 @@
 /turf/open/floor/plating,
 /area/construction)
 "caH" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
-"caI" = (
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"caJ" = (
-/obj/machinery/telecomms/server/presets/science,
 /obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"caK" = (
-/obj/machinery/telecomms/server/presets/supply,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"caL" = (
-/obj/machinery/computer/telecomms/server{
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
+"caI" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
 	dir = 4;
-	network = "tcommsat"
+	name = "Engineering yellow corner"
 	},
-/turf/open/floor/circuit,
-/area/tcommsat/computer)
-"caM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
+"caJ" = (
+/turf/closed/wall,
+/area/commons/vacant_room/commissary)
+"caK" = (
+/obj/machinery/button/door/directional/north{
+	id = "commissaryshutter";
+	name = "Commisary Shutter Control"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "caO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18454,19 +18521,12 @@
 "caU" = (
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"caV" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/obj/item/radio/off,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "caZ" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasmarglass{
 	amount = 15
 	},
 /obj/machinery/light/directional/east,
-/obj/item/toy/plush/ratplush,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cbc" = (
@@ -18475,12 +18535,17 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cbd" = (
-/obj/structure/mirror/directional/east,
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 14
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron/white,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/iron,
 /area/engineering/lobby)
 "cbf" = (
 /obj/machinery/newscaster/directional/west,
@@ -18591,18 +18656,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/storage)
-"cbY" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
 "cbZ" = (
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
@@ -18611,10 +18664,9 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "cce" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/tcommsat/server)
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "ccl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -18624,14 +18676,6 @@
 /obj/effect/spawner/random/techstorage/rnd_all,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cco" = (
-/obj/machinery/door/airlock/command{
-	name = "Telecomms Control Room";
-	req_access_txt = "19; 61"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
 "ccr" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/cable,
@@ -18692,6 +18736,10 @@
 /area/science)
 "ccC" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ccD" = (
@@ -18852,19 +18900,14 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "cdl" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/machinery/power/apc{
+	areastring = "/area/commons/vacant_room/commissary";
 	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
+	name = "Vacant Commissary APC";
+	pixel_y = 25
 	},
 /turf/open/floor/iron,
-/area/engineering/storage_shared)
+/area/commons/vacant_room/commissary)
 "cdm" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/tile/yellow{
@@ -18877,25 +18920,34 @@
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cdo" = (
-/obj/machinery/firealarm/directional/north,
+/obj/machinery/newscaster/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
+"cdp" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
 	name = "Engineering yellow corner"
 	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
-"cdp" = (
-/obj/structure/stairs/east,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cdq" = (
@@ -18905,44 +18957,20 @@
 /obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"cdr" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "cds" = (
-/obj/machinery/power/terminal{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"cdt" = (
-/obj/machinery/ntnet_relay,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"cdu" = (
-/obj/machinery/telecomms/hub/preset,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"cdw" = (
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
-"cdx" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room";
-	req_access_txt = "61"
-	},
-/turf/open/floor/iron/dark,
-/area/tcommsat/computer)
-"cdy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /turf/open/floor/iron,
-/area/tcommsat/computer)
+/area/engineering/storage_shared)
+"cdu" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/vendor,
+/obj/item/circuitboard/machine/vendor,
+/obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cdA" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -18950,23 +18978,9 @@
 /turf/open/floor/iron,
 /area/command/gateway)
 "cdB" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
@@ -18974,16 +18988,6 @@
 "cdC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -19001,20 +19005,10 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cdF" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Server Room";
-	req_access_txt = "61"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/tcommsat/server)
-"cdG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/tcommsat/computer)
+/area/commons/vacant_room/commissary)
 "cdM" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -19027,13 +19021,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cdU" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "cdX" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -19200,45 +19187,44 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ceX" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "ceY" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 30
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
+"cfc" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator Room";
+	req_access_txt = "19;23"
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"cfb" = (
-/obj/machinery/camera/directional/west{
-	c_tag = "Telecomms Server";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"cfc" = (
-/obj/structure/sign/poster/official/safety_internals{
-	pixel_x = -30
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/space/basic,
+/area/engineering/gravity_generator)
 "cff" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/geneticist,
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "cfg" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/engineering/lobby)
+/obj/structure/rack,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/stack/cable_coil,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "cfh" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow{
@@ -19248,11 +19234,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
@@ -19267,17 +19248,6 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cfw" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Telecomms Control";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "cfz" = (
 /obj/structure/chair{
 	dir = 8
@@ -19362,14 +19332,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/genetics)
-"cge" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
 "cgj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -19384,21 +19346,32 @@
 /turf/open/floor/plating,
 /area/construction)
 "cgl" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/structure/cable,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cgm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/obj/item/circuitboard/computer/arcade,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cgp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
@@ -19416,30 +19389,27 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "cgr" = (
-/obj/machinery/telecomms/server/presets/command,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cgs" = (
-/obj/machinery/telecomms/server/presets/common,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/structure/frame/machine,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cgt" = (
-/obj/structure/table,
-/obj/item/storage/firstaid/regular,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
-"cgu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cgz" = (
 /turf/closed/wall,
 /area/maintenance/starboard)
@@ -19447,31 +19417,16 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "cgB" = (
-/obj/structure/reagent_dispensers/fueltank/large,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cgH" = (
@@ -19487,16 +19442,6 @@
 /obj/effect/spawner/random/techstorage/service_all,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"cgL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
 "cgM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -19518,9 +19463,10 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cgQ" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "cgS" = (
 /obj/structure/table,
 /obj/item/stack/sticky_tape,
@@ -19635,24 +19581,11 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "chx" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
+/obj/effect/landmark/event_spawn,
+/obj/structure/chair/stool/directional/west,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/engineering/storage_shared)
+/area/commons/vacant_room/commissary)
 "chz" = (
 /obj/structure/sink{
 	dir = 8;
@@ -19668,17 +19601,38 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "chA" = (
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Storage";
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "chB" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "chC" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+/obj/structure/rack,
+/obj/item/flashlight,
+/obj/machinery/camera/directional/east{
+	c_tag = "Commissary";
+	name = "Commissary camera";
+	network = list("ss13","cargo")
+	},
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "chD" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -19687,27 +19641,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "chE" = (
-/obj/machinery/computer/telecomms/monitor{
-	dir = 4;
-	network = "tcommsat"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
-"chF" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "chG" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -19725,7 +19668,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "chH" = (
-/obj/structure/closet/secure_closet/engineering_welding,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -19772,17 +19714,21 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "chO" = (
-/obj/machinery/telecomms/processor/preset_four,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
-"chS" = (
-/obj/structure/closet/firecloset,
-/obj/item/radio/off,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_one_access_txt = "10; 24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/tcommsat/computer)
+/area/maintenance/port/aft)
 "chU" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/machinery/firealarm/directional/east,
@@ -19843,11 +19789,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ciw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
 "cix" = (
 /obj/machinery/component_printer,
 /obj/effect/turf_decal/tile/purple,
@@ -19872,7 +19813,7 @@
 /turf/open/floor/iron/white,
 /area/science)
 "ciC" = (
-/obj/effect/mob_spawn/human/skeleton,
+/obj/effect/mob_spawn/corpse/human/skeleton,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -19936,17 +19877,11 @@
 /turf/open/floor/iron/white,
 /area/science)
 "ciJ" = (
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
+/obj/item/stack/sheet/cardboard{
+	amount = 14
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ciK" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
@@ -20015,28 +19950,21 @@
 /turf/open/floor/iron/white,
 /area/science)
 "cjd" = (
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cje" = (
+/obj/structure/frame/machine,
+/obj/item/stack/sheet/iron/five,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cjf" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"cji" = (
 /obj/structure/rack,
-/obj/item/stock_parts/cell/emproof,
-/obj/item/stock_parts/cell/emproof,
-/obj/item/stock_parts/cell/emproof,
+/obj/item/stock_parts/cell/high/plus,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -20049,40 +19977,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
-"cjf" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
-"cji" = (
-/obj/structure/rack,
-/obj/item/stock_parts/cell/high/plus,
-/obj/machinery/light_switch/directional/south,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
@@ -20092,7 +19986,6 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -20105,41 +19998,68 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cjm" = (
-/obj/machinery/telecomms/bus/preset_three,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 4;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 1;
+	name = "dark corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "cjn" = (
-/obj/machinery/telecomms/server/presets/security,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 1;
+	name = "dark corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "cjo" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/obj/machinery/light/directional/south,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering Hall - Hallway W";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "cjq" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/multitool,
-/obj/item/screwdriver,
-/obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/sink{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = -8
 	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cjr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
-	name = "Telecomms Monitoring APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cju" = (
-/obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -20167,10 +20087,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"cjy" = (
-/obj/machinery/telecomms/bus/preset_four,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
 "cjA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -20178,26 +20094,16 @@
 /turf/open/floor/plating,
 /area/construction)
 "cjB" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Power Storage";
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "cjC" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/obj/machinery/camera/directional/south{
+	c_tag = "Gravity Generator Lower";
+	name = "Gravity Camera";
+	network = list("ss13","engineer")
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cjE" = (
 /obj/structure/rack,
 /obj/item/stock_parts/subspace/transmitter,
@@ -20224,19 +20130,13 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "cjL" = (
-/obj/structure/closet/emcloset,
-/obj/item/radio/off,
-/obj/machinery/requests_console/directional/east{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC"
+/obj/machinery/shower{
+	dir = 8;
+	name = "emergency shower";
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cjM" = (
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -20252,9 +20152,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cjX" = (
-/obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/port/aft)
 "cjY" = (
 /obj/item/stack/sheet/cardboard,
 /obj/structure/rack,
@@ -20353,14 +20253,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ckv" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering Hall - CE Office";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
@@ -20377,19 +20269,13 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ckx" = (
-/obj/machinery/vending/modularpc,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
+/obj/item/radio/intercom/directional/south,
+/obj/structure/table,
+/obj/item/circuitboard/machine/paystand,
+/obj/item/stack/cable_coil/five,
+/obj/item/stack/sheet/iron/five,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/commons/vacant_room/commissary)
 "cky" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -20460,19 +20346,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ckR" = (
-/obj/machinery/door/airlock/engineering,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/engineering/gravity_generator)
 "ckS" = (
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/floor/circuit,
@@ -20582,9 +20457,22 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "clj" = (
-/turf/closed/wall{
-	layer = 3
+/obj/structure/sink{
+	dir = 1;
+	layer = 2.7;
+	pixel_y = -8
 	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 4;
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "clk" = (
 /obj/effect/landmark/start/scientist,
@@ -20651,22 +20539,11 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "clu" = (
-/obj/item/clothing/gloves/color/yellow,
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
+/obj/item/storage/secure/safe/directional/south,
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/spawner/random/bureaucracy/briefcase,
 /turf/open/floor/iron,
-/area/engineering/storage_shared)
+/area/commons/vacant_room/commissary)
 "clw" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -20682,7 +20559,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "clz" = (
-/obj/machinery/vending/engivend,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 4;
@@ -20693,9 +20569,8 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -20730,39 +20605,17 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "clG" = (
-/obj/machinery/status_display/evac/directional/north,
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/crowbar,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "clI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering Hall - Escape Pod";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "clV" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Engineering Hall - Telecomms";
@@ -20851,10 +20704,11 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cml" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/maintenance/port/aft)
 "cmm" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
@@ -20930,13 +20784,13 @@
 /turf/open/floor/iron/white,
 /area/science)
 "cmD" = (
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "supply dock loading door"
-	},
 /obj/machinery/conveyor{
 	dir = 1;
 	id = "QMLoad2"
+	},
+/obj/machinery/door/poddoor{
+	id = "cargoload";
+	name = "supply dock loading door"
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -20981,22 +20835,10 @@
 /turf/open/space/basic,
 /area/maintenance/solars/port/aft)
 "cmQ" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cmU" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -21098,11 +20940,10 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "cnx" = (
-/obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
 	id = "QMLoad"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/cargo/storage)
 "cny" = (
 /obj/structure/closet/secure_closet/cytology,
@@ -21155,36 +20996,20 @@
 /turf/open/floor/iron/dark,
 /area/science/cytology)
 "cnN" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cnO" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/nuke_storage)
 "cnP" = (
-/obj/structure/tank_dispenser/oxygen,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/storage_shared)
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cnT" = (
 /obj/structure/closet/firecloset,
 /obj/structure/railing{
@@ -21276,10 +21101,12 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "cok" = (
-/obj/machinery/conveyor{
-	id = "QMLoad"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/arrows,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "coy" = (
 /obj/structure/cable,
@@ -21347,10 +21174,10 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "coG" = (
-/obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel/airless,
-/area/maintenance/solars/port/aft)
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "coH" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -21445,24 +21272,9 @@
 /turf/open/floor/iron/dark,
 /area/science/cytology)
 "cpk" = (
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "QMLoad2"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/cargo/storage)
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cpl" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -21578,7 +21390,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cqe" = (
-/obj/structure/closet/crate,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cql" = (
@@ -21645,26 +21458,41 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cqK" = (
-/obj/structure/plasticflaps/opaque,
 /obj/machinery/conveyor{
-	dir = 1;
+	dir = 9;
 	id = "QMLoad2"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/cargo/storage)
 "cqO" = (
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
 	dir = 4;
-	name = "Engineering yellow corner"
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
 	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/security/checkpoint/engineering)
 "cqS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -21748,23 +21576,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "crE" = (
-/obj/machinery/door/airlock/atmos{
-	name = "Atmospherics";
-	req_access_txt = "24"
-	},
 /obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "crF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -21785,28 +21600,22 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "crJ" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Engineering Hall - Atmos Entrance";
-	name = "Engineering Camera";
-	network = list("ss13","engineering")
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 8;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
 	dir = 4;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/security/checkpoint/engineering)
 "crP" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -21815,20 +21624,23 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "crQ" = (
-/obj/machinery/conveyor{
-	dir = 1;
+/obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
 	},
-/obj/machinery/door/poddoor{
-	id = "cargoload";
-	name = "supply dock loading door"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "crU" = (
-/obj/structure/bed/roller,
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
+/turf/closed/wall{
+	layer = 3
+	},
+/area/medical/treatment_center)
 "crY" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 8
@@ -21949,10 +21761,9 @@
 /turf/closed/wall,
 /area/science/mixing)
 "csv" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/area/maintenance/solars/port/aft)
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "csx" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/turf_decal/tile/blue{
@@ -21990,19 +21801,22 @@
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
 "csK" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Post - Engineering";
-	req_access_txt = "63"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
 	dir = 1;
-	name = "Engineering yellow corner"
+	name = "Security red corner"
 	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
+	dir = 8;
 	name = "Security red corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "csL" = (
@@ -22065,30 +21879,12 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "csV" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/machinery/requests_console/directional/north{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo Bay Requests Console"
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/obj/item/stamp{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/stamp/denied{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "csW" = (
 /obj/machinery/light_switch/directional/west,
 /obj/structure/closet,
@@ -22131,21 +21927,14 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "cta" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "QMLoad2"
-	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/cargo/storage)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "ctb" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -22221,17 +22010,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/nuke_storage)
 "ctw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/machinery/power/solar_control{
-	dir = 4;
-	id = "aftport";
-	name = "Aft Port Solars Control"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ctx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -22255,7 +22039,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ctz" = (
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "ctD" = (
@@ -22368,34 +22151,11 @@
 /area/cargo/storage)
 "cub" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
+/obj/item/storage/cans/sixbeer,
+/obj/effect/spawner/random/decoration/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cud" = (
-/obj/structure/table,
-/obj/item/radio/off,
-/obj/item/screwdriver,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 4;
@@ -22403,17 +22163,17 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cue" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/computer/security/telescreen{
-	name = "Security Engineering monitor";
-	network = list("engineering","atmos");
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 1;
@@ -22428,6 +22188,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cuf" = (
@@ -22436,10 +22197,12 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "cuj" = (
-/obj/machinery/power/terminal,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cuk" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22456,36 +22219,24 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "cuq" = (
-/obj/machinery/computer/cargo,
-/obj/machinery/button/door/directional/east{
-	id = "cargounload";
-	layer = 3.3;
-	name = "Unloading Doors";
-	pixel_x = -8;
-	pixel_y = 24;
-	req_access_txt = "31"
-	},
-/obj/machinery/button/door/directional/east{
-	id = "cargoload";
-	layer = 3.3;
-	name = "Loading Doors";
-	pixel_x = 8;
-	pixel_y = 24;
-	req_access_txt = "31"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
 	},
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/engineering/lobby)
 "cur" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -22542,12 +22293,12 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "cuv" = (
-/obj/structure/bed/roller,
-/obj/structure/window{
-	dir = 4
+/obj/machinery/camera/directional/west{
+	c_tag = "Aft Primary Hallway - Central";
+	name = "Hallway Camera"
 	},
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "cuw" = (
 /obj/structure/table/optable,
 /turf/open/floor/iron/dark,
@@ -22579,10 +22330,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
-"cuC" = (
-/obj/effect/landmark/start/depsec/engineering,
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/engineering)
 "cuD" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -22606,53 +22353,40 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cuJ" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_one_access_txt = "10;24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/obj/structure/table,
+/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cuK" = (
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 4;
-	name = "dark corner"
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cuL" = (
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
 	dir = 1;
-	name = "dark corner"
+	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 4;
-	name = "dark corner"
-	},
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cuR" = (
@@ -22667,6 +22401,13 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "cuW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cvb" = (
@@ -22686,15 +22427,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cve" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Internal Airlock";
-	req_access_txt = "24"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
+/obj/structure/table,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/maintenance/port/aft)
 "cvh" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -22708,18 +22443,16 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
-"cvi" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
+"cvj" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
-	dir = 8;
+	dir = 1;
 	name = "Security red corner"
 	},
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
-	dir = 1;
+	dir = 8;
 	name = "Security red corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -22728,23 +22461,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
-"cvj" = (
-/obj/structure/cable,
-/obj/effect/landmark/start/depsec/engineering,
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/engineering)
 "cvk" = (
-/obj/machinery/holopad,
-/obj/structure/cable,
-/obj/effect/landmark/start/depsec/engineering,
-/turf/open/floor/iron/dark,
-/area/security/checkpoint/engineering)
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/costume,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cvl" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/effect/landmark/start/depsec/engineering,
+/obj/structure/chair/office,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "cvs" = (
@@ -22817,40 +22541,24 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cvy" = (
-/obj/machinery/conveyor_switch/oneway{
-	dir = 1;
-	id = "QMLoad"
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cvz" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad2"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/box/corners{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/engineering/storage_shared)
 "cvC" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Access";
@@ -22900,12 +22608,9 @@
 /turf/open/floor/carpet/green,
 /area/service/library)
 "cvT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Engineering Maintenance";
-	req_one_access_txt = "10; 24"
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
+	dir = 4;
 	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -22913,33 +22618,61 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/stairs/north,
 /turf/open/floor/iron,
-/area/maintenance/port/aft)
+/area/engineering/storage_shared)
 "cvV" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
 "cvW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/machinery/power/smes,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/area/engineering/storage_shared)
 "cwh" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cwi" = (
-/obj/machinery/door/airlock/external{
-	name = "Atmospherics Internal Airlock";
-	req_access_txt = "24"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cwk" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/multiz/cyan/visible/layer4,
@@ -22977,44 +22710,36 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cwr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	name = "Engineering yellow corner"
-	},
-/obj/machinery/button/door/atmos_test_room_mainvent_1{
-	pixel_y = -30
-	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/storage_shared)
 "cws" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
+	dir = 1;
 	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/storage_shared)
 "cwx" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
+/obj/machinery/power/smes,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cwy" = (
@@ -23023,45 +22748,36 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "cwz" = (
-/obj/structure/table,
-/obj/machinery/recharger,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 1;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
-	},
-/turf/open/floor/iron,
-/area/security/checkpoint/engineering)
-"cwA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/landmark/start/depsec/engineering,
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	dir = 8;
-	name = "Security red corner"
-	},
-/obj/effect/turf_decal/tile/red{
-	color = "#FF0000";
-	name = "Security red corner"
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
-	dir = 1;
 	name = "Engineering yellow corner"
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
+"cwA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -23070,9 +22786,6 @@
 	c_tag = "Security Post - Engineering";
 	name = "Security Post Camera";
 	network = list("ss13","engineering")
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /obj/machinery/requests_console/directional/south{
 	department = "Security";
@@ -23094,6 +22807,8 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cwC" = (
@@ -23150,12 +22865,12 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cwO" = (
 /obj/machinery/bounty_board/directional/south,
 /obj/machinery/rnd/production/techfab/department/cargo,
-/obj/structure/window/reinforced,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -23255,6 +22970,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/structure/closet/secure_closet/security/engine,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cxi" = (
@@ -23290,6 +23006,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cxr" = (
@@ -23308,6 +23025,9 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/table,
+/obj/item/radio/off,
+/obj/item/screwdriver,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cxu" = (
@@ -23335,15 +23055,30 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cxz" = (
-/turf/open/floor/plating,
-/area/engineering/lobby)
-"cxB" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/area/tcommsat/computer)
+"cxB" = (
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "cxI" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/turf_decal/arrows/white{
@@ -23375,17 +23110,6 @@
 "cxZ" = (
 /turf/closed/wall/r_wall,
 /area/cargo/office)
-"cya" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	req_one_access_txt = "10;24";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engineering/lobby)
 "cye" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/tile/purple{
@@ -23483,9 +23207,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cyA" = (
-/obj/machinery/door/poddoor/atmos_test_room_mainvent_1,
-/turf/open/floor/engine/airless,
-/area/engineering/atmos)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cyC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
@@ -23669,6 +23393,8 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "czF" = (
@@ -23941,9 +23667,22 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cAZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
@@ -23995,9 +23734,6 @@
 	color = "#FFD700";
 	dir = 8;
 	name = "Engineering yellow corner"
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -24136,11 +23872,22 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "cBG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
 "cBJ" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -24186,7 +23933,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cBY" = (
-/obj/item/toy/plush/bubbleplush,
+/obj/item/toy/plush/ratplush,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cBZ" = (
@@ -24198,6 +23945,16 @@
 	color = "#FFD700";
 	dir = 4;
 	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/camera/directional/east{
+	c_tag = "Engineering Hall - Atmos Entrance";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -24316,25 +24073,14 @@
 /turf/open/floor/iron,
 /area/maintenance/solars/port/aft)
 "cCq" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod";
-	req_one_access_txt = "10;24";
-	safety_mode = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/engineering/lobby)
+/area/tcommsat/computer)
 "cCs" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
 "cCF" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -24411,56 +24157,42 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "cDN" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 1;
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/storage_shared)
 "cDO" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	name = "dark corner"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000";
-	dir = 8;
-	name = "dark corner"
-	},
-/turf/open/floor/iron,
-/area/engineering/lobby)
-"cDQ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance";
-	req_one_access_txt = "10;24"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
+/obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
 	dir = 1;
-	name = "Engineering yellow corner"
+	name = "Security red corner"
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
+	},
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
 /turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/area/security/checkpoint/engineering)
+"cDQ" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "cDT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24489,16 +24221,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cEi" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/space/basic,
-/area/space)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/tcommsat/computer)
 "cEq" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -24545,35 +24271,57 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "cEQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/directional/south{
-	c_tag = "Solar Control - Port Aft";
-	name = "Solars Camera";
-	network = list("ss13","engineering")
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/area/engineering/storage_shared)
 "cES" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/rack,
+/obj/item/stock_parts/cell/emproof,
+/obj/item/stock_parts/cell/emproof,
+/obj/item/stock_parts/cell/emproof,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/area/engineering/storage_shared)
 "cET" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cEV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/structure/rack,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/maintenance/solars/port/aft)
+/area/engineering/storage_shared)
 "cFk" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/maintenance/solars/starboard/aft)
 "cFp" = (
-/obj/effect/landmark/start/depsec/engineering,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 1;
@@ -24588,6 +24336,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cFr" = (
@@ -24609,6 +24358,9 @@
 	color = "#FFD700";
 	dir = 1;
 	name = "Engineering yellow corner"
+	},
+/obj/machinery/computer/secure_data{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -24642,7 +24394,20 @@
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
 "cGS" = (
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/medical{
+	name = "Medbay Reception";
+	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 1;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "cGU" = (
 /obj/structure/lattice/catwalk,
@@ -24753,6 +24518,9 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
 "cIh" = (
@@ -25023,6 +24791,11 @@
 "cMv" = (
 /turf/open/floor/engine/airless,
 /area/engineering/atmos)
+"cMD" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "cMH" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -25405,30 +25178,51 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "cSL" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engineering/storage_shared";
-	name = "Engineering Shared Storage APC";
-	pixel_y = -24
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/structure/cable,
+/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cSM" = (
-/obj/machinery/light/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cSQ" = (
-/obj/structure/cable,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron,
+/area/engineering/storage_shared)
 "cSU" = (
 /obj/structure/rack,
 /obj/item/storage/box/halloween/edition_21/willard,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "cSW" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cSX" = (
@@ -25475,6 +25269,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"cVJ" = (
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "cVL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -25536,12 +25334,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cXb" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/random/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/closet/radiation,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cXf" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -25550,7 +25345,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cXn" = (
-/obj/effect/landmark/start/station_engineer,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Power Storage";
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "cXo" = (
@@ -25668,22 +25476,23 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cXC" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "cXI" = (
-/obj/machinery/holopad,
+/obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
-	dir = 4;
 	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "cXK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -25697,8 +25506,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/science/robotics/lab)
 "cXT" = (
-/obj/structure/reagent_dispensers/peppertank/directional/east,
-/obj/structure/closet/secure_closet/security/engine,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 8;
@@ -25718,6 +25525,10 @@
 	dir = 1;
 	name = "Engineering yellow corner"
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/filingcabinet,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/space/basic,
 /turf/open/floor/iron,
 /area/security/checkpoint/engineering)
@@ -25805,10 +25616,9 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "djJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/tcommsat/computer)
+/obj/structure/stairs/west,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "djZ" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -25855,32 +25665,30 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dst" = (
-/obj/effect/landmark/start/paramedic,
+/obj/structure/table,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
-	dir = 4;
+	dir = 8;
 	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
+	color = "#73c2fb";
+	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
+	color = "#73c2fb";
 	dir = 1;
-	name = "Command blue corner"
+	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white,
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "dtb" = (
-/obj/structure/cable,
-/obj/machinery/camera/directional/south{
-	c_tag = "Gravity Generator Antechamber";
-	name = "Gravity Camera";
-	network = list("ss13","engineer")
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/vending/modularpc,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "duA" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -25961,6 +25769,14 @@
 /obj/item/stock_parts/subspace/crystal,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"dyB" = (
+/obj/structure/closet/firecloset,
+/obj/item/radio/off,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "dzf" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/bluespace_vendor/directional/south,
@@ -25977,17 +25793,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dEZ" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 4;
-	name = "Engineering yellow corner"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
+/obj/machinery/vending/engivend,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "dFZ" = (
@@ -26070,19 +25876,40 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dJT" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
-"dKk" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 4;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/engineering/lobby)
+"dKk" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "dKI" = (
 /turf/closed/indestructible{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
@@ -26112,6 +25939,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/science/lab)
+"dMU" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	req_one_access_txt = "10;24";
+	safety_mode = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "dNd" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -26142,11 +25980,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "dQj" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/geiger_counter,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "dQJ" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron/dark/textured_large,
@@ -26306,8 +26144,18 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"epe" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "epN" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -26431,9 +26279,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"eIT" = (
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
 "eKn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -26443,7 +26288,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "eMa" = (
-/obj/structure/window/reinforced,
 /obj/machinery/autolathe,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -26478,13 +26322,27 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "eRf" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator Room";
-	req_access_txt = "19;23"
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering Hall - CE Office";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "eUZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -26593,19 +26451,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "feF" = (
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/gravity_generator)
 "feI" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -26637,12 +26489,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/brig)
+"fji" = (
+/obj/machinery/telecomms/broadcaster/preset_right,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "fju" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "fjL" = (
 /obj/machinery/smartfridge/organ,
 /obj/machinery/camera/directional/north{
@@ -26695,6 +26549,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"fpN" = (
+/obj/machinery/telecomms/broadcaster/preset_left,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "fqq" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -26741,6 +26599,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fte" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fvM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -26916,6 +26787,10 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"fIr" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "fIK" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -27057,6 +26932,20 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gel" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/tcommsat/server)
 "ghO" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/fyellow,
@@ -27091,18 +26980,29 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/medical/coldroom)
 "gkA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 4;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/engineering/lobby)
 "gmY" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
 	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -27186,13 +27086,34 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"grQ" = (
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "gsC" = (
 /turf/open/floor/iron,
 /area/commons/storage/tools)
 "gth" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/security/checkpoint/engineering)
 "gtO" = (
 /obj/structure/railing{
@@ -27200,23 +27121,11 @@
 	},
 /turf/open/floor/iron,
 /area/commons/lounge)
-"gum" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+"gup" = (
+/obj/machinery/blackbox_recorder,
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "guA" = (
 /obj/machinery/button/door/directional/north{
 	id = "solitary";
@@ -27256,13 +27165,17 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "gzx" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 6
+/obj/docking_port/stationary{
+	dwidth = 4;
+	height = 6;
+	id = "supply_home";
+	name = "Cargo Bay";
+	width = 12
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/space/basic,
+/area/space)
 "gBc" = (
-/obj/effect/mob_spawn/human/corpse,
+/obj/effect/mob_spawn/corpse/human,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -27334,6 +27247,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"gOi" = (
+/obj/machinery/telecomms/hub/preset,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "gOU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/directional/north{
@@ -27350,7 +27267,7 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/private_investigators_office)
 "gST" = (
-/obj/structure/reagent_dispensers/peppertank/directional/west,
+/obj/structure/reagent_dispensers/wall/peppertank/directional/west,
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
 	dir = 8;
@@ -27470,13 +27387,9 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "heb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/arrows,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "hek" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -27579,6 +27492,10 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"htf" = (
+/obj/machinery/telecomms/receiver/preset_right,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "hug" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral,
@@ -27645,10 +27562,20 @@
 /turf/open/floor/iron/white,
 /area/science)
 "hBj" = (
+/obj/effect/landmark/start/paramedic,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
 	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
+	name = "Command blue corner"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -27707,11 +27634,12 @@
 /turf/open/floor/iron/white,
 /area/science)
 "hJt" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/screwdriver,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "hKR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -27729,7 +27657,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hME" = (
@@ -27752,7 +27679,6 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "hNk" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
@@ -27760,6 +27686,11 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 1;
 	name = "Command blue corner"
 	},
 /turf/open/floor/iron/white,
@@ -27835,6 +27766,8 @@
 /area/science)
 "hVE" = (
 /obj/structure/table,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	name = "Medical blue corner"
@@ -27842,11 +27775,6 @@
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
 	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/dark,
@@ -27876,12 +27804,15 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "hXT" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/door/poddoor{
+	id = "cargounload";
+	name = "supply dock unloading door"
 	},
-/obj/effect/spawner/random/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/conveyor{
+	id = "QMLoad"
+	},
+/turf/open/floor/iron,
+/area/space)
 "hYF" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -27900,6 +27831,15 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/construction)
+"ibO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "ich" = (
 /obj/structure/window{
 	dir = 1
@@ -27956,6 +27896,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science)
+"iiV" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "ijl" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 30
@@ -28084,9 +28032,12 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "iAk" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
+	},
+/turf/open/floor/iron,
+/area/space)
 "iBu" = (
 /obj/item/toy/plush/nukeplushie,
 /obj/effect/turf_decal/tile/red{
@@ -28153,6 +28104,10 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/construction)
+"iLx" = (
+/obj/machinery/telecomms/server/presets/engineering,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "iNH" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -28171,6 +28126,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"iSu" = (
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "iUc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/crew_quarters/dorms";
@@ -28213,23 +28172,7 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "jaJ" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/bounty_board/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
-	},
-/turf/open/floor/iron/white,
+/turf/closed/wall/r_wall,
 /area/medical/medbay/lobby)
 "jbI" = (
 /obj/effect/spawner/random/maintenance/two,
@@ -28269,9 +28212,14 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "jfo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/pen,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "jgB" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 8
@@ -28301,6 +28249,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "jpa" = (
@@ -28373,6 +28322,7 @@
 "jtK" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jtQ" = (
@@ -28417,6 +28367,10 @@
 /obj/structure/stairs/east,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"jwR" = (
+/obj/machinery/telecomms/server/presets/science,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jxa" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -28438,15 +28392,22 @@
 /turf/open/floor/iron/white,
 /area/science)
 "jxV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jzb" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/cargo/storage)
+/obj/machinery/door/poddoor{
+	id = "cargoload";
+	name = "supply dock loading door"
+	},
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad2"
+	},
+/turf/open/floor/iron,
+/area/space)
 "jAq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -28546,11 +28507,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/cargo/office)
 "jNN" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/maintenance/solars/port/aft)
 "jOz" = (
 /obj/effect/turf_decal/tile/red{
 	color = "#FF0000";
@@ -28640,6 +28600,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"jRF" = (
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
+"jSm" = (
+/obj/machinery/telecomms/processor/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jSw" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -28685,6 +28652,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"jYs" = (
+/obj/machinery/telecomms/server/presets/service,
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "jYt" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -28800,14 +28772,19 @@
 "khA" = (
 /obj/effect/turf_decal/siding/wideplating,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"kjk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "kjN" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil,
+/turf/open/space/basic,
+/area/maintenance/solars/port/aft)
 "kpF" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Surgery Maintenance";
@@ -28890,6 +28867,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"kEI" = (
+/obj/machinery/telecomms/bus/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "kFa" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -29053,6 +29034,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"kVG" = (
+/obj/machinery/holopad,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "kWd" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -29086,12 +29072,29 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "lan" = (
-/obj/structure/bed/roller,
-/obj/structure/window{
-	dir = 8
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
 	},
-/turf/open/floor/iron/dark,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/neutral{
+	alpha = 255;
+	color = "#000000";
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 8;
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "lbR" = (
 /obj/effect/turf_decal/tile/purple{
 	color = "#4D0067";
@@ -29126,6 +29129,7 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office)
 "lfw" = (
+/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 1;
@@ -29256,6 +29260,13 @@
 /obj/item/trash/chips,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lzN" = (
+/obj/machinery/computer/message_monitor{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "lzP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -29272,6 +29283,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"lCd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "lFU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -29307,7 +29325,6 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/science/research)
 "lJc" = (
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
 	dir = 8;
@@ -29317,6 +29334,7 @@
 	color = "#FFD700";
 	name = "Engineering yellow corner"
 	},
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "lKC" = (
@@ -29379,15 +29397,16 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lPW" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
-/obj/machinery/photocopier,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/engineering/lobby)
 "lSC" = (
 /obj/structure/rack,
 /obj/item/stock_parts/micro_laser/high,
@@ -29576,19 +29595,28 @@
 /turf/open/floor/iron,
 /area/cargo/miningoffice)
 "mrE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 4;
 	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
+"msa" = (
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "mtB" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -29685,10 +29713,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mEK" = (
+/obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+	color = "#73c2fb";
+	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
@@ -29700,7 +29728,7 @@
 	dir = 8;
 	name = "Medical blue corner"
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "mGc" = (
 /obj/structure/closet/l3closet/scientist,
@@ -29730,15 +29758,33 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "mIa" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
-	dir = 4;
+	dir = 1;
 	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -29776,12 +29822,18 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mLq" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/engineering/lobby)
 "mOd" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -29818,11 +29870,18 @@
 /turf/open/floor/iron/white,
 /area/science)
 "mUd" = (
-/obj/structure/table,
-/obj/effect/spawner/random/maintenance,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 8;
+	name = "dark corner"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	name = "dark corner"
+	},
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "mVE" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -29862,11 +29921,15 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "ngs" = (
-/obj/effect/landmark/start/paramedic,
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
 	dir = 1;
 	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	dir = 8;
+	name = "Medical blue corner"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -30112,11 +30175,9 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "nGJ" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/crowbar,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/iron,
+/area/space)
 "nIY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -30165,10 +30226,13 @@
 /turf/open/floor/iron/white,
 /area/science)
 "nQl" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad2"
+	},
+/turf/open/floor/iron,
+/area/space)
 "nSe" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
@@ -30197,6 +30261,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"nVV" = (
+/obj/machinery/announcement_system,
+/obj/machinery/status_display/ai/directional/west,
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "nYG" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/external{
@@ -30228,6 +30297,10 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"occ" = (
+/obj/machinery/telecomms/server/presets/command,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "odg" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron,
@@ -30261,22 +30334,8 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "ogY" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 1;
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/closed/wall/r_wall,
+/area/tcommsat/computer)
 "ogZ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/wood{
@@ -30292,6 +30351,10 @@
 "omY" = (
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"opd" = (
+/obj/machinery/status_display/ai/directional/south,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "oqb" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil,
@@ -30419,17 +30482,39 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "oJL" = (
-/obj/structure/frame/machine,
-/obj/effect/turf_decal/bot_red,
-/obj/machinery/defibrillator_mount/directional/east,
-/turf/open/floor/iron/dark,
-/area/medical/treatment_center)
+/obj/machinery/door/airlock/engineering,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "oLR" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"oNx" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Server Room";
+	req_access_txt = "61"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "oOD" = (
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
@@ -30459,6 +30544,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"oRh" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = -30
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"oRy" = (
+/obj/machinery/telecomms/bus/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "oRH" = (
 /obj/structure/table,
 /obj/item/surgicaldrill,
@@ -30606,11 +30708,14 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "pjg" = (
-/obj/structure/sign/directions/supply{
-	pixel_x = 30
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod";
+	req_one_access_txt = "10;24";
+	safety_mode = 1
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "pjm" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
@@ -30639,7 +30744,6 @@
 "ple" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "plG" = (
@@ -30824,6 +30928,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"pHJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "pHK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Access";
@@ -30869,6 +30979,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"pOK" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "pOX" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -30903,6 +31017,34 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"pVq" = (
+/obj/machinery/power/solar_control{
+	dir = 8;
+	id = "aftport";
+	name = "Aft Port Solars Control"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
+"pVt" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/space)
 "pXf" = (
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
@@ -30916,6 +31058,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/medical)
+"pYO" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/south{
+	c_tag = "Solar Control - Port Aft";
+	name = "Solars Camera";
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
 "qay" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/computer/operating,
@@ -30965,9 +31117,22 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "qlV" = (
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/door/airlock/security{
+	name = "Security Post - Engineering";
+	req_access_txt = "63"
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	name = "Security red corner"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/checkpoint/engineering)
 "qna" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue{
@@ -31020,13 +31185,8 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "qsO" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/turf/closed/wall/r_wall,
+/area/space)
 "qsQ" = (
 /obj/structure/table,
 /obj/item/stock_parts/cell,
@@ -31130,11 +31290,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qJp" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/filingcabinet,
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "qJs" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
@@ -31166,7 +31324,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qNT" = (
-/obj/effect/spawner/random/structure/crate,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 30
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qPc" = (
@@ -31192,13 +31352,11 @@
 /turf/open/floor/carpet,
 /area/service/lawoffice)
 "qQD" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/item/radio/intercom/directional/north{
+	freerange = 1
 	},
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/tcommsat/computer)
 "qQK" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -31267,10 +31425,12 @@
 /turf/open/floor/iron/white,
 /area/security/checkpoint/medical)
 "qVC" = (
-/obj/structure/closet/cardboard,
-/obj/effect/spawner/costume,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/door/airlock/command{
+	name = "Telecomms Control Room";
+	req_access_txt = "19; 61"
+	},
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "qWj" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/brown{
@@ -31390,8 +31550,15 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "rkl" = (
-/turf/closed/wall,
-/area/commons/vacant_room/commissary)
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west{
+	c_tag = "Central Primary Hallway - Computers";
+	name = "Hallway Camera"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "rmz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -31497,9 +31664,7 @@
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
 "rwL" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 30
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rwY" = (
@@ -31513,6 +31678,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"rzc" = (
+/obj/machinery/ntnet_relay,
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "rCw" = (
 /obj/structure/cable,
 /obj/machinery/camera/directional/south{
@@ -31548,9 +31718,14 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "rGv" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "rKa" = (
 /obj/effect/spawner/costume/commie,
 /turf/open/floor/plating,
@@ -31561,6 +31736,12 @@
 /obj/item/reagent_containers/glass/bottle/nutrient/ez,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"rMU" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "rOd" = (
 /obj/effect/turf_decal/tile/yellow{
 	color = "#FFD700";
@@ -31597,6 +31778,15 @@
 "rPB" = (
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"rRA" = (
+/obj/machinery/computer/telecomms/monitor{
+	dir = 1;
+	network = "tcommsat"
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "rTh" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -31666,6 +31856,22 @@
 	},
 /turf/open/floor/iron,
 /area/security/processing)
+"scT" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/space)
 "sgG" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -31717,6 +31923,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"sjr" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "sjz" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light_switch/directional/west,
@@ -31769,6 +31983,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"spw" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "sqQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -31840,6 +32059,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/checkpoint/engineering)
 "szo" = (
@@ -31862,20 +32082,25 @@
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"sCF" = (
+/obj/structure/chair/office/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "sEl" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/paramedic,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 8;
-	name = "Command blue corner"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "sKe" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -31886,6 +32111,17 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/cargo/office)
+"sLU" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/space/basic,
+/area/space)
 "sMi" = (
 /obj/structure/rack,
 /obj/item/flashlight,
@@ -31945,6 +32181,22 @@
 /obj/item/electronics/airalarm,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"sVp" = (
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = -30
+	},
+/obj/structure/closet/emcloset,
+/obj/item/radio/off,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
+"sWv" = (
+/obj/machinery/telecomms/server/presets/common,
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "sWy" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
@@ -31983,6 +32235,18 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"tfu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "tgU" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plating,
@@ -31993,19 +32257,14 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "tiZ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	color = "#FFD700";
-	dir = 1;
-	name = "Engineering yellow corner"
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -30
+/obj/structure/table,
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/multitool,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/tcommsat/computer)
 "tkj" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/purple{
@@ -32127,6 +32386,26 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/security/processing)
+"tsX" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance";
+	req_one_access_txt = "10;24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	dir = 1;
+	name = "Engineering yellow corner"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	color = "#FFD700";
+	name = "Engineering yellow corner"
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
 "ttL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -32244,6 +32523,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"tBQ" = (
+/obj/structure/cable,
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Security Engineering monitor";
+	network = list("engineering","atmos");
+	pixel_y = -30
+	},
+/obj/structure/chair/office,
+/turf/open/floor/iron/dark,
+/area/security/checkpoint/engineering)
 "tET" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -32265,22 +32555,27 @@
 /turf/open/floor/iron/dark,
 /area/security/detectives_office/private_investigators_office)
 "tIB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/storage/firstaid/regular,
+/obj/item/screwdriver,
+/obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/tcommsat/computer)
 "tIW" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/medical/coldroom)
+"tLo" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "tMk" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -32293,11 +32588,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tMy" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/space)
 "tMB" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -32306,6 +32598,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
+"tNC" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/radio/off,
+/obj/item/folder/blue,
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "tQm" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -32390,25 +32689,39 @@
 /turf/open/floor/engine,
 /area/science/misc_lab/range)
 "ucH" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/west,
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 1;
+	name = "Security red corner"
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 8;
+	name = "Security red corner"
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 4
+	color = "#FFD700";
+	name = "Engineering yellow corner"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	color = "#FF0000";
+	dir = 4;
+	name = "Security red corner"
 	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/security/checkpoint/engineering)
 "ucU" = (
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"udC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "uef" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/siding/white,
@@ -32426,13 +32739,9 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "uez" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/geiger_counter,
-/obj/item/geiger_counter,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "uhZ" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue{
@@ -32505,6 +32814,11 @@
 "upj" = (
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"urk" = (
+/obj/machinery/telecomms/server/presets/medical,
+/obj/machinery/light/directional/west,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "urD" = (
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
@@ -32536,12 +32850,40 @@
 /obj/machinery/defibrillator_mount/directional/east,
 /turf/open/floor/iron/dark,
 /area/medical/treatment_center)
+"uvz" = (
+/turf/open/floor/iron/dark,
+/area/tcommsat/computer)
 "uwc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/machinery/requests_console/directional/north{
+	department = "Cargo Bay";
+	departmentType = 2;
+	name = "Cargo Bay Requests Console"
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/obj/item/stamp{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/space)
+"uxA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "uys" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/requests_console/directional/north{
@@ -32590,13 +32932,10 @@
 /turf/open/floor/wood/large,
 /area/service/bar/atrium)
 "uKX" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
+/mob/living/simple_animal/bot/cleanbot{
+	name = "C.L.E.A.N."
 	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "uLc" = (
@@ -32641,18 +32980,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "uTo" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "uTN" = (
@@ -32703,14 +33034,12 @@
 /area/cargo/storage)
 "uYP" = (
 /obj/structure/table,
-/obj/structure/cable,
+/obj/machinery/cell_charger,
+/obj/machinery/light/directional/north,
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
 	dir = 8;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
 	name = "Medical blue corner"
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -32735,6 +33064,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/detectives_office)
+"vcD" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 1;
+	network = "tcommsat"
+	},
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "vdZ" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /obj/item/radio/intercom/directional/north,
@@ -32759,6 +33095,14 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/green,
 /area/service/library)
+"veP" = (
+/obj/machinery/telecomms/bus/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
+"veT" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "vfs" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4;
@@ -32818,8 +33162,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/photocopier,
 /turf/open/floor/iron,
-/area/cargo/storage)
+/area/space)
 "vnE" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -32833,11 +33178,8 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vnH" = (
-/obj/structure/sink{
-	pixel_y = 20
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "vpR" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
@@ -32853,6 +33195,10 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"vqA" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/cargo/storage)
 "vrF" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -32912,16 +33258,8 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "vyQ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 8;
-	name = "Medical blue corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
-	},
+/obj/structure/chair/office/light,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/medical/medbay/lobby)
 "vyZ" = (
@@ -32931,16 +33269,34 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "vzH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	color = "#4169E1";
-	dir = 1;
-	name = "Command blue corner"
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_access_txt = "5"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#73c2fb";
-	dir = 4;
+	dir = 1;
 	name = "Medical blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#73c2fb";
+	name = "Medical blue corner"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 4;
+	name = "Command blue corner"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#4169E1";
+	dir = 8;
+	name = "Command blue corner"
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -32948,6 +33304,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"vCp" = (
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "vCx" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/door/firedoor,
@@ -32958,12 +33317,14 @@
 /turf/open/space/basic,
 /area/maintenance/solars/port/fore)
 "vEC" = (
-/obj/structure/cable,
-/obj/structure/sign/departments/examroom{
-	pixel_y = 30
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/space)
 "vED" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#4169E1";
@@ -32987,6 +33348,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/service/hydroponics/garden)
+"vFo" = (
+/obj/machinery/telecomms/processor/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "vFp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple{
@@ -33013,11 +33378,27 @@
 /turf/open/floor/iron/white,
 /area/science)
 "vKS" = (
-/obj/effect/turf_decal/trimline/blue/line{
+/obj/machinery/conveyor_switch/oneway{
+	dir = 1;
+	id = "QMLoad"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "vOj" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -33067,8 +33448,17 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vSn" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -33103,6 +33493,16 @@
 /obj/item/food/grown/garlic,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"vXL" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Telecomms Server";
+	name = "Engineering Camera";
+	network = list("ss13","engineering")
+	},
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "vXO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -33187,15 +33587,51 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"whZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/maintenance/solars/port/aft)
 "wiH" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "wjW" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/computer/cargo,
+/obj/machinery/button/door/directional/east{
+	id = "cargounload";
+	layer = 3.3;
+	name = "Unloading Doors";
+	pixel_x = -8;
+	pixel_y = 24;
+	req_access_txt = "31"
+	},
+/obj/machinery/button/door/directional/east{
+	id = "cargoload";
+	layer = 3.3;
+	name = "Loading Doors";
+	pixel_x = 8;
+	pixel_y = 24;
+	req_access_txt = "31"
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"wkc" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "wmN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -33274,6 +33710,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
+"wyG" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/circuit,
+/area/tcommsat/computer)
 "wzd" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow{
@@ -33352,10 +33792,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"wPr" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
 "wPu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -33408,6 +33844,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wSL" = (
+/obj/machinery/telecomms/processor/preset_one,
+/obj/structure/cable,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "wTg" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -33437,9 +33878,9 @@
 /turf/open/floor/iron,
 /area/security/processing)
 "wUZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
 "wXz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -33450,9 +33891,6 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "wZc" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -33463,20 +33901,17 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xbW" = (
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/obj/machinery/status_display/ai/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	name = "Medical blue corner"
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#73c2fb";
-	dir = 4;
-	name = "Medical blue corner"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/medical/medbay/lobby)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "xca" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/security_all,
@@ -33487,6 +33922,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xdu" = (
+/obj/machinery/telecomms/server/presets/security,
+/obj/machinery/light/directional/east,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "xfJ" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
@@ -33496,6 +33936,10 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/iron,
 /area/commons/lounge)
+"xhl" = (
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "xiS" = (
 /obj/effect/turf_decal/tile/neutral{
 	alpha = 255;
@@ -33562,6 +34006,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xkJ" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/server)
 "xlx" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights/mixed,
@@ -33622,6 +34069,13 @@
 "xuU" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab/range)
+"xwc" = (
+/obj/structure/cable,
+/obj/machinery/power/smes{
+	charge = 500000
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/tcommsat/server)
 "xxQ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -33677,16 +34131,25 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xIH" = (
-/obj/structure/table,
-/obj/item/storage/cans/sixbeer,
-/obj/effect/spawner/random/decoration/glowstick,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"xPk" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 30
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "QMLoad2"
 	},
-/obj/effect/spawner/random/trash/grille_or_waste,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/cargo/storage)
+"xPk" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xQB" = (
@@ -33724,6 +34187,10 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xWB" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "xXO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -33824,12 +34291,20 @@
 /turf/open/floor/iron,
 /area/commons/lounge)
 "ygU" = (
-/obj/machinery/shower{
-	dir = 4;
-	name = "emergency shower"
+/obj/structure/table,
+/obj/item/storage/bag/trash,
+/turf/open/floor/iron,
+/area/commons/vacant_room/commissary)
+"yhK" = (
+/obj/machinery/door/airlock/external{
+	name = "Atmospherics Internal Airlock";
+	req_access_txt = "24"
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/engineering/atmos)
 "yhT" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -44286,11 +44761,11 @@ aaa
 aaa
 aaa
 aaa
-aae
-aae
-aae
-aae
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -44543,11 +45018,11 @@ aaa
 aaa
 aaa
 aaa
-aae
-aak
-aak
-aak
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -44801,9 +45276,9 @@ aaa
 aaa
 aaa
 aaa
-aak
-coG
-aak
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -45050,22 +45525,22 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aae
 aae
 aae
 aae
 aaf
-aae
-aae
-aae
-aak
-aak
-cgj
-aak
-aak
-aae
-aae
-aak
-aae
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -45307,25 +45782,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aae
 aak
 aak
 aak
-aak
-aak
-aak
-aak
-aak
-cgj
-aaa
-aaa
-aaa
-aaa
-aaa
-aak
-aaj
-aaj
 aae
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -45563,26 +46038,26 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
-aae
+jNN
 aak
 aaa
-ceV
-ceV
-ceV
-ceV
-ceV
 aaa
-cgj
 aaa
-ceV
-ceV
-ceV
-ceV
-ceV
-aak
-aak
-aae
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -45822,24 +46297,24 @@ aaa
 aaa
 aaa
 aae
+aae
+aae
+aaf
+aae
+aae
+aae
 aak
-ceV
+aak
 cgj
-cgj
-cgj
-cgj
-cgj
-cmO
-cmO
-cmO
-cgj
-cgj
-cgj
-cgj
-cgj
-ceV
+aak
 aak
 aae
+aae
+aak
+aae
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -46080,22 +46555,22 @@ aaa
 aaa
 aae
 aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+cgj
 aaa
-ceV
-ceV
-ceV
-ceV
-ceV
 aaa
-cmO
 aaa
-ceV
-ceV
-ceV
-ceV
-ceV
+aaa
 aaa
 aak
+aaj
+aaj
 aae
 aaa
 aaa
@@ -46334,7 +46809,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aak
 aae
 aak
 aaa
@@ -46344,14 +46819,14 @@ ceV
 ceV
 ceV
 aaa
-cmO
+cgj
 aaa
 ceV
 ceV
 ceV
 ceV
 ceV
-aaa
+aak
 aak
 aae
 aaa
@@ -46610,7 +47085,7 @@ cgj
 cgj
 ceV
 aak
-aak
+aae
 aaa
 aaa
 aaa
@@ -46848,7 +47323,7 @@ aaa
 aaa
 aaa
 aaa
-aak
+aaa
 aae
 aak
 aaa
@@ -47123,7 +47598,7 @@ ceV
 ceV
 ceV
 aaa
-aaa
+aak
 aae
 aaa
 aaa
@@ -47329,6 +47804,9 @@ aaa
 aaa
 aaa
 aaa
+bBU
+bJk
+bBU
 aaa
 aaa
 aaa
@@ -47342,12 +47820,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bBU
+bJk
+bBU
 aaa
 aaa
 aaa
@@ -47381,7 +47856,7 @@ cgj
 cgj
 ceV
 aak
-aae
+aak
 aaa
 aaa
 aaa
@@ -47586,9 +48061,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+bBU
+bOA
+bBU
 aaa
 aaa
 aaa
@@ -47602,6 +48077,9 @@ aaa
 aaa
 aaa
 aaa
+bBU
+bOA
+bBU
 aaa
 aaa
 aaa
@@ -47616,11 +48094,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaf
+aak
+aae
 aak
 aaa
 ceV
@@ -47638,7 +48113,7 @@ ceV
 ceV
 aaa
 aak
-aak
+aae
 aaa
 aaa
 aaa
@@ -47842,10 +48317,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+fIK
+bBU
+bPA
+bBU
 fIK
 fIK
 fIK
@@ -47859,10 +48334,10 @@ fIK
 fIK
 fIK
 fIK
-aaa
-aaa
-aaa
-aaa
+bBU
+bPA
+bBU
+fIK
 aaa
 aaa
 aaa
@@ -47879,23 +48354,23 @@ aaa
 aaa
 aae
 aak
-aak
-aak
-aak
-aak
-aak
-aak
-aak
+aaa
+ceV
+ceV
+ceV
+ceV
+ceV
+aaa
 cmO
 aaa
+ceV
+ceV
+ceV
+ceV
+ceV
 aaa
 aaa
-aaa
-aaa
-aak
-aak
-aak
-aaa
+aae
 aaa
 aaa
 aaa
@@ -48100,9 +48575,9 @@ aaa
 aaa
 aaa
 fIK
-fIK
-fIK
-fIK
+qTU
+bLw
+bLw
 fIK
 aUf
 bLw
@@ -48116,15 +48591,15 @@ aVh
 bLw
 aXg
 fIK
-fIK
-fIK
-fIK
+bLw
+bLw
+qTU
 cjG
 cjG
 cjG
 cjG
-cjG
-cjG
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -48135,24 +48610,24 @@ aaa
 aaa
 aaa
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aaa
 aak
-csv
+ceV
+cgj
+cgj
+cgj
+cgj
+cgj
+cmO
+cmO
 cmO
 cgj
 cgj
 cgj
-aaa
-aaa
-aaa
-aaa
-aaa
+cgj
+cgj
+ceV
+aak
+aae
 aaa
 aaa
 aaa
@@ -48378,22 +48853,11 @@ bLw
 qTU
 bwU
 bGh
-bGh
-bGh
-bGh
+bEL
+cjG
 cjG
 aaa
 aaa
-aak
-aaa
-aak
-aaa
-aak
-aak
-aak
-aak
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -48402,14 +48866,25 @@ aaa
 aak
 aak
 aak
+aaf
+aak
 aaa
+ceV
+ceV
+ceV
+ceV
+ceV
 aaa
-cgj
+cmO
 aaa
+ceV
+ceV
+ceV
+ceV
+ceV
 aaa
-aaa
-aaa
-aaa
+aak
+aak
 aaa
 aaa
 aaa
@@ -48635,37 +49110,37 @@ qTU
 oFl
 lFU
 bGh
-bPf
-bEL
+bZY
 bGh
+cjG
 cjG
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aaa
+aaa
+aae
 aak
+aak
+aak
+aak
+aak
+aak
+aak
+aak
+cmO
+aaa
+aaa
+aaa
+aaa
 aaa
 aak
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cgj
-aaa
-aaa
-aaa
-aaa
+aak
+aak
 aaa
 aaa
 aaa
@@ -48893,31 +49368,31 @@ bGs
 bwU
 bwU
 jHB
-bEL
+bGh
 bGh
 cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-rGv
-rGv
-rGv
-rGv
-cjG
-cjG
+aaa
+aaa
+aak
+aaa
+aak
+aaa
 aak
 aaa
 aaa
+aae
+aae
+aae
+aae
+aae
+aae
+aae
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aak
+kjN
+cmO
+cgj
+cgj
 cgj
 aaa
 aaa
@@ -49152,20 +49627,20 @@ bwU
 bwU
 bEM
 bGh
-bEM
-bQr
-bEL
-qNT
-bEL
-bVW
 cjG
-cqe
-xIH
-mUd
-qlV
-qlV
-iAk
-cjG
+aaa
+aaa
+aak
+aaa
+aak
+aaa
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aaa
 aaa
@@ -49409,20 +49884,20 @@ bID
 bwU
 bEM
 bGh
-bEM
-bQs
-bEL
-bEL
-bEL
-bKg
 cjG
-bEL
-bNz
-bNz
-bNz
-bNz
-dQj
 cjG
+cjG
+cjG
+cjG
+cjG
+cjG
+aak
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aaa
 aaa
@@ -49666,20 +50141,20 @@ bIE
 bwU
 bLy
 bGh
-cjG
-cjG
-cjG
-cjG
-bUB
-bKg
-cjG
+bEM
+cgl
 bEL
+cjX
 bEL
-bEL
-bEL
-bEL
-bEL
+cnP
 cjG
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aak
 aaa
 aaa
@@ -49923,19 +50398,19 @@ bwU
 bwU
 bGh
 bGh
-cjG
-bQt
-bRS
 bEM
-bGh
-bGh
-ceW
-bGh
+bQt
 bEL
+bEL
+bEL
+bKg
+cjG
+cjG
 rwL
-bEL
-bEL
-bEL
+rwL
+rwL
+rwL
+cjG
 cjG
 aak
 aaa
@@ -50181,18 +50656,18 @@ pOX
 icD
 bEL
 cjG
-bQu
-bRT
-cjG
-bGh
-bEL
-cjG
-ceW
 cjG
 cjG
 cjG
+cml
+bKg
 cjG
-bHu
+csv
+cub
+cuJ
+cve
+cve
+cyA
 cjG
 aak
 aaa
@@ -50439,16 +50914,16 @@ bGh
 bEL
 cjG
 bQv
-bEL
-cjG
+ciJ
+bEM
 bGh
-bEL
-cjG
 bGh
-bEL
-bEL
-qVC
 cjG
+bEL
+bNz
+bNz
+bNz
+bNz
 xPk
 cjG
 aak
@@ -50699,14 +51174,14 @@ bQw
 bRU
 cjG
 bGh
-bPf
-cjG
-ceY
-bGh
-bEL
 bEL
 cjG
-bHu
+bEL
+bEL
+bEL
+bEL
+bEL
+bEL
 cjG
 aak
 aak
@@ -50953,17 +51428,17 @@ bLD
 bEL
 cjG
 bQx
-bRV
-cjG
-bGh
-bEM
-cjG
 bEL
+cjG
 bGh
+bEL
+ceW
+bGh
+bEL
 qNT
 bEL
-cjG
-bHu
+bEL
+bEL
 cjG
 cjG
 cjG
@@ -51209,16 +51684,16 @@ bwU
 bLD
 bEL
 cjG
-cjG
-cjG
+cgm
+cje
 cjG
 bGh
-bEM
+bPf
 cjG
-bHq
-bGh
-bEL
-bEL
+ceW
+cjG
+cjG
+cjG
 cjG
 bEL
 bEL
@@ -51230,9 +51705,9 @@ aaa
 aaa
 aaa
 aaa
-ctu
-cuJ
-ctu
+aaa
+cgj
+aaa
 aaa
 aaa
 aaa
@@ -51465,20 +51940,20 @@ bIF
 bwU
 ceP
 bEL
-bEL
-bEL
-bEL
-bwU
-bUC
+cjG
+cgs
+cjf
+cjG
+bGh
 bEM
 cjG
-hXT
-cgl
 bGh
-bGh
+bEL
+bEL
+cvk
 cjG
 bUB
-bEL
+cjG
 bGh
 bGh
 bGh
@@ -51486,9 +51961,9 @@ cjG
 cjG
 aaa
 aaa
-aak
+aaa
 ctu
-cAY
+tsX
 ctu
 aaa
 aaa
@@ -51728,14 +52203,14 @@ bGh
 pOX
 bGh
 bVY
-bwU
-bwU
-bwU
+cjG
+csV
+bGh
 bEL
-bGh
-ceW
-bGh
-bGh
+bEL
+cjG
+bHu
+cjG
 bGh
 bEL
 bGh
@@ -51985,13 +52460,13 @@ bEL
 bwU
 bEL
 bGh
+cjG
 bEL
+bGh
+cjX
 bEL
 cjG
-cjG
-cjG
-cjG
-cjG
+bHu
 cjG
 cjG
 cjG
@@ -51999,12 +52474,12 @@ cku
 cjG
 cjG
 bXs
-haR
-haR
+bXs
+aak
 ctu
-cDQ
+cAY
 ctu
-haR
+aaa
 aaa
 aaa
 aaa
@@ -52242,26 +52717,26 @@ bwU
 bwU
 bEL
 bGh
+cjG
+bHq
+bGh
 bEL
 bEL
 cjG
-chx
-clu
-cmQ
-cnN
-cnP
-cje
-bXo
+bEL
+bEL
+bEL
+cjG
 ctx
 azn
 coe
 azn
 cuD
-cvW
-cxB
-cAZ
-ctw
 haR
+ctu
+cAZ
+ctu
+aaa
 aaa
 aaa
 aaa
@@ -52499,16 +52974,16 @@ pyc
 bwU
 bwU
 bGh
-bGh
-cSL
 cjG
-cdl
-ceX
-ceX
-ceX
-cgm
-cjf
-bXo
+cSL
+cuj
+bGh
+bGh
+cjG
+cml
+bEL
+bEL
+cjG
 ckv
 coe
 coe
@@ -52516,9 +52991,9 @@ coe
 haR
 cwx
 cuW
-ctz
-cEQ
+whZ
 haR
+aaa
 aaa
 aaa
 aaa
@@ -52756,16 +53231,16 @@ pyc
 pyc
 bwU
 bGh
+bwU
+bwU
+bwU
 bEL
+bGh
+ceW
+bGh
+bGh
 bEL
 cjG
-cdm
-ceX
-ceX
-ceX
-cXn
-ciJ
-cjB
 cuK
 cyV
 cyV
@@ -52773,9 +53248,9 @@ cAX
 haR
 cxm
 ctz
-ctz
-cES
+pYO
 haR
+aaa
 aaa
 aaa
 aaa
@@ -53016,32 +53491,32 @@ bGh
 bEL
 bEL
 cjG
-cdo
-ceX
-ceX
-cSW
-ceX
-ciJ
-cjB
-cuL
+cjG
+cjG
+cjG
+cjG
+cku
+cjG
+cjG
+cdE
 caU
 cmU
 nlF
 cCo
 cxp
 cBh
-cBh
-cEV
+pVq
 haR
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
 aaa
 aaa
 aaa
@@ -53275,8 +53750,8 @@ bwU
 cjG
 cdm
 ceX
-ceX
-ceX
+cwh
+cBG
 cgp
 cji
 bXo
@@ -53289,16 +53764,16 @@ haR
 haR
 haR
 haR
-haR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ogY
+xkJ
+vCp
+jYs
+jSm
+vXL
+xhl
+urk
+vCp
+xkJ
 aaa
 aaa
 aaa
@@ -53531,31 +54006,31 @@ bEL
 bEL
 cjG
 bKA
-cbY
-cbY
-cge
-ceX
+cjd
+cjd
+cjd
+cEQ
 cjj
 bXo
-ckx
+cvh
 caU
 cmV
 cBc
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ogY
+qJp
+msa
+cVJ
+aUs
+nVV
+kjk
+vCp
+ajV
+ati
+fIr
+fpN
+jwR
+opd
+xkJ
 aaa
 aaa
 aaa
@@ -53788,31 +54263,31 @@ bEL
 bEL
 cjG
 cdp
-cdp
-bXo
+cvz
+cwi
 cjd
 cgB
 chG
 bXo
 clz
-cyW
+caU
 cmU
 cBd
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ogY
+qQD
+uvz
+uvz
+wyG
+lzN
+kjk
+vCp
+jRF
+veP
+fIr
+wSL
+bVQ
+fIr
+xkJ
 aaa
 aaa
 aaa
@@ -54045,31 +54520,31 @@ bEL
 bEL
 cjG
 cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cvh
+bXo
+cwr
+cjd
+cES
+bXo
+bXo
+eRf
+caU
 cmW
 lJc
-bXs
-bXs
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+ogY
+qVC
+cCq
+tNC
+aOl
+vcD
+kjk
+vCp
+jRF
+vCp
+vCp
+vCp
+jRF
+gup
+xkJ
 aaa
 aaa
 aaa
@@ -54301,32 +54776,32 @@ bGh
 bEL
 bEL
 bEL
-bEL
-bEL
-bEL
-bPd
-bEL
-bEL
-bEL
+cjG
 cvT
-cvh
+cws
+cjd
+cEV
+bXo
+dtb
+cmc
+caU
 cmU
 cmc
 cCq
 cxz
-cya
 cEi
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cEi
+cEi
+cCq
+kjk
+vCp
+jRF
+gOi
+jRF
+rzc
+cMD
+xwc
+xkJ
 aaa
 aaa
 aaa
@@ -54555,35 +55030,35 @@ bEL
 bEL
 bwU
 bGh
+bEL
+bEL
+bEL
 cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
-cjG
+bYp
+cjd
+cCs
+cSM
+bXo
 dEZ
+cBe
+caU
 cmU
 cBe
-bXs
-bXs
-bXs
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cCq
+rGv
+ibO
+dyB
+cEi
+sVp
+spw
+vCp
+bVQ
+fIr
+fIr
+fIr
+jRF
+veT
+xkJ
 aaa
 aaa
 aaa
@@ -54812,37 +55287,37 @@ bEL
 bEL
 bwU
 bGh
+bEL
+bEL
+bEL
 cjG
-bYv
-bYv
-cSM
 bYp
-cdr
-cfb
+cjd
+cjd
 caH
-bYv
-bYv
+cXn
+dJT
 bXp
-cvh
 cmU
-cmc
-bXs
+cmU
+lan
+oJL
+sEl
+kVG
+tLo
+oNx
+tfu
+gel
+fIr
+bVQ
+vFo
+vCp
+kEI
+jRF
+vCp
+xkJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cKk
-cve
-cKk
 aaa
 aaa
 aaa
@@ -55070,36 +55545,36 @@ bwU
 bwU
 pOX
 cjG
-bYq
-bZL
-cSQ
+cjG
+cjG
+cjG
 caI
 cds
 cSQ
-caI
+cgr
 chA
 cjm
-bXp
-clE
+caU
+caU
 cmU
-lJc
-bXs
+cmc
+cCq
+tiZ
+lCd
+aYf
+cEi
+spw
+spw
+vCp
+iLx
+fji
+vCp
+htf
+occ
+opd
+xkJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cKk
-fNz
-cKk
 aaa
 aaa
 aaa
@@ -55326,37 +55801,37 @@ bGh
 bGh
 bGh
 bGh
+bEL
+bEL
+bEL
 cjG
-bYr
-bZM
-caJ
 bYv
-cdt
-bZN
+cjd
+cjd
 cgr
-chB
+bXo
 cjn
-bXp
-clF
+caU
+caU
 cmU
 cmc
-bXs
+cCq
+tIB
+blj
+sCF
+rRA
+spw
+vCp
+vCp
+sWv
+oRy
+pOK
+iSu
+xdu
+vCp
+xkJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cKk
-fNz
-cKk
 aaa
 aaa
 aaa
@@ -55583,39 +56058,39 @@ bGh
 bwU
 bEL
 bGh
+bEL
+bEL
+bEL
 cjG
-bYs
-bZN
-bZN
-bYv
-caI
-bZN
-bYv
-bYv
-bYv
-bXp
-cvh
+cvW
+cwz
+cDN
+cSW
+bXo
+dKk
+caU
+fju
 cmU
 cmc
-coW
-coW
-coW
-coW
-coW
-coW
-coW
-coW
-coW
-coW
-coW
-coW
-coW
-cKk
-cKk
-cwi
-cKk
-cKk
-coW
+ogY
+ogY
+ogY
+ogY
+ogY
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+xkJ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -55840,18 +56315,18 @@ bGh
 bwU
 bEL
 bGh
+bEL
+bEL
+bEL
 cjG
-bYt
-bZO
-caK
-bYv
-cdu
-bZN
-cgs
-chC
+cjG
+cjG
+cjG
+cjG
+cjG
 cjo
-bXp
-clG
+caU
+caU
 cmU
 cmc
 coW
@@ -55865,18 +56340,18 @@ cIA
 cIA
 cIA
 cIA
-cIA
-cIA
-cIA
-tiZ
-cIA
-tiZ
-cwr
+aOM
 coW
-coW
-coW
-coW
-coW
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -56097,18 +56572,18 @@ bGh
 bwU
 bEL
 bGh
-cjG
-bYC
-bZY
-caI
-caI
-caI
-cSQ
-caI
+bEL
+bEL
+bEL
+bEL
+bEL
+bEL
+bPd
+bEL
 chO
-cjy
-bXp
-cvh
+cBe
+cxT
+cyW
 cmU
 cBc
 coW
@@ -56122,18 +56597,18 @@ bWq
 cql
 crj
 crj
-crj
-crj
-crj
-crj
-crj
-crj
-cJv
-ctU
-cyC
-cMv
-cMv
-cyA
+cyG
+cKk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -56354,20 +56829,20 @@ bGh
 bwU
 bEL
 bGh
+bEL
+bEL
+bEL
+bEL
+bEL
+bEL
 cjG
-bYv
-bYv
-bYv
-cce
-cdF
-cce
-bYv
-bYv
-bYv
-bXp
+cjG
+cjG
+ckR
+ckR
 clw
 cmU
-cmc
+lJc
 coW
 aOF
 crj
@@ -56379,18 +56854,18 @@ fNz
 fNz
 fNz
 fNz
-fNz
-fNz
-fNz
-fNz
-fNz
-crj
-cyG
+oRh
 cKk
-cMv
-cMv
-cMv
-cyA
+cKk
+cKk
+cKk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -56611,18 +57086,18 @@ bGh
 bwU
 bUI
 bGh
+bEL
+bEL
 cjG
-djJ
-djJ
-djJ
-djJ
-cdw
-djJ
-djJ
-djJ
-djJ
-bXq
-clI
+cjG
+cjG
+cjG
+cjG
+cXb
+cXb
+dQj
+ckR
+cnW
 cmX
 cBf
 coW
@@ -56636,18 +57111,18 @@ fNz
 fNz
 fNz
 fNz
-fNz
-fNz
-fNz
-fNz
-fNz
-crj
 cyG
-cKk
-cMv
-cMv
-cMv
-cyA
+iiV
+fNz
+fNz
+yhK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -56868,17 +57343,17 @@ bGh
 bwU
 bUJ
 bGh
-cjG
-bYx
-bZQ
-caL
+bEL
+bEL
+ckR
 djJ
-cdx
 djJ
+djJ
+cDQ
 cgt
 chE
 cjq
-bXq
+ckR
 cvh
 cmU
 cBg
@@ -56893,18 +57368,18 @@ fNz
 fNz
 fNz
 fNz
-fNz
-fNz
-fNz
-fNz
-fNz
-crj
-cJv
-aQb
-bEw
-cMv
-cMv
-cyA
+oRh
+cKk
+cKk
+cKk
+cKk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -57121,22 +57596,22 @@ bwU
 bwU
 bwU
 bwU
-pOX
+bGh
 bwU
 bEM
 bGh
-cjG
-bYy
-bZR
-caM
-djJ
-cdy
+bEL
+bEL
+ckR
+cgt
+cgt
+cgt
 cfc
-cgu
-chF
 cjr
-bXq
-cvh
+cjr
+cjr
+feF
+gkA
 cmU
 cBg
 coW
@@ -57150,18 +57625,18 @@ cvd
 crk
 crj
 crj
-crj
-crj
-crj
-crj
-crj
-crj
-aOj
-coW
-coW
-coW
-coW
-coW
+cyG
+cKk
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -57383,17 +57858,17 @@ bwU
 bwU
 pOX
 cjG
-bYz
-cdw
-cdw
-cco
-cdG
+bEL
+ckR
+cgt
+cgt
+cgt
 cgQ
-cgQ
-cgQ
+cgt
+cXC
 cjC
 ckR
-csM
+cdE
 cmU
 cBg
 coW
@@ -57407,14 +57882,14 @@ coZ
 cro
 crj
 cBs
-cHm
-cHm
-cHm
-cHm
-cHm
-cHm
-cws
+fte
 coW
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -57640,19 +58115,19 @@ bwU
 bUK
 bGh
 cjG
-bYD
-caf
-caV
-djJ
-cdU
-cfw
-cgL
-chS
+cjG
+ckR
+ckR
+ckR
+ckR
+ckR
 cjL
-bXq
+cjL
+cjL
+ckR
 cvh
 cmU
-cBi
+cBg
 coW
 ttL
 crj
@@ -57896,17 +58371,17 @@ bGh
 bwU
 bUL
 bGh
+cqe
 cjG
-cjG
-bXs
-bXs
-bXs
-bXs
-bXs
-bXs
-bXs
-bXs
-bXs
+cuq
+cuL
+cuL
+cxB
+ckR
+ckR
+ckR
+ckR
+ckR
 ijl
 cmU
 cBg
@@ -58153,11 +58628,11 @@ bGh
 bwU
 bUM
 bGh
-bHM
+bEL
 cjG
-bJj
-cfg
-bRi
+bJm
+caU
+caU
 cdB
 chH
 chH
@@ -58412,9 +58887,9 @@ bUN
 bGh
 bEL
 cjG
-bJk
-cfg
-bRi
+cdE
+caU
+caU
 cdC
 caU
 caU
@@ -58423,7 +58898,7 @@ cmc
 bXs
 czm
 cmU
-cBg
+lPW
 coW
 ttL
 crj
@@ -58669,10 +59144,10 @@ bEL
 bGh
 bHn
 cjG
-bRj
-bRj
-bRi
 cdE
+caU
+caU
+caU
 caU
 caU
 cjw
@@ -58927,9 +59402,9 @@ bGh
 bEL
 cjG
 bJm
-bPA
-bRj
-cdE
+caU
+caU
+caU
 caU
 caU
 chK
@@ -59185,7 +59660,7 @@ bil
 cjG
 bJn
 cbd
-bRi
+cbd
 cfh
 chI
 cgO
@@ -60737,7 +61212,7 @@ caU
 caU
 cmV
 cBg
-bXs
+coW
 ttL
 crj
 fNz
@@ -60994,7 +61469,7 @@ caU
 caU
 cmU
 cBg
-bXs
+coW
 ttL
 crj
 fNz
@@ -61251,7 +61726,7 @@ caU
 caU
 cmU
 cBg
-bXs
+coW
 ttL
 crj
 fNz
@@ -61508,7 +61983,7 @@ caU
 caU
 cmU
 cBg
-bXs
+coW
 ttL
 crj
 fNz
@@ -63049,10 +63524,10 @@ cJP
 eAq
 cvh
 cmU
-cBg
+mLq
 coW
-aaa
-aaa
+qsO
+qsO
 aaa
 aaa
 aaa
@@ -63307,10 +63782,10 @@ eAq
 czK
 cmW
 cBg
-coW
-aaa
-aaa
-aaa
+pjg
+tMy
+dMU
+sLU
 aaa
 aaa
 aaa
@@ -63563,10 +64038,10 @@ cJP
 bXv
 clE
 cmU
-cBg
+mLq
 coW
-aaa
-aaa
+qsO
+qsO
 aaa
 aaa
 aaa
@@ -63820,7 +64295,7 @@ bXv
 bXv
 cvh
 cmU
-cBi
+cBg
 coW
 aaa
 aaa
@@ -64077,15 +64552,15 @@ cjE
 bXv
 clF
 cmU
-cBg
+lPW
 coW
-coW
-crE
-csI
-cxS
-cwh
-cxS
-csI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -64334,14 +64809,14 @@ cjF
 bXv
 clw
 cmU
-cBG
-cCs
-cCs
-cDN
+cBg
+csI
+csI
+csI
+csI
 cxS
-cub
-cvi
-cwz
+gth
+cxS
 csI
 aaa
 aaa
@@ -64591,12 +65066,12 @@ fVT
 bXv
 clV
 cmU
-cmU
-cmU
-cmU
+mUd
+qlV
+ucH
 cDO
 csK
-cuC
+cvj
 cvj
 cwA
 cxS
@@ -64849,12 +65324,12 @@ cky
 czV
 cAr
 cBZ
-cBZ
+cxS
 cqO
 crJ
-cxS
+grQ
 cud
-cvk
+cFr
 cwB
 csI
 aaa
@@ -65107,8 +65582,8 @@ bXs
 coH
 bXs
 csI
-csI
-csI
+cxS
+cxS
 csI
 cue
 cvl
@@ -65368,7 +65843,7 @@ jjw
 sxx
 gth
 cFp
-cvj
+tBQ
 cwN
 cxS
 aaa
@@ -65882,7 +66357,7 @@ ejT
 qKl
 gth
 cxh
-qKl
+cFr
 cxr
 csI
 aaa
@@ -66377,9 +66852,9 @@ bJd
 bJe
 bJe
 bJB
-bxE
-bYV
-bJe
+cjO
+bXy
+cuv
 bJe
 rOd
 rOd
@@ -66394,7 +66869,7 @@ cma
 duA
 bJe
 bJB
-bJe
+xWB
 csI
 csI
 csI
@@ -66634,8 +67109,8 @@ bJe
 bJe
 bVf
 bJB
-bXy
 bJe
+bXy
 bJe
 bJe
 bJe
@@ -66651,7 +67126,7 @@ bJe
 bJe
 bJe
 bJB
-bJe
+wkc
 cWe
 cxW
 aaa
@@ -66891,8 +67366,8 @@ bJe
 bJe
 bJe
 bJB
-bXy
 bJe
+bXy
 bJe
 bJe
 bJe
@@ -66908,7 +67383,7 @@ bJe
 bJe
 bJe
 crC
-bJe
+wkc
 cWe
 cxW
 aaa
@@ -67148,8 +67623,8 @@ bJB
 bJB
 bWt
 bJB
-bXy
 bJe
+bXy
 bJe
 bJe
 bJe
@@ -67165,7 +67640,7 @@ bJe
 bJe
 bJe
 bJB
-bJe
+wkc
 cWe
 cxW
 aaa
@@ -67395,18 +67870,18 @@ aKv
 bjW
 bjW
 bjW
-ccu
-cXC
+bZO
+bjW
 bxl
 bJe
 bPY
 qJs
 bJe
 bJe
-pjg
-bJB
-bXO
+bJe
+coG
 ccD
+cta
 bqh
 ccD
 cbs
@@ -67422,7 +67897,7 @@ acS
 crZ
 crZ
 fqS
-crZ
+epe
 cWe
 cxW
 aaa
@@ -67648,25 +68123,25 @@ bxk
 bxk
 bxk
 bxk
-rkl
-rkl
-bGD
-bGD
-bGD
-rkl
+bxk
+bxk
+bxk
+bxk
 cvV
 pHK
 cvV
-pAS
+caJ
 bLY
 bLY
 bLY
-dJT
-bLY
-pAS
+caJ
+cvV
 cvV
 ceu
 pAS
+cxW
+cxW
+cxW
 cry
 cry
 cry
@@ -67905,25 +68380,25 @@ bxk
 byG
 bAr
 bBQ
-rkl
+bxk
 aOC
-boG
-boG
-boG
-boG
+jgB
+bYz
 cvV
 rwY
-rwY
-pAS
+cvV
+caK
+wUZ
+chx
 uez
 ygU
-ygU
-cuj
-qQD
-pAS
+cvV
 rwY
 bVv
 pAS
+aaa
+aaa
+aaa
 aak
 aak
 aak
@@ -68162,25 +68637,25 @@ bxk
 byH
 bjW
 khA
-rkl
+bxk
 aRy
-bOA
-boG
-boG
-boG
-cau
+bjW
+bYC
+cvV
 rwY
-rwY
-pAS
+cvV
+cce
+cdF
+vnH
 vnH
 jfo
-eIT
-uwc
-dtb
-pAS
+cvV
 rwY
 bVv
 pAS
+aaa
+aaa
+aaa
 aak
 cnO
 cnO
@@ -68419,25 +68894,25 @@ bxk
 byI
 bAs
 bBR
-rkl
+bxk
 aXE
-boG
+bjW
 bYZ
-boG
-bZp
 cvV
 rwY
-rwY
-pAS
-wPr
-wPr
-eIT
-eIT
-nQl
-pAS
+cvV
+cdl
+wUZ
+chB
+wUZ
+ckx
+cvV
 rwY
 bVv
 pAS
+aaa
+aaa
+aaa
 aak
 cnO
 cgq
@@ -68676,25 +69151,25 @@ bxk
 byJ
 bxk
 bxk
-rkl
+bxk
 boG
-boG
-boG
-boG
-cag
+bjW
+bYD
 cvV
 rwY
-rwY
-pAS
-ciw
-ciw
-eRf
-ciw
-ciw
-pAS
+cag
+vnH
+ceY
+vnH
+wUZ
+clu
+cvV
 rwY
 bVv
 pAS
+aaa
+aaa
+aaa
 aak
 cnO
 chb
@@ -68935,23 +69410,23 @@ bAt
 bBS
 rkl
 bqS
-bYX
+bjW
 bZa
-boG
-boG
 cvV
 rwY
-rwY
-pAS
+cvV
+cdo
 wUZ
-eIT
-eIT
-eIT
-fju
-pAS
+wUZ
+wUZ
+vnH
+cvV
 rwY
 bVv
 pAS
+aaa
+aaa
+aaa
 aak
 cnO
 chd
@@ -69188,27 +69663,27 @@ csc
 bwl
 bjW
 bjW
-bAu
-bBT
-cvV
-cvV
-cvV
-cvV
-cvV
-cvV
+bjW
+bjW
+bjW
+bjW
+bjW
+bYV
 cvV
 rwY
-rwY
-pAS
-eIT
+cvV
+cdu
+cfg
+chC
+wUZ
 hJt
-vKS
-kjN
-eIT
-pAS
+cvV
 bXF
 bVv
 pAS
+aaa
+aaa
+aaa
 aak
 cnO
 chV
@@ -69446,26 +69921,26 @@ bjW
 fym
 vOj
 fym
-bBU
-rwY
-rwY
-rwY
-rwY
-rwY
-rwY
+fym
+fym
+bYq
+bjW
+bYX
 cvV
 rwY
-rwY
-pAS
-eIT
-bTB
-bVh
-bWy
-eIT
-pAS
+cvV
+cvV
+cvV
+cvV
+bTC
+bTC
+cvV
 ciH
 bVv
 pAS
+aaa
+aaa
+aaa
 aak
 cnO
 cnO
@@ -69704,26 +70179,22 @@ bxk
 byK
 bxl
 bxl
+bxk
+bYr
+bYt
+bZp
 cvV
 rwY
+cau
 rwY
 rwY
 rwY
-rwY
-cvV
-rwY
-rwY
-pAS
-eIT
+cjB
 bTC
-bVi
-gzx
-eIT
-pAS
+rwY
 rwY
 bVv
 pAS
-aak
 aaa
 aaa
 aaa
@@ -69734,8 +70205,12 @@ aaa
 aaa
 aaa
 aaa
-vHB
-csV
+aaa
+aaa
+qsO
+uwc
+cqE
+cqE
 cqE
 jEj
 wZc
@@ -69961,26 +70436,22 @@ bxl
 mtB
 bAv
 bBV
+bxk
+bYs
+bYx
+bZL
+cvV
+cvV
 cvV
 rwY
 rwY
 rwY
+cjB
+bTC
 rwY
-rwY
-cvV
-rwY
-rwY
-pAS
-eIT
-eIT
-bVj
-eIT
-eIT
-pAS
 rwY
 bVv
 pAS
-aak
 aaa
 aaa
 aaa
@@ -69991,9 +70462,13 @@ aaa
 aaa
 aaa
 aaa
-vAh
-lPW
+aaa
+aaa
+heb
+vlV
 cqE
+jEj
+jEj
 jEj
 cwO
 vHB
@@ -70222,22 +70697,18 @@ cvV
 cvV
 cvV
 cvV
-nzM
 cvV
+rwY
+rwY
+rwY
+rwY
+rwY
+rwY
 cvV
-cvV
-nzM
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
-pAS
+rwY
 rwY
 bVv
 pAS
-pAS
 aaa
 aaa
 aaa
@@ -70248,10 +70719,14 @@ aaa
 aaa
 aaa
 aaa
-vAh
-vlV
+aaa
+aaa
+heb
+vEC
 cqE
 jEj
+cqE
+cqE
 eMa
 crH
 csN
@@ -70477,13 +70952,9 @@ bAK
 bCn
 cvV
 cBY
+bYy
+bZM
 cvV
-rwY
-rwY
-rwY
-rwY
-rwY
-rwY
 rwY
 rwY
 rwY
@@ -70492,8 +70963,8 @@ rwY
 rwY
 nzM
 rwY
+rwY
 bVv
-cml
 pAS
 aaa
 aaa
@@ -70503,12 +70974,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+heb
+heb
 vAh
-vAh
-vAh
+vKS
+udC
 cvy
-wjW
-mLq
+cqE
+cqE
 tlY
 tlY
 cqE
@@ -70743,14 +71218,10 @@ rwY
 rwY
 rwY
 rwY
-rwY
-rwY
-rwY
-rwY
 cvV
+cmQ
 rwY
 bVv
-rwY
 pAS
 aaa
 aaa
@@ -70759,13 +71230,17 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+gzx
+hXT
 acT
 cpu
 cnx
-cpu
+vqA
 cok
-jzb
-heb
+czo
+cqE
 czo
 cqE
 czo
@@ -71002,12 +71477,8 @@ rwY
 cvV
 cvV
 cvV
-cvV
-cvV
-cvV
-cjX
+cpk
 bVv
-rwY
 pAS
 aaa
 aaa
@@ -71017,12 +71488,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+iAk
+nGJ
 crP
-odg
-crP
-uTo
 vSn
-gkA
+pHJ
+uTo
+czo
+cqE
 czo
 cqE
 ple
@@ -71256,15 +71731,11 @@ dRQ
 cnV
 cvV
 oOI
-oOI
-oOI
-cdX
 cvV
-nGJ
-tMy
+clG
+cnN
 rwY
 bVv
-rwY
 pAS
 aaa
 aaa
@@ -71274,12 +71745,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+heb
+heb
 vAh
-vAh
-vAh
-cuq
+wjW
 uLc
 jEj
+czo
+cqE
 czo
 cqE
 czo
@@ -71513,15 +71988,11 @@ oCO
 byO
 cvV
 oOI
-oOI
-oOI
-cdX
 cvV
-qJp
-tMy
+clI
+cnN
 rwY
 bVv
-rwY
 pAS
 aaa
 aaa
@@ -71531,13 +72002,17 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+iAk
+nGJ
 crP
-odg
-crP
-tIB
+xbW
 cqE
 jEj
-qsO
+sjr
+cqE
+czo
 cqE
 czo
 cqE
@@ -71770,15 +72245,11 @@ byN
 bOg
 cvV
 oOI
-oOI
-oOI
-cdX
 cvV
 cvV
 rwY
 rwY
 bVv
-rwY
 pAS
 aaa
 aaa
@@ -71788,12 +72259,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+jzb
+nQl
 cmD
 cqK
 crQ
-cpk
-cvz
 jEj
+cqE
+cqE
 cqE
 cqE
 cqE
@@ -72027,15 +72502,11 @@ byN
 byO
 cvV
 oOI
-oOI
-oOI
-cdX
 cvV
-rwY
-rwY
+bUc
 rwY
 bVv
-rwY
+crE
 pAS
 aaa
 aaa
@@ -72045,12 +72516,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+heb
+heb
 vAh
-vAh
-vAh
-cta
-jxV
+xIH
+uxA
 jEj
+cqE
+cqE
 cqE
 cwQ
 cqE
@@ -72284,15 +72759,12 @@ byN
 byO
 cvV
 oOI
-oOI
-oOI
-cdX
 cvV
 rwY
 rwY
 bVv
-bVv
-rwY
+cvV
+pAS
 pAS
 aaa
 aaa
@@ -72304,11 +72776,14 @@ aaa
 aaa
 aaa
 aaa
-vAh
-cta
-jxV
+aaa
+heb
+scT
+uxA
 jEj
-dKk
+jxV
+cqE
+czo
 cqE
 czo
 cqE
@@ -72541,15 +73016,12 @@ bMx
 bOi
 cvV
 oOI
-oOI
-oOI
-cdX
 bVv
 bVv
 bVv
 bVv
-rwY
-lnh
+ckb
+ctw
 pAS
 aaa
 aaa
@@ -72561,11 +73033,14 @@ aaa
 aaa
 aaa
 aaa
-vAh
-cta
-jxV
+aaa
+heb
+scT
+uxA
 jEj
 czo
+cqE
+bUp
 cqE
 czo
 cqE
@@ -72801,12 +73276,9 @@ oOI
 oOI
 oOI
 cdX
-cvV
-cit
 rwY
-ckb
-cvV
-cvV
+rwY
+cWZ
 pAS
 aaa
 aaa
@@ -72818,10 +73290,13 @@ aaa
 aaa
 aaa
 aaa
-vHB
-cta
-jxV
+aaa
+qsO
+scT
+uxA
 jEj
+czo
+cqE
 czo
 cqE
 czo
@@ -73059,11 +73534,8 @@ oOI
 fGR
 cdX
 cvV
+cit
 tyZ
-cWZ
-cXb
-cvV
-bUc
 pAS
 aaa
 aaa
@@ -73075,10 +73547,13 @@ aaa
 aaa
 aaa
 aaa
-vHB
-ucH
-jNN
+aaa
+qsO
+pVt
+rMU
 jEj
+czo
+cqE
 czo
 uLc
 czp
@@ -73318,9 +73793,9 @@ bVv
 cvV
 cvV
 cvV
-cvV
-cvV
-cvV
+pAS
+pAS
+pAS
 pAS
 pAS
 pAS
@@ -73334,7 +73809,7 @@ fNZ
 fNZ
 vHB
 eoB
-cqE
+jEj
 jEj
 jEj
 jEj
@@ -77395,7 +77870,7 @@ xFO
 kav
 kFa
 qoB
-ogY
+bVS
 aZf
 biP
 bck
@@ -77652,10 +78127,10 @@ xFO
 beO
 beO
 xFO
+beO
 dXn
-aZn
 mIa
-bky
+bEw
 bky
 bky
 bky
@@ -77906,14 +78381,14 @@ aAg
 xFO
 xFO
 xFO
-aDK
 beO
+aDK
 xFO
-sEl
+xFO
 aZo
 vzH
+bGD
 tmr
-bky
 bky
 bky
 bky
@@ -78163,15 +78638,15 @@ aSo
 dqs
 nGc
 dqs
+dqs
 aSo
 aSo
-vEC
+aZW
 dhZ
-aZn
-gum
+mIa
 hNk
 gmY
-tmr
+bQr
 tmr
 tmr
 etc
@@ -78420,16 +78895,16 @@ ivN
 ptC
 xZB
 ptC
+ptC
 ivN
 aSD
-lan
 bzo
+bAu
 bhD
-aZW
 uYP
 dst
 hBj
-bky
+bRm
 bky
 uST
 bsh
@@ -78677,12 +79152,12 @@ ivL
 rrF
 xZB
 ptC
-feF
+ptC
+aOj
 aSD
-crU
+aZX
 dhZ
 bhD
-biU
 uKX
 blU
 bnj
@@ -78934,16 +79409,16 @@ tYg
 ptC
 xZB
 kQV
-bRm
+ptC
+aZn
 aSo
-crU
+biU
 dhZ
-aZQ
 cGS
 bag
 vyQ
 cXI
-bky
+bRP
 bky
 uhZ
 bhF
@@ -79191,16 +79666,16 @@ pAu
 xZB
 noL
 ptC
-bRP
+ptC
 clj
 crU
+biU
 dhZ
 bhD
-biW
 baj
 bbc
-mIa
-bky
+bQs
+bEw
 bky
 ewM
 bhF
@@ -79448,16 +79923,16 @@ wQS
 tYa
 xZB
 ptC
-feF
+ptC
+aOj
 aSD
-crU
 bCG
+bBT
 bhD
-aZX
 bkv
 cgA
 mrE
-bky
+bRS
 bky
 soQ
 bhF
@@ -79705,16 +80180,16 @@ uuG
 ptC
 xZB
 ptC
-oJL
+ptC
+aZQ
 aSD
-cuv
+bzo
 dhZ
 bhD
-xbW
 hVE
 mEK
+bQu
 tkG
-bky
 bky
 bry
 bhD
@@ -79962,15 +80437,15 @@ aSo
 ogo
 vQf
 ogo
+ogo
 aSo
 aSo
-vEC
+biW
 dhZ
-bhW
-bjd
+jaJ
 lfw
 ngs
-bky
+bRj
 bky
 bky
 brE
@@ -80219,13 +80694,13 @@ aDI
 beO
 xFO
 beO
-aDI
 beO
+aDI
 xFO
-dXn
+bxE
 bhW
 jaJ
-jSw
+bHM
 jSw
 jSw
 jSw
@@ -83316,7 +83791,7 @@ boM
 cXK
 brM
 bsk
-btB
+bRV
 btm
 btm
 btm
@@ -83830,7 +84305,7 @@ bbw
 bqb
 brK
 bsk
-btm
+bUC
 btm
 btm
 btm
@@ -84088,9 +84563,9 @@ bmy
 brL
 bje
 bnE
-buh
 btm
-bvu
+btm
+btm
 jUy
 aGP
 cvV
@@ -84344,10 +84819,10 @@ bnw
 bmy
 brM
 bmD
-btB
+bVh
+buh
 btm
-btm
-btm
+bvu
 jUy
 aGP
 cvV
@@ -84858,12 +85333,12 @@ brM
 brM
 brM
 bje
+btm
+btm
+btm
+btm
 bzy
-bzy
-bzy
-bzy
-bzy
-bzy
+bXO
 pAS
 rwY
 bVv
@@ -85115,12 +85590,12 @@ bje
 bje
 bje
 bje
-aak
-aak
-aak
-aak
-aak
-aak
+btm
+btm
+btm
+btm
+btm
+btm
 pAS
 ckb
 bVv
@@ -85371,13 +85846,13 @@ aak
 aak
 aak
 aak
-aak
-aak
-aaa
-aaa
-aaa
-aaa
-aak
+bRT
+bRT
+bVi
+bVj
+bVi
+bRT
+bRT
 pAS
 ctm
 bqe
@@ -85627,13 +86102,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aak
+aak
+aak
+bVi
+bVW
+bVi
+aak
 aak
 aak
 ctm
@@ -85886,11 +86361,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aak
+bVi
+bWy
+bVi
+aak
 aaa
 aak
 ctm


### PR DESCRIPTION
pushes engineering more inwards
moves gravity generator to engineering, while moving cargo/vacant commissary to make up for it
moves telecomms
moves some lower atmos stuff
moves pod to near sec post
enlarges the sec post
moves some minor things around in engineering
removes lower shower room
fixes engineering solars
VERY minor update to SM, since this map isn't really being maintained for new mapping things going on.

also updates paths to latest fulp